### PR TITLE
Add source & target ikey headers for correlation

### DIFF
--- a/AutoCollection/ClientRequestParser.ts
+++ b/AutoCollection/ClientRequestParser.ts
@@ -53,18 +53,14 @@ class ClientRequestParser extends RequestParser {
         let dependencyName = this.method.toUpperCase() + " " + url.format(urlObject);
 
         let remoteDependency = new ContractsModule.Contracts.RemoteDependencyData();
+        remoteDependency.dependencyKind = ContractsModule.Contracts.DependencyKind.Http;
 
         if (this.targetIKeyHash) {
-            // Currently the service supports a dependency type name of ApplicationInsights,
-            // but not a dependency kind. So the dependency kind here is still just HTTP.
-            remoteDependency.dependencyKind = ContractsModule.Contracts.DependencyKind.Http;
-            remoteDependency.dependencyTypeName = ContractsModule.Contracts.DependencyKind
-                [ContractsModule.Contracts.DependencyKind.ApplicationInsights];
+            remoteDependency.dependencyTypeName =
+                ContractsModule.Contracts.RemoteDependencyTypes.ApplicationInsights;
             remoteDependency.target = urlObject.hostname + " | " + this.targetIKeyHash;
         } else {
-            remoteDependency.dependencyKind = ContractsModule.Contracts.DependencyKind.Http;
-            remoteDependency.dependencyTypeName =
-                ContractsModule.Contracts.DependencyKind[ContractsModule.Contracts.DependencyKind.Http];
+            remoteDependency.dependencyTypeName = ContractsModule.Contracts.RemoteDependencyTypes.Http;
             remoteDependency.target = urlObject.hostname;
         }
 

--- a/AutoCollection/ClientRequests.ts
+++ b/AutoCollection/ClientRequests.ts
@@ -1,7 +1,7 @@
 ///<reference path="..\Declarations\node\node.d.ts" />
 
 import http = require("http");
-import https = require("http");
+import https = require("https");
 import url = require("url");
 
 import ContractsModule = require("../Library/Contracts");

--- a/AutoCollection/ServerRequestParser.ts
+++ b/AutoCollection/ServerRequestParser.ts
@@ -7,6 +7,7 @@ import ContractsModule = require("../Library/Contracts");
 import Client = require("../Library/Client");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
+import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
 import RequestParser = require("./RequestParser");
 
 /**
@@ -20,6 +21,7 @@ class ServerRequestParser extends RequestParser {
     private connectionRemoteAddress:string;
     private legacySocketRemoteAddress:string;
     private userAgent: string;
+    private sourceIKeyHash: string;
 
     constructor(request:http.ServerRequest) {
         super();
@@ -30,6 +32,8 @@ class ServerRequestParser extends RequestParser {
             this.rawHeaders = request.headers || (<any>request).rawHeaders;
             this.socketRemoteAddress = (<any>request).socket && (<any>request).socket.remoteAddress;
             this.userAgent = request.headers && request.headers["user-agent"];
+            this.sourceIKeyHash =
+                request.headers && request.headers[RequestResponseHeaders.sourceInstrumentationKeyHeader];
             if (request.connection) {
                 this.connectionRemoteAddress = request.connection.remoteAddress;
                 this.legacySocketRemoteAddress = request.connection["socket"] && request.connection["socket"].remoteAddress;
@@ -56,6 +60,7 @@ class ServerRequestParser extends RequestParser {
         requestData.name = this.method + " " + url.parse(this.url).pathname;
         requestData.startTime = (new Date(this.startTime)).toISOString();
         requestData.url = this.url;
+        requestData.source = this.sourceIKeyHash;
         requestData.duration = Util.msToTimeSpan(this.duration);
         requestData.responseCode = this.statusCode ? this.statusCode.toString() : null;
         requestData.success = this._isSuccess();

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -8,6 +8,7 @@ import ContractsModule = require("../Library/Contracts");
 import Client = require("../Library/Client");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
+import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
 import ServerRequestParser = require("./ServerRequestParser");
 
 class AutoCollectServerRequests {
@@ -78,6 +79,13 @@ class AutoCollectServerRequests {
             return;
         }
 
+        // Add the target ikey hash to the response headers, if not already provided.
+        if (client.config && client.config.instrumentationKeyHash &&
+            response.setHeader && !response.getHeader(RequestResponseHeaders.targetInstrumentationKeyHeader)) {
+                response.setHeader(RequestResponseHeaders.targetInstrumentationKeyHeader,
+                    client.config.instrumentationKeyHash);
+        }
+
         // store data about the request
         var requestParser = new ServerRequestParser(request);
 
@@ -93,18 +101,25 @@ class AutoCollectServerRequests {
             return;
         }
 
+        // Add the target ikey hash to the response headers, if not already provided.
+        if (client.config && client.config.instrumentationKeyHash &&
+            response.setHeader && !response.getHeader(RequestResponseHeaders.targetInstrumentationKeyHeader)) {
+                response.setHeader(RequestResponseHeaders.targetInstrumentationKeyHeader,
+                    client.config.instrumentationKeyHash);
+        }
+
         // store data about the request
         var requestParser = new ServerRequestParser(request);
 
         // response listeners
-        if (response && response.once) {
+        if (response.once) {
             response.once("finish", () => {
                 AutoCollectServerRequests.endRequest(client, requestParser, response, null, properties, null);
             });
         }
 
         // track a failed request if an error is emitted
-        if (request && request.on) {
+        if (request.on) {
             request.on("error", (error:any) => {
                 AutoCollectServerRequests.endRequest(client, requestParser, response, null, properties, error);
             });

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -79,12 +79,7 @@ class AutoCollectServerRequests {
             return;
         }
 
-        // Add the target ikey hash to the response headers, if not already provided.
-        if (client.config && client.config.instrumentationKeyHash &&
-            response.setHeader && !response.getHeader(RequestResponseHeaders.targetInstrumentationKeyHeader)) {
-                response.setHeader(RequestResponseHeaders.targetInstrumentationKeyHeader,
-                    client.config.instrumentationKeyHash);
-        }
+        AutoCollectServerRequests.addResponseIKeyHeader(client, response);
 
         // store data about the request
         var requestParser = new ServerRequestParser(request);
@@ -101,12 +96,7 @@ class AutoCollectServerRequests {
             return;
         }
 
-        // Add the target ikey hash to the response headers, if not already provided.
-        if (client.config && client.config.instrumentationKeyHash &&
-            response.setHeader && !response.getHeader(RequestResponseHeaders.targetInstrumentationKeyHeader)) {
-                response.setHeader(RequestResponseHeaders.targetInstrumentationKeyHeader,
-                    client.config.instrumentationKeyHash);
-        }
+        AutoCollectServerRequests.addResponseIKeyHeader(client, response);
 
         // store data about the request
         var requestParser = new ServerRequestParser(request);
@@ -123,6 +113,18 @@ class AutoCollectServerRequests {
             request.on("error", (error:any) => {
                 AutoCollectServerRequests.endRequest(client, requestParser, response, null, properties, error);
             });
+        }
+    }
+
+    /**
+     * Add the target ikey hash to the response headers, if not already provided.
+     */
+    private static addResponseIKeyHeader(client:Client, response:http.ServerResponse) {
+        if (client.config && client.config.instrumentationKeyHash &&
+            response.getHeader && response.setHeader &&
+            !response.getHeader(RequestResponseHeaders.targetInstrumentationKeyHeader)) {
+                response.setHeader(RequestResponseHeaders.targetInstrumentationKeyHeader,
+                    client.config.instrumentationKeyHash);
         }
     }
 

--- a/Declarations/applicationInsights/bond.d.ts
+++ b/Declarations/applicationInsights/bond.d.ts
@@ -275,6 +275,7 @@ declare module Bond {
         url:string;
         properties:any;
         measurements:any;
+        source:string;
 
         constructor();
     }

--- a/Library/Config.ts
+++ b/Library/Config.ts
@@ -1,5 +1,7 @@
 ///<reference path="..\Declarations\node\node.d.ts" />
 
+import crypto = require('crypto');
+
 class Config {
 
     // Azure adds this prefix to all environment variables
@@ -10,6 +12,7 @@ class Config {
     public static legacy_ENV_iKey = "APPINSIGHTS_INSTRUMENTATION_KEY";
 
     public instrumentationKey: string;
+    public instrumentationKeyHash: string;
     public sessionRenewalMs: number;
     public sessionExpirationMs: number;
     public endpointUrl: string;
@@ -18,7 +21,8 @@ class Config {
     public disableAppInsights: boolean;
 
     constructor(instrumentationKey?: string) {
-        this.instrumentationKey = instrumentationKey || this._getInstrumentationKey();
+        this.instrumentationKey = instrumentationKey || Config._getInstrumentationKey();
+        this.instrumentationKeyHash = Config._getStringHashBase64(this.instrumentationKey);
         this.endpointUrl = "https://dc.services.visualstudio.com/v2/track";
         this.sessionRenewalMs = 30 * 60 * 1000;
         this.sessionExpirationMs = 24 * 60 * 60 * 1000;
@@ -27,7 +31,7 @@ class Config {
         this.disableAppInsights = false;
     }
 
-    private _getInstrumentationKey() {
+    private static _getInstrumentationKey(): string {
         // check for both the documented env variable and the azure-prefixed variable
         var iKey = process.env[Config.ENV_iKey]
             || process.env[Config.ENV_azurePrefix + Config.ENV_iKey]
@@ -38,6 +42,13 @@ class Config {
         }
 
         return iKey;
+    }
+
+    private static _getStringHashBase64(value: string): string {
+        let hash = crypto.createHash('sha256');
+        hash.update(value);
+        let result = hash.digest('base64');
+        return result;
     }
 }
 

--- a/Library/Contracts.ts
+++ b/Library/Contracts.ts
@@ -10,7 +10,6 @@ export module Contracts {
         SQL = 0,
         Http = 1,
         Other = 2,
-        ApplicationInsights = 3,
     }
 
     export enum DependencySourceType
@@ -298,6 +297,12 @@ export module Contracts {
 
             super();
         }
+    }
+
+    export class RemoteDependencyTypes {
+        public static ApplicationInsights = "Application Insights";
+        public static Http = "Http";
+        public static Sql = "SQL";
     }
 
     export class RemoteDependencyData extends Contracts.Domain {

--- a/Library/Contracts.ts
+++ b/Library/Contracts.ts
@@ -10,6 +10,7 @@ export module Contracts {
         SQL = 0,
         Http = 1,
         Other = 2,
+        ApplicationInsights = 3,
     }
 
     export enum DependencySourceType
@@ -368,6 +369,7 @@ export module Contracts {
         public url:string;
         public properties:any;
         public measurements:any;
+        public source:string;
 
         constructor() {
             super();

--- a/Library/RequestResponseHeaders.ts
+++ b/Library/RequestResponseHeaders.ts
@@ -10,14 +10,4 @@ export = {
      * calling application when processing incoming responses.
      */
     targetInstrumentationKeyHeader: "x-ms-request-target-ikey",
-
-    /**
-     * Standard parent Id header.
-     */
-    standardParentIdHeader: "x-ms-request-id",
-
-    /**
-     * Standard root id header.
-     */
-    standardRootIdHeader: "x-ms-request-root-id",
 }

--- a/Library/RequestResponseHeaders.ts
+++ b/Library/RequestResponseHeaders.ts
@@ -1,0 +1,23 @@
+export = {
+    /**
+     * Source instrumentation header that is added by an application while making http
+     * requests and retrieved by the other application when processing incoming requests.
+     */
+    sourceInstrumentationKeyHeader: "x-ms-request-source-ikey",
+
+    /**
+     * Target instrumentation header that is added to the response and retrieved by the
+     * calling application when processing incoming responses.
+     */
+    targetInstrumentationKeyHeader: "x-ms-request-target-ikey",
+
+    /**
+     * Standard parent Id header.
+     */
+    standardParentIdHeader: "x-ms-request-id",
+
+    /**
+     * Standard root id header.
+     */
+    standardRootIdHeader: "x-ms-request-root-id",
+}

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -9,6 +9,7 @@ import url = require("url");
 import zlib = require("zlib");
 
 import Logging = require("./Logging");
+import AutoCollectClientRequests = require("../AutoCollection/ClientRequests");
 
 class Sender {
     private static TAG = "Sender";
@@ -74,7 +75,7 @@ class Sender {
             Logging.info(Sender.TAG, options);
 
             // Ensure this request is not captured by auto-collection.
-            options['disableAppInsigntsAutoCollection'] = true;
+            options[AutoCollectClientRequests.disableCollectionRequestOption] = true;
 
             var req = protocol.request(<any> options, (res:http.ClientResponse) => {
                 res.setEncoding("utf-8");

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -120,12 +120,12 @@ describe("EndToEnd", () => {
 
         beforeEach(() => {
             sandbox = sinon.sandbox.create();
-            this.request = sandbox.stub(http, "request", (options: any, callback: any) => {
+            this.request = sandbox.stub(https, "request", (options: any, callback: any) => {
                 var req = new fakeRequest(false);
                 req.on("end", callback);
                 return req;
             });
-	});
+        });
 
         afterEach(() => {
             // Dispose the default app insights client and auto collectors so that they can be reconfigured

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -489,8 +489,8 @@ describe("Library/Client", () => {
                 var args = trackStub.args;
                 assert.equal(args[0][0].baseData.target, "bing.com | " +
                     response.headers[RequestResponseHeaders.targetInstrumentationKeyHeader]);
-                assert.equal(args[0][0].baseData.dependencyKind,
-                    ContractsModule.Contracts.DependencyKind.ApplicationInsights);
+                assert.equal(args[0][0].baseData.dependencyTypeName,
+                    ContractsModule.Contracts.RemoteDependencyTypes.ApplicationInsights);
             });
         });
     });


### PR DESCRIPTION
 * Add source field to the `RequestData` contract
 * Add ikey hash to incoming request response headers and dependency request headers
 * Check for ikey hash headers on incoming requests and returned dependency responses, and record in the respective telemetry `source` and `target` fields
 * Set dependency type to ApplicationInsights if an ikey header was received in a dependency response
 * Fix some bugs related to slightly different `https.request` behavior on v0.10.x