### PR TITLE
Cache data on error only, avoid caching on throttling

### DIFF
--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -88,8 +88,13 @@ class Sender {
                     if (this._enableOfflineMode) {
                         // try to send any cached events if the user is back online
                         if (res.statusCode === 200) {
-                            setTimeout(() => this._sendFirstFileOnDisk(), Sender.WAIT_BETWEEN_RESEND); 
-                        }
+                            setTimeout(() => this._sendFirstFileOnDisk(), Sender.WAIT_BETWEEN_RESEND);
+                        // store to disk in case of burst throttling  
+                        } else if (res.statusCode === 206 ||  
+                                   res.statusCode === 429 || 
+                                   res.statusCode === 439) {
+                                       this._storeToDisk(payload);
+                                   }
                     }
                 });
             });

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -89,9 +89,6 @@ class Sender {
                         // try to send any cached events if the user is back online
                         if (res.statusCode === 200) {
                             setTimeout(() => this._sendFirstFileOnDisk(), Sender.WAIT_BETWEEN_RESEND); 
-                        } else {
-                            // cache the payload to send it later
-                            this._storeToDisk(payload);
                         }
                     }
                 });


### PR DESCRIPTION
This change is to avoid caching when throttling (206) or rejection due to old data (400) happens. 