### PR TITLE
Fill required StackFrame fields with default values

### DIFF
--- a/AutoCollection/Exceptions.ts
+++ b/AutoCollection/Exceptions.ts
@@ -166,12 +166,12 @@ class _StackFrame {
 
     constructor(frame: string, level: number) {
         this.level = level;
-        this.method = "unavailable";
+        this.method = "<no_method>";
         this.assembly = Util.trim(frame);
         var matches = frame.match(_StackFrame.regex);
         if (matches && matches.length >= 5) {
-            this.method = Util.trim(matches[2]);
-            this.fileName = Util.trim(matches[4]);
+            this.method = Util.trim(matches[2]) || this.method;
+            this.fileName = Util.trim(matches[4]) || "<no_filename>";
             this.line = parseInt(matches[5]) || 0;
         }
 

--- a/Tests/AutoCollection/Exceptions.tests.ts
+++ b/Tests/AutoCollection/Exceptions.tests.ts
@@ -1,0 +1,44 @@
+///<reference path="..\..\Declarations\node\node.d.ts" />
+///<reference path="..\..\Declarations\mocha\mocha.d.ts" />
+///<reference path="..\..\Declarations\sinon\sinon.d.ts" />
+
+import assert = require("assert");
+import sinon = require("sinon");
+
+import AutoCollectionExceptions = require("../../AutoCollection/Exceptions");
+
+describe("AutoCollection/Exceptions", () => {
+    describe("#getExceptionData()", () => {
+        var simpleError;
+        
+        beforeEach(() => {
+            try {
+                throw Error("simple error");
+            } catch(e) {
+                simpleError = e;
+            }
+        });
+            
+        it("fills empty 'method' with '<no_method>'", () => {
+            simpleError.stack = "  at \t (/path/file.js:12:34)\n" + simpleError.stack;
+            
+            var exceptionData = AutoCollectionExceptions.getExceptionData(simpleError, false);
+            
+            var actual = exceptionData.baseData.exceptions[0].parsedStack[0].method;
+            var expected = "<no_method>";
+            
+            assert.deepEqual(actual, expected);
+        });
+        
+        it("fills empty 'method' with '<no_filename>'", () => {
+            simpleError.stack = "  at Context.<anonymous> (\t:12:34)\n" + simpleError.stack;
+            
+            var exceptionData = AutoCollectionExceptions.getExceptionData(simpleError, false);
+            
+            var actual = exceptionData.baseData.exceptions[0].parsedStack[0].fileName;
+            var expected = "<no_filename>";
+            
+            assert.deepEqual(actual, expected);
+        });
+	});
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     {
       "name": "bogdanbe",
       "email": "bogdanbe@microsoft.com"
+    },
+    {
+      "name": "lukim",
+      "email": "lukim@microsoft.com"
     }
   ],
   "scripts": {


### PR DESCRIPTION
This change ensures the method and fileName fields on StackFrame are populated so the item will not be rejected by dc.services.visualstudio.com