### PR TITLE
Track request sync

### DIFF
--- a/AutoCollection/Requests.ts
+++ b/AutoCollection/Requests.ts
@@ -67,9 +67,41 @@ class AutoCollectRequests {
             });
 	    }
     }
+    
+    /**
+     * Tracks a request synchronously (doesn't wait for response 'finish' event)
+     */
+    public static trackRequestSync(client: Client, request: http.ServerRequest, response:http.ServerResponse, ellapsedMilliseconds?: number, properties?:{ [key: string]: string; }, error?: any) {
+        if (!request || !response || !client) {
+            Logging.info("AutoCollectRequests.trackRequestSync was called with invalid parameters: ", !request, !response, !client);
+            return;
+        }
+        
+        // store data about the request
+        var requestDataHelper = new RequestDataHelper(request);
+        
+        if (error) {
+            if(!properties) {
+                properties = <{[key: string]: string}>{};
+            }
+
+            if (typeof error === "string") {
+                properties["error"] = error;
+            } else if (typeof error === "object") {
+                for (var key in error) {
+                    properties[key] = error[key] && error[key].toString && error[key].toString();
+                }
+            }
+        }
+        
+        requestDataHelper.onResponse(response, properties, ellapsedMilliseconds);
+        var data = requestDataHelper.getRequestData();
+        var tags = requestDataHelper.getRequestTags(client.context.tags);
+        client.track(data, tags);
+    }
 
     /**
-     * Tracks a request
+     * Tracks a request by listening to the response 'finish' event
      */
     public static trackRequest(client:Client, request:http.ServerRequest, response:http.ServerResponse, properties?:{ [key: string]: string; }) {
         if (!request || !response || !client) {
@@ -77,43 +109,15 @@ class AutoCollectRequests {
             return;
         }
 
-        // store data about the request
-        var requestDataHelper = new RequestDataHelper(request);
-
-        // async processing of the telemetry
-        var processRequest = (isError?:boolean) => {
-            setTimeout(() => {
-                requestDataHelper.onResponse(response, properties);
-                var data = requestDataHelper.getRequestData();
-                var tags = requestDataHelper.getRequestTags(client.context.tags);
-                client.track(data, tags);
-            }, 0);
-        };
-
         // response listeners
         if (response && response.once) {
-            response.once("finish", () => processRequest());
+            response.once("finish", () => this.trackRequestSync(client, request, response, null, properties));
         }
 
         // track a failed request if an error is emitted
         if (request && request.on) {
             request.on("error", (error:any) => {
-
-                if(!properties) {
-                    properties = <{[key: string]: string}>{};
-                }
-
-                if (error) {
-                    if (typeof error === "string") {
-                        properties["error"] = error;
-                    } else if (typeof error === "object") {
-                        for (var key in error) {
-                            properties[key] = error[key] && error[key].toString && error[key].toString();
-                        }
-                    }
-                }
-
-                processRequest(true);
+                this.trackRequestSync(client, request, response, null, properties, error);
             });
         }
     }

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -128,6 +128,10 @@ class Client {
         data.baseData = metrics;
         this.track(data);
     }
+    
+    public trackRequestSync(request: http.ServerRequest, response: http.ServerResponse, ellapsedMilliseconds?: number, properties?: {[key: string]: string;}, error?: any) {
+        RequestTracking.trackRequestSync(this, request, response, ellapsedMilliseconds, properties, error);
+    }
 
     public trackRequest(request: http.ServerRequest, response: http.ServerResponse, properties?:{ [key: string]: string; }) {
         RequestTracking.trackRequest(this, request, response, properties);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "applicationinsights",
   "license": "MIT",
   "bugs": "https://github.com/Microsoft/ApplicationInsights-node.js/issues",
-  "version": "0.15.12",
+  "version": "0.15.13",
   "description": "Microsoft Application Insights module for Node.JS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We need to be able to track requests in a synchronous call because we have custom properties that we want to add in the response.finish event, at which point it is too late to use the async track request method. Additionally you cannot set the context tag keys for the request reliably with the async way, because they could be reset by another request before the request is actually tracked.

More details in this issue: https://github.com/Microsoft/ApplicationInsights-node.js/issues/74
