### PR TITLE
[Sender] make resend interval configurable

### DIFF
--- a/Library/Channel.ts
+++ b/Library/Channel.ts
@@ -24,8 +24,8 @@ class Channel {
     /**
      * Enable or disable offline mode
      */
-    public setOfflineMode(value: boolean) {
-        this._sender.setOfflineMode(value);
+    public setOfflineMode(value: boolean, resendInterval?: number) {
+        this._sender.setOfflineMode(value, resendInterval);
     }
 
     /**

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -20,7 +20,7 @@ class Sender {
     private _onSuccess: (response: string) => void;
     private _onError: (error: Error) => void;
     private _enableOfflineMode: boolean; 
-    private _resendInterval: number;
+    protected _resendInterval: number;
 
     constructor(getUrl: () => string, onSuccess?: (response: string) => void, onError?: (error: Error) => void) {
         this._getUrl = getUrl;
@@ -35,7 +35,7 @@ class Sender {
     */
     public setOfflineMode(value: boolean, resendInterval?: number) {
         this._enableOfflineMode = value;
-        if (typeof resendInterval === 'number' && resendInterval >= 1) {
+        if (typeof resendInterval === 'number' && resendInterval >= 0) {
             this._resendInterval = Math.floor(resendInterval);
         }
     }

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -272,10 +272,9 @@ describe("EndToEnd", () => {
             var req = new fakeRequest(false);
             var res = new fakeResponse();
             res.statusCode = 200; 
-            Sender.WAIT_BETWEEN_RESEND =0; 
 
             var client = AppInsights.getClient("key"); 
-            client.channel.setOfflineMode(true);
+            client.channel.setOfflineMode(true, 0);
             
             client.trackEvent("test event");
             

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -15,7 +15,7 @@ describe("Library/Sender", () => {
     var sender:SenderMock;
 
     beforeEach(() => {
-        sender = new SenderMock(() => 'https://www.microsoft.com');
+        sender = new SenderMock(() => "https://www.microsoft.com");
     });
 
     describe("#setOfflineMode(value, resendInterval)", () => {

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -1,0 +1,43 @@
+///<reference path="..\..\Declarations\node\node.d.ts" />
+///<reference path="..\..\Declarations\mocha\mocha.d.ts" />
+
+import assert = require("assert");
+
+import Sender = require("../../Library/Sender");
+
+class SenderMock extends Sender {
+    public getResendInterval() {
+        return this._resendInterval;
+    }
+}
+
+describe("Library/Sender", () => {
+    var sender:SenderMock;
+
+    beforeEach(() => {
+        sender = new SenderMock(() => 'https://www.microsoft.com');
+    });
+
+    describe("#setOfflineMode(value, resendInterval)", () => {
+        it("default resend interval is 60 seconds", () => {
+            sender.setOfflineMode(true);
+            assert.equal(Sender.WAIT_BETWEEN_RESEND, sender.getResendInterval());
+        });
+
+        it("resend interval can be configured", () => {
+            sender.setOfflineMode(true, 0);
+            assert.equal(0, sender.getResendInterval());
+
+            sender.setOfflineMode(true, 1234);
+            assert.equal(1234, sender.getResendInterval());
+
+            sender.setOfflineMode(true, 1234.56);
+            assert.equal(1234, sender.getResendInterval());
+        });
+
+        it("resend interval can't be negative", () => {
+            sender.setOfflineMode(true, -1234);
+            assert.equal(Sender.WAIT_BETWEEN_RESEND, sender.getResendInterval());
+        });
+    });
+});

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -138,13 +138,14 @@ class ApplicationInsights {
     
      /**
      * Enable or disable offline mode to cache events when client is offline (disabled by default)
-     * @param value if true events that occured while client is offline will be cahced on disk
+     * @param value if true events that occured while client is offline will be cached on disk
+     * @param resendInterval. The wait interval for resending cached events.
      * @returns {ApplicationInsights} this class
      */
-    public static setOfflineMode(value: boolean) {
+    public static setOfflineMode(value: boolean, resendInterval?: number) {
         ApplicationInsights._isOfflineMode = value;
         if (ApplicationInsights.client && ApplicationInsights.client.channel){
-            ApplicationInsights.client.channel.setOfflineMode(value);
+            ApplicationInsights.client.channel.setOfflineMode(value, resendInterval);
         }
 
         return ApplicationInsights;


### PR DESCRIPTION
When in offline mode, resend interval for cached events is hard coded as 60 seconds. This is too long for small application/tools which only run for several seconds. Application will hang in there, being prevented from exiting.
Here making the resend interval configurable in *setOfflineMode* API to give more flexibility to end users.