### PR TITLE
Increase end to end test timeout from 2 to 10 seconds

### DIFF
--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -68,6 +68,7 @@ class Sender {
 
             Logging.info(Sender.TAG, options);
 
+            console.log("creating request");
             var req = protocol.request(<any> options, (res:http.ClientResponse) => {
                 console.log('STATUS: ' + res.statusCode);
                 console.log('HEADERS: ' + JSON.stringify(res.headers));

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -69,6 +69,8 @@ class Sender {
             Logging.info(Sender.TAG, options);
 
             var req = protocol.request(<any> options, (res:http.ClientResponse) => {
+                console.log('STATUS: ' + res.statusCode);
+                console.log('HEADERS: ' + JSON.stringify(res.headers));
                 res.setEncoding("utf-8");
 
                 //returns empty if the data is accepted
@@ -78,6 +80,7 @@ class Sender {
                 });
 
                 res.on("end", () => {
+                    console.log(responseString);
                     Logging.info(Sender.TAG, responseString);
                     if (typeof this._onSuccess === "function") {
                         this._onSuccess(responseString);

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -59,7 +59,7 @@ describe("EndToEnd", () => {
     describe("Basic usage", function() {
         this.timeout(10000);
         it("should send telemetry", (done) => {
-            var client =AppInsights.getClient("iKey");
+            var client =AppInsights.getClient();
             client.trackEvent("test event");
             client.trackException(new Error("test error"));
             client.trackMetric("test metric", 3);
@@ -72,7 +72,7 @@ describe("EndToEnd", () => {
 
         it("should collect request telemetry", (done) => {
             AppInsights
-                .setup("ikey")
+                .setup()
                 .start();
 
             var server = http.createServer((req: http.ServerRequest, res: http.ServerResponse) => {

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -140,7 +140,7 @@ describe("EndToEnd", () => {
             });
         }); 
         
-        it("stores data to disk when enabled", (done) => {
+        it("stores data to disk when enabled", (done) => { 
             var req = new fakeReuqest();
 
             var client = AppInsights.getClient("key"); 

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -104,7 +104,7 @@ describe("EndToEnd", () => {
                         done();
                     });
                 }, 10);
-            });
+            }); 
 
             server.on("listening", () => {
                 http.get("http://localhost:" + server.address().port +"/test", (response: http.ServerResponse) => {

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -58,6 +58,26 @@ describe("EndToEnd", () => {
 
     describe("Basic usage", function() {
         this.timeout(10000);
+
+	before(() => {
+            var originalHttpRequest = http.request;
+            this.request = sinon.stub(http, "request", (options: any, callback: any) => {
+                if(options.headers) {
+                    options.headers["Connection"] = "close";
+                } else {
+                    options.headers = {
+                        "Connection": "close"
+                    }
+                }
+                console.log(JSON.stringify(options));
+                return originalHttpRequest(options, callback);
+            });
+        });
+
+        after(() => {
+            this.request.restore();
+        });
+
         it("should send telemetry", (done) => {
             var client =AppInsights.getClient();
             client.trackEvent("test event");
@@ -86,7 +106,6 @@ describe("EndToEnd", () => {
                 }, 10);
             });
 
-            server.listen(0, "::"); // "::" causes node to listen on both ipv4 and ipv6
             server.on("listening", () => {
                 http.get("http://localhost:" + server.address().port +"/test", (response: http.ServerResponse) => {
                     response.on("end", () => {
@@ -94,6 +113,7 @@ describe("EndToEnd", () => {
                     });
                 });
             });
+            server.listen(0, "::"); // "::" causes node to listen on both ipv4 and ipv6
         });
     });
     

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -98,7 +98,7 @@ describe("EndToEnd", () => {
     });
     
     describe("Offline mode", () => {
-        var AppInsights = require("../applicationinsights");
+        var AppInsights = require("../applicationinsights"); 
      
         
         beforeEach(() => {

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -115,7 +115,7 @@ describe("EndToEnd", () => {
             });
             server.listen(0, "::"); // "::" causes node to listen on both ipv4 and ipv6
         });
-    });
+    }); 
      
     describe("Offline mode", () => {
         var AppInsights = require("../applicationinsights"); 

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -56,7 +56,8 @@ class fakeReuqest {
 
 describe("EndToEnd", () => {
 
-    describe("Basic usage", () => {
+    describe("Basic usage", function() {
+        this.timeout(10000);
         it("should send telemetry", (done) => {
             var client =AppInsights.getClient("iKey");
             client.trackEvent("test event");

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -116,7 +116,7 @@ describe("EndToEnd", () => {
             server.listen(0, "::"); // "::" causes node to listen on both ipv4 and ipv6
         });
     });
-    
+     
     describe("Offline mode", () => {
         var AppInsights = require("../applicationinsights"); 
      


### PR DESCRIPTION
The end to end tests are having intermittent failures on Travis builds. Increasing the timeout from 2 to 10 seconds seems to fix the issue, 4 builds in a row passed after increasing it.