### PR TITLE
Run unit tests in Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "node"
+  - "6"
   - "5"
   - "5.1"
   - "4"


### PR DESCRIPTION
Run unit tests in the latest Node v6.* LTS. "node" (on line 3) covers v7.*
