### PR TITLE
JSON order of envelope properties

### DIFF
--- a/Library/Channel.ts
+++ b/Library/Channel.ts
@@ -20,7 +20,7 @@ class Channel {
         this._getBatchIntervalMs = getBatchIntervalMs;
         this._sender = sender;
     }
-    
+
     /**
      * Enable or disable offline mode
      */
@@ -109,11 +109,28 @@ class Channel {
         this._timeoutHandle = null;
     }
 
-    private _stringify(envelope) {
+    private _stringify(e: ContractsModule.Contracts.Envelope) {
         try {
-            return JSON.stringify(envelope);
+            var clonedEnvelope: ContractsModule.Contracts.Envelope = {
+                ver: e.ver,
+                name: e.name,
+                time: e.time,
+                sampleRate: e.sampleRate,
+                seq: e.seq,
+                iKey: e.iKey,
+                flags: e.flags,
+                deviceId: e.deviceId,
+                os: e.os,
+                osVer: e.osVer,
+                appId: e.appId,
+                appVer: e.appVer,
+                userId: e.userId,
+                tags: e.tags,
+                data: e.data
+            };
+            return JSON.stringify(clonedEnvelope);
         } catch (error) {
-            Logging.warn("Failed to serialize payload", error, envelope);
+            Logging.warn("Failed to serialize payload", error, e);
         }
     }
 }

--- a/Library/Channel.ts
+++ b/Library/Channel.ts
@@ -111,6 +111,8 @@ class Channel {
 
     private _stringify(e: ContractsModule.Contracts.Envelope) {
         try {
+            // Serialize the envelope in specific order. It is a requirement for
+            // some channels.
             var clonedEnvelope: ContractsModule.Contracts.Envelope = {
                 ver: e.ver,
                 name: e.name,

--- a/Library/Channel.ts
+++ b/Library/Channel.ts
@@ -109,30 +109,11 @@ class Channel {
         this._timeoutHandle = null;
     }
 
-    private _stringify(e: ContractsModule.Contracts.Envelope) {
+    private _stringify(envelope: ContractsModule.Contracts.Envelope) {
         try {
-            // Serialize the envelope in specific order. It is a requirement for
-            // some channels.
-            var clonedEnvelope: ContractsModule.Contracts.Envelope = {
-                ver: e.ver,
-                name: e.name,
-                time: e.time,
-                sampleRate: e.sampleRate,
-                seq: e.seq,
-                iKey: e.iKey,
-                flags: e.flags,
-                deviceId: e.deviceId,
-                os: e.os,
-                osVer: e.osVer,
-                appId: e.appId,
-                appVer: e.appVer,
-                userId: e.userId,
-                tags: e.tags,
-                data: e.data
-            };
-            return JSON.stringify(clonedEnvelope);
+            return JSON.stringify(envelope);
         } catch (error) {
-            Logging.warn("Failed to serialize payload", error, e);
+            Logging.warn("Failed to serialize payload", error, envelope);
         }
     }
 }

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -181,26 +181,19 @@ class Client {
         // sanitize properties
         data.baseData.properties = Util.validateStringMap(data.baseData.properties);
 
-        // Write the envelope properties in the specific order. It is a
-        // requirement for some channels. 
-        var envelope: ContractsModule.Contracts.Envelope = {
-            ver: 1,
-            // this is kind of a hack, but the envelope name is always the same as the data name sans the chars "data"
-            name: "Microsoft.ApplicationInsights." + data.baseType.substr(0, data.baseType.length - 4),
-            time: (new Date()).toISOString(),
-            sampleRate: 100.0,
-            seq: (Client._sequenceNumber++).toString(),
-            iKey: this.config.instrumentationKey,
-            flags: 0,
-            deviceId: "",
-            os: this.context.tags[this.context.keys.deviceOS],
-            osVer: this.context.tags[this.context.keys.deviceOSVersion],
-            appId: "",
-            appVer: this.context.tags[this.context.keys.applicationVersion],
-            userId: "",
-            tags: tagOverrides || this.context.tags,
-            data: data
-        };
+        var envelope = new ContractsModule.Contracts.Envelope();
+        envelope.data = data;
+        envelope.appVer = this.context.tags[this.context.keys.applicationVersion];
+        envelope.iKey = this.config.instrumentationKey;
+
+        // this is kind of a hack, but the envelope name is always the same as the data name sans the chars "data"
+        envelope.name = "Microsoft.ApplicationInsights." + data.baseType.substr(0, data.baseType.length - 4);
+        envelope.os = this.context.tags[this.context.keys.deviceOS];
+        envelope.osVer = this.context.tags[this.context.keys.deviceOSVersion];
+        envelope.seq = (Client._sequenceNumber++).toString();
+        envelope.tags = tagOverrides || this.context.tags;
+        envelope.time = (new Date()).toISOString();
+        envelope.ver = 1;
         return envelope;
     }
 

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -181,19 +181,26 @@ class Client {
         // sanitize properties
         data.baseData.properties = Util.validateStringMap(data.baseData.properties);
 
-        var envelope = new ContractsModule.Contracts.Envelope();
-        envelope.data = data;
-        envelope.appVer = this.context.tags[this.context.keys.applicationVersion];
-        envelope.iKey = this.config.instrumentationKey;
-
-        // this is kind of a hack, but the envelope name is always the same as the data name sans the chars "data"
-        envelope.name = "Microsoft.ApplicationInsights." + data.baseType.substr(0, data.baseType.length - 4);
-        envelope.os = this.context.tags[this.context.keys.deviceOS];
-        envelope.osVer = this.context.tags[this.context.keys.deviceOSVersion];
-        envelope.seq = (Client._sequenceNumber++).toString();
-        envelope.tags = tagOverrides || this.context.tags;
-        envelope.time = (new Date()).toISOString();
-        envelope.ver = 1;
+        // Write the envelope properties in the specific order. It is a
+        // requirement for some channels. 
+        var envelope: ContractsModule.Contracts.Envelope = {
+            ver: 1,
+            // this is kind of a hack, but the envelope name is always the same as the data name sans the chars "data"
+            name: "Microsoft.ApplicationInsights." + data.baseType.substr(0, data.baseType.length - 4),
+            time: (new Date()).toISOString(),
+            sampleRate: 100.0,
+            seq: (Client._sequenceNumber++).toString(),
+            iKey: this.config.instrumentationKey,
+            flags: 0,
+            deviceId: "",
+            os: this.context.tags[this.context.keys.deviceOS],
+            osVer: this.context.tags[this.context.keys.deviceOSVersion],
+            appId: "",
+            appVer: this.context.tags[this.context.keys.applicationVersion],
+            userId: "",
+            tags: tagOverrides || this.context.tags,
+            data: data
+        };
         return envelope;
     }
 

--- a/Library/Contracts.ts
+++ b/Library/Contracts.ts
@@ -140,7 +140,7 @@ export module Contracts {
         public tags:{ [key: string]: string; };
         public data:Data<Domain>;
 
-        constructor() {            
+        constructor() {
             this.ver = 1;
             // the 'name' property must be initialized before 'tags' and/or 'data'.
             this.name = "";

--- a/Library/Contracts.ts
+++ b/Library/Contracts.ts
@@ -140,8 +140,12 @@ export module Contracts {
         public tags:{ [key: string]: string; };
         public data:Data<Domain>;
 
-        constructor() {
+        constructor() {            
             this.ver = 1;
+            // the 'name' property must be initialized before 'tags' and/or 'data'.
+            this.name = "";
+            // the 'time' property must be initialized before 'tags' and/or 'data'.
+            this.time = "";
             this.sampleRate = 100.0;
             this.tags = {};
         }

--- a/Tests/Library/Channel.tests.ts
+++ b/Tests/Library/Channel.tests.ts
@@ -59,8 +59,6 @@ describe("Library/Channel", () => {
             channel.send(testEnvelope);
             clock.tick(config.batchInterval);
             assert.ok(sendSpy.calledOnce);
-            console.log(sendSpy.firstCall.args[0].toString());
-            console.log(JSON.stringify(testEnvelope));
             assert.equal(sendSpy.firstCall.args[0].toString(), JSON.stringify(testEnvelope));            
         });
 

--- a/Tests/Library/Channel.tests.ts
+++ b/Tests/Library/Channel.tests.ts
@@ -6,6 +6,7 @@ import assert = require("assert");
 import sinon = require("sinon");
 
 import Channel = require("../../Library/Channel");
+import Contracts = require("../../Library/Contracts");
 
 class ChannelMock extends Channel {
     public getBuffer() {
@@ -19,7 +20,7 @@ class ChannelMock extends Channel {
 
 describe("Library/Channel", () => {
 
-    var testEnvelope = <any>{test: "test"};
+    var testEnvelope = new Contracts.Contracts.Envelope();
     var sender = {
         saveOnCrash: (str) => null,
         send: (Buffer) => null
@@ -58,7 +59,9 @@ describe("Library/Channel", () => {
             channel.send(testEnvelope);
             clock.tick(config.batchInterval);
             assert.ok(sendSpy.calledOnce);
-            assert.equal(sendSpy.firstCall.args[0].toString(), JSON.stringify(testEnvelope));
+            console.log(sendSpy.firstCall.args[0].toString());
+            console.log(JSON.stringify(testEnvelope));
+            assert.equal(sendSpy.firstCall.args[0].toString(), JSON.stringify(testEnvelope));            
         });
 
         it("should do nothing if disabled", () => {

--- a/Tests/Library/Channel.tests.ts
+++ b/Tests/Library/Channel.tests.ts
@@ -59,7 +59,7 @@ describe("Library/Channel", () => {
             channel.send(testEnvelope);
             clock.tick(config.batchInterval);
             assert.ok(sendSpy.calledOnce);
-            assert.equal(sendSpy.firstCall.args[0].toString(), JSON.stringify(testEnvelope));            
+            assert.equal(sendSpy.firstCall.args[0].toString(), JSON.stringify(testEnvelope));
         });
 
         it("should do nothing if disabled", () => {

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -232,6 +232,20 @@ describe("Library/Client", () => {
             assert.ok(seq1 < seq2);
             assert.equal(seq1 + 1, seq2);
         });
+        
+        it("should write properties in a specific order", () => {
+            let env = client.getEnvelope(mockData);
+            let keys = Object.keys(env);
+            let indices: { [name: string]: number } = {};
+            let index = 0;
+            for(let propertyName in env) {
+                indices[propertyName] = index;
+                ++index;
+            }
+            assert.ok(
+                Math.max(indices["name"], indices["time"]) < 
+                Math.min(indices["data"], indices["tags"]));
+        });
     });
 
     describe("#track()", () => {


### PR DESCRIPTION
Some channels require a specific order of envelope properties. In particular, the “data”, “tags” properties must all come after the "name" and "time" properties.