### PR TITLE
Fixing bug that throws unhandled rejections

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "applicationinsights",
   "license": "MIT",
   "bugs": "https://github.com/Microsoft/ApplicationInsights-node.js/issues",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "description": "Microsoft Application Insights module for Node.JS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In the previous version that was released today there was a 'bug' that threw unhandled promise rejections, as if they were exceptions. This changes the behavior of node, since things that were silently swallowed before now are thrown as unhandled exceptions and can crash node.