### PR TITLE
Add capability to pass custom properties to the trackMetric api

### DIFF
--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -106,7 +106,7 @@ class Client {
      * @param max    the max sample for this set
      * @param stdDev the standard deviation of the set
      */
-    public trackMetric(name:string, value:number, count?:number, min?: number, max?: number, stdDev?: number) {
+    public trackMetric(name:string, value:number, count?:number, min?: number, max?: number, stdDev?: number, properties?: { [key: string]: string; }) {
         var metrics = new ContractsModule.Contracts.MetricData(); // todo: enable client-batching of these
         metrics.metrics = [];
 
@@ -120,6 +120,8 @@ class Client {
         metric.value = value;
 
         metrics.metrics.push(metric);
+        
+        metrics.properties = properties;
 
         var data = new ContractsModule.Contracts.Data<ContractsModule.Contracts.MetricData>();
         data.baseType = "MetricData";

--- a/Library/Contracts.ts
+++ b/Library/Contracts.ts
@@ -158,6 +158,7 @@ export module Contracts {
         public measurements:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.properties = {};
             this.measurements = {};
@@ -173,6 +174,7 @@ export module Contracts {
         public properties:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.properties = {};
 
@@ -191,6 +193,7 @@ export module Contracts {
         public measurements:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.exceptions = [];
             this.properties = {};
@@ -246,6 +249,7 @@ export module Contracts {
         public properties:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.metrics = [];
             this.properties = {};
@@ -263,6 +267,7 @@ export module Contracts {
         public measurements:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.properties = {};
             this.measurements = {};
@@ -285,6 +290,7 @@ export module Contracts {
         public measurements:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.properties = {};
             this.measurements = {};
@@ -311,6 +317,7 @@ export module Contracts {
         public properties:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.kind = Contracts.DataPointType.Measurement;
             this.dependencyKind = Contracts.DependencyKind.Other;
@@ -339,6 +346,7 @@ export module Contracts {
         public measurements:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.properties = {};
             this.measurements = {};
@@ -361,6 +369,7 @@ export module Contracts {
         public measurements:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.properties = {};
             this.measurements = {};
@@ -375,6 +384,7 @@ export module Contracts {
         public state:Contracts.SessionState;
 
         constructor() {
+            super();
             this.ver = 2;
             this.state = Contracts.SessionState.Start;
 
@@ -396,6 +406,7 @@ export module Contracts {
         public properties:any;
 
         constructor() {
+            super();
             this.ver = 2;
             this.kind = DataPointType.Aggregation;
             this.properties = {};

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -134,13 +134,26 @@ describe("Library/Client", () => {
     describe("#trackMetric()", () => {
         it("should track Metric with correct data", () => {
             trackStub.reset();
+            var count = 1;
+            var min = 0;
+            var max = 0;
+            var stdev = 0;
             client.trackMetric(name, value);
+            client.trackMetric(name, value, count, min, max, stdev, properties);
 
             assert.ok(trackStub.calledOnce);
 
             var args = trackStub.args;
             assert.equal(args[0][0].baseData.metrics[0].name, name);
             assert.equal(args[0][0].baseData.metrics[0].value, value);
+            
+            assert.equal(args[1][0].baseData.metrics[0].name, name);
+            assert.equal(args[1][0].baseData.metrics[0].value, value);
+            assert.equal(args[1][0].baseData.metrics[0].count, count);
+            assert.equal(args[1][0].baseData.metrics[0].min, min);
+            assert.equal(args[1][0].baseData.metrics[0].max, max);
+            assert.equal(args[1][0].baseData.metrics[0].stdev, stdev);
+            assert.deepEqual(args[1][0].baseData.metrics[0].properties, properties);
         });
 
         it("should not crash with invalid input", () => {

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -141,7 +141,7 @@ describe("Library/Client", () => {
             client.trackMetric(name, value);
             client.trackMetric(name, value, count, min, max, stdev, properties);
 
-            assert.ok(trackStub.calledOnce);
+            assert.ok(trackStub.calledTwice);
 
             var args = trackStub.args;
             assert.equal(args[0][0].baseData.metrics[0].name, name);
@@ -152,8 +152,8 @@ describe("Library/Client", () => {
             assert.equal(args[1][0].baseData.metrics[0].count, count);
             assert.equal(args[1][0].baseData.metrics[0].min, min);
             assert.equal(args[1][0].baseData.metrics[0].max, max);
-            assert.equal(args[1][0].baseData.metrics[0].stdev, stdev);
-            assert.deepEqual(args[1][0].baseData.metrics[0].properties, properties);
+            assert.equal(args[1][0].baseData.metrics[0].stdDev, stdev);
+            assert.deepEqual(args[1][0].baseData.properties, properties);
         });
 
         it("should not crash with invalid input", () => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "applicationinsights",
   "license": "MIT",
   "bugs": "https://github.com/Microsoft/ApplicationInsights-node.js/issues",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "description": "Microsoft Application Insights module for Node.JS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We would like to add custom properties to our metrics telemetry. Currently the contracts data model for metrics in the SDK has properties on the MetricsData object, but the api doesn't allow them as arguments.