### PR TITLE
Fixes CPU metric; charaters '[' and ']' cause it to be rejected

### DIFF
--- a/AutoCollection/Performance.ts
+++ b/AutoCollection/Performance.ts
@@ -172,7 +172,7 @@ class AutoCollectPerformance {
                 var cpu = cpus[i];
                 var lastCpu = this._lastCpus[i];
 
-                var name = "% cpu[" + i + "] ";
+                var name = "% cpu(" + i + ") ";
                 var model = cpu.model;
                 var speed = cpu.speed;
                 var times = cpu.times;


### PR DESCRIPTION
the characters '[' and ']' are not allowed, switching them to '(' and ')' instead to fix #39