### PR TITLE
Add automatic correlation between dependencies and requests

### DIFF
--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -1,0 +1,94 @@
+import http = require("http");
+
+interface CorrelationContext {
+    id: string;
+    req: http.ServerRequest;
+    res: http.ServerResponse;
+    metadata?: {};
+}
+
+class CorrelationContextManager {
+    private contexts: {[uid: number]: CorrelationContext} = [];
+    private currentContext: CorrelationContext = null;
+    private enabled: boolean = false;
+    private hasEverEnabled: boolean = false;
+
+    /** 
+     *  Provides the current Context.
+     *  The context is the most recent one entered into for the current
+     *  logical chain of execution, including across asynchronous calls.
+     */
+    public getCurrentContext(): CorrelationContext {
+        if (!this.enabled) {
+            return null;
+        }
+        return this.currentContext;
+    }
+
+    /** 
+     *  Enters a new Context.
+     *  All logical children of the execution path that entered this Context
+     *  will receive this Context object on calls to GetCurrentContext.
+     */
+    public enterNewContext(context: CorrelationContext) {
+        this.currentContext = context;
+    }
+
+    /**
+     *  Enables the CorrelationContextManager. This uses Node's async_wrap
+     *  API which is not available in older versions of Node (< 0.12.1).
+     *  This method will detect these old versions and do nothing.
+     */
+    public enable() {
+        if (/^0\.([0-9]\.)|(10\.)|(11\.)|(12\.0$)/.test(process.versions.node)) {
+            return;
+        }
+
+        this.enabled = true;
+        
+        if (!this.hasEverEnabled) {
+            this.hasEverEnabled = true;
+
+            // Suppress unstable warning from async-hook
+            process.env["NODE_ASYNC_HOOK_NO_WARNING"] = true;
+
+            // Load in async-hook and enable it
+            var asyncHook = require("async-hook");
+            asyncHook.addHooks({
+                init: this.onAsyncInit,
+                pre: this.onAsyncPre,
+                post: this.onAsyncPost,
+                destroy: this.onAsyncDestroy});
+            asyncHook.enable();
+        }
+    }
+
+    public disable() {
+        this.enabled = false;
+    }
+
+    public isEnabled() {
+        return this.enabled;
+    }
+
+
+    // Callbacks for async-hook
+    private onAsyncInit(uid: number) {
+        this.contexts[uid] = this.currentContext;
+    }
+
+    private onAsyncPre(uid: number) {
+        this.currentContext = this.contexts[uid];
+    }
+
+    private onAsyncPost(uid: number) {
+        this.currentContext = null;
+    }
+
+    private onAsyncDestroy(uid: number) {
+        delete this.contexts[uid];
+    }
+}
+
+// Force singleton
+export = new CorrelationContextManager();

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -2,8 +2,6 @@ import http = require("http");
 
 interface CorrelationContext {
     operationId: string;
-    req: http.ServerRequest;
-    res: http.ServerResponse;
 }
 
 class CorrelationContextManager {

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -1,4 +1,4 @@
-import "zone.js";
+import "zone.js"; // Keep this first
 import http = require("http");
 
 export interface CorrelationContext {
@@ -29,7 +29,7 @@ export class CorrelationContextManager {
      */
     public static runWithContext(context: CorrelationContext, fn: ()=>any) {
         if (CorrelationContextManager.enabled) {
-            var newZone = Zone.current.fork({name: context.operationId, properties: {context: context}});
+            var newZone = Zone.current.fork({name: "AI-"+((context && context.operationId) || "Unknown"), properties: {context: context}});
             newZone.run(fn);
         } else {
             fn();

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -1,4 +1,8 @@
-import "zone.js"; // Keep this first
+/// <reference path="..\node_modules\zone.js\dist\zone.js.d.ts" />
+var nodeVer = process.versions.node.split(".");
+if (parseInt(nodeVer[0]) > 3 || (parseInt(nodeVer[0]) > 2 && parseInt(nodeVer[1]) > 2)) { // Unit tests warn of errors < 3.3 from timer patching. All versions before 4 were 0.x
+    require("zone.js"); // Keep this first
+}
 import http = require("http");
 
 export interface CorrelationContext {
@@ -54,6 +58,11 @@ export class CorrelationContextManager {
      *  Enables the CorrelationContextManager.
      */
     public static enable() {
+        if (!this.isNodeVersionCompatible()) {
+            this.enabled = false;
+            return;
+        }
+
         // Run patches first
         if (!this.hasEverEnabled) {
             this.hasEverEnabled = true;
@@ -68,6 +77,14 @@ export class CorrelationContextManager {
      */
     public static disable() {
         this.enabled = false;
+    }
+
+
+    /**
+     *  Reports if the CorrelationContextManager is able to run in this environment
+     */
+    public static isNodeVersionCompatible() {
+        return typeof Zone !== 'undefined'
     }
 
     // Patch methods that manually go async that Zone doesn't catch

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -3,6 +3,7 @@ import http = require("http");
 
 export interface CorrelationContext {
     operationId: string;
+    userProperties?: {};
 }
 
 export class CorrelationContextManager {
@@ -35,6 +36,20 @@ export class CorrelationContextManager {
         }
     }
 
+    /** 
+     *  Patches a callback to restore the correct Context when getCurrentContext 
+     *  is run within it. This is necessary if automatic correlation fails to work
+     *  with user-included libraries.
+     * 
+     *  The supplied callback will be given the same context that was present for 
+     *  the call to wrapCallback.  */
+    public static wrapCallback<T extends Function>(fn: T): T {
+        if (CorrelationContextManager.enabled) {
+            return Zone.current.wrap(fn, "User-wrapped method");
+        }
+        return fn;
+    }
+
     /**
      *  Enables the CorrelationContextManager.
      */
@@ -65,28 +80,27 @@ export class CorrelationContextManager {
         }
         return req;
     }
+
     private static patchRedis() {
         var redis = this.requireForPatch("redis");
 
-        if (!redis || !redis.RedisClient) {
-            return;
+        if (redis && redis.RedisClient) {
+            var orig = redis.RedisClient.prototype.send_command;
+            redis.RedisClient.prototype.send_command = function() {
+                var args = Array.prototype.slice.call(arguments);
+                var lastArg = args[args.length - 1];
+
+                if (typeof lastArg === "function") {
+                    args[args.length - 1] = Zone.current.wrap(lastArg, "AI.CCM.patchRedis");
+                } else if (Array.isArray(lastArg) && typeof lastArg[lastArg.length - 1] === "function") {
+                    // The last argument can be an array!
+                    var lastIndexLastArg = lastArg[lastArg.length - 1];
+                    lastArg[lastArg.length - 1] = Zone.current.wrap(lastIndexLastArg, "AI.CCM.patchRedis");
+                }
+
+                return orig.apply(this, args);
+            };
         }
-
-        var orig = redis.RedisClient.prototype.send_command;
-        redis.RedisClient.prototype.send_command = function() {
-            var args = Array.prototype.slice.call(arguments);
-            var lastArg = args[args.length - 1];
-
-            if (typeof lastArg === "function") {
-                args[args.length - 1] = Zone.current.wrap(lastArg, "ApplicationInsights.CorrelationContextManager.patchRedis");
-            } else if (Array.isArray(lastArg) && typeof lastArg[lastArg.length - 1] === "function") {
-                // The last argument can be an array!
-                var lastIndexLastArg = lastArg[lastArg.length - 1];
-                lastArg[lastArg.length - 1] = Zone.current.wrap(lastIndexLastArg, "ApplicationInsights.CorrelationContextManager.patchRedis");
-            }
-
-            return orig.apply(this, args);
-        };
     }
 
 }

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -183,9 +183,9 @@ export class CorrelationContextManager {
         var orig = global.Error;
 
         // New error handler
-        function AppInsightsAsyncCorrelatedErrorHandler() {
-            if (!(this instanceof AppInsightsAsyncCorrelatedErrorHandler)) {
-                return AppInsightsAsyncCorrelatedErrorHandler.apply(Object.create(AppInsightsAsyncCorrelatedErrorHandler.prototype), arguments);
+        function AppInsightsAsyncCorrelatedErrorWrapper() {
+            if (!(this instanceof AppInsightsAsyncCorrelatedErrorWrapper)) {
+                return AppInsightsAsyncCorrelatedErrorWrapper.apply(Object.create(AppInsightsAsyncCorrelatedErrorWrapper.prototype), arguments);
             }
 
             orig.apply(this, arguments);
@@ -207,19 +207,19 @@ export class CorrelationContextManager {
         }
 
         // Inherit from the Zone.js error handler
-        AppInsightsAsyncCorrelatedErrorHandler.prototype = orig.prototype;
+        AppInsightsAsyncCorrelatedErrorWrapper.prototype = orig.prototype;
 
         // We need this loop to copy outer methods like Error.captureStackTrace
         var props = Object.getOwnPropertyNames(orig);
         for(var i=0; i<props.length; i++) {
             var propertyName = props[i];
-            if (!AppInsightsAsyncCorrelatedErrorHandler[propertyName]) {
-                Object.defineProperty(AppInsightsAsyncCorrelatedErrorHandler, propertyName, {
+            if (!AppInsightsAsyncCorrelatedErrorWrapper[propertyName]) {
+                Object.defineProperty(AppInsightsAsyncCorrelatedErrorWrapper, propertyName, {
                     value: orig[propertyName],
                     enumerable: orig.propertyIsEnumerable(propertyName)
                 });
             }
         }
-        global.Error = AppInsightsAsyncCorrelatedErrorHandler;
+        global.Error = AppInsightsAsyncCorrelatedErrorWrapper;
     }
 }

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -1,21 +1,21 @@
 import http = require("http");
 
-interface CorrelationContext {
+export interface CorrelationContext {
     operationId: string;
 }
 
-class CorrelationContextManager {
-    private contexts: {[uid: number]: CorrelationContext} = [];
-    private currentContext: CorrelationContext = null;
-    private enabled: boolean = false;
-    private hasEverEnabled: boolean = false;
+export class CorrelationContextManager {
+    private static contexts: {[uid: number]: CorrelationContext} = [];
+    private static currentContext: CorrelationContext = null;
+    private static enabled: boolean = false;
+    private static hasEverEnabled: boolean = false;
 
     /** 
      *  Provides the current Context.
      *  The context is the most recent one entered into for the current
      *  logical chain of execution, including across asynchronous calls.
      */
-    public getCurrentContext(): CorrelationContext {
+    public static getCurrentContext(): CorrelationContext {
         if (!this.enabled) {
             return null;
         }
@@ -27,7 +27,7 @@ class CorrelationContextManager {
      *  All logical children of the execution path that entered this Context
      *  will receive this Context object on calls to GetCurrentContext.
      */
-    public enterNewContext(context: CorrelationContext) {
+    public static enterNewContext(context: CorrelationContext) {
         this.currentContext = context;
     }
 
@@ -36,7 +36,7 @@ class CorrelationContextManager {
      *  API which is not available in older versions of Node (< 0.12.1).
      *  This method will detect these old versions and do nothing.
      */
-    public enable() {
+    public static enable() {
         if (/^0\.([0-9]\.)|(10\.)|(11\.)|(12\.0$)/.test(process.versions.node)) {
             return;
         }
@@ -60,32 +60,29 @@ class CorrelationContextManager {
         }
     }
 
-    public disable() {
+    public static disable() {
         this.enabled = false;
     }
 
-    public isEnabled() {
+    public static isEnabled() {
         return this.enabled;
     }
 
 
     // Callbacks for async-hook
-    private onAsyncInit(uid: number) {
+    private static onAsyncInit(uid: number) {
         this.contexts[uid] = this.currentContext;
     }
 
-    private onAsyncPre(uid: number) {
+    private static onAsyncPre(uid: number) {
         this.currentContext = this.contexts[uid];
     }
 
-    private onAsyncPost(uid: number) {
+    private static onAsyncPost(uid: number) {
         this.currentContext = null;
     }
 
-    private onAsyncDestroy(uid: number) {
+    private static onAsyncDestroy(uid: number) {
         delete this.contexts[uid];
     }
 }
-
-// Force singleton
-export = new CorrelationContextManager();

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -1,10 +1,9 @@
 import http = require("http");
 
 interface CorrelationContext {
-    id: string;
+    operationId: string;
     req: http.ServerRequest;
     res: http.ServerResponse;
-    metadata?: {};
 }
 
 class CorrelationContextManager {

--- a/AutoCollection/ServerRequestParser.ts
+++ b/AutoCollection/ServerRequestParser.ts
@@ -91,9 +91,13 @@ class ServerRequestParser extends RequestParser {
         newTags[ServerRequestParser.keys.userAgent] = tags[ServerRequestParser.keys.userAgent] || this.userAgent;
         newTags[ServerRequestParser.keys.operationName] = tags[ServerRequestParser.keys.operationName] || this.method + " " + url.parse(this.url).pathname;
         newTags[ServerRequestParser.keys.operationParentId] = tags[ServerRequestParser.keys.operationParentId] || this.parentId;
-        newTags[ServerRequestParser.keys.operationId] = tags[ServerRequestParser.keys.operationId] || this.operationId;
+        newTags[ServerRequestParser.keys.operationId] = this.getOperationId(tags);
 
         return newTags;
+    }
+
+    public getOperationId(tags:{[key: string]:string}) {
+        return tags[ServerRequestParser.keys.operationId] || this.operationId;
     }
 
     private _getAbsoluteUrl(request:http.ServerRequest):string {

--- a/AutoCollection/ServerRequestParser.ts
+++ b/AutoCollection/ServerRequestParser.ts
@@ -24,10 +24,12 @@ class ServerRequestParser extends RequestParser {
     private sourceIKeyHash: string;
     private parentId: string;
     private operationId: string;
+    private requestId: string;
 
-    constructor(request:http.ServerRequest) {
+    constructor(request:http.ServerRequest, requestId?: string) {
         super();
         if (request) {
+            this.requestId = requestId || Util.newGuid();
             this.method = request.method;
             this.url = this._getAbsoluteUrl(request);
             this.startTime = +new Date();
@@ -61,7 +63,7 @@ class ServerRequestParser extends RequestParser {
 
     public getRequestData():ContractsModule.Contracts.Data<ContractsModule.Contracts.RequestData> {
         var requestData = new ContractsModule.Contracts.RequestData();
-        requestData.id = Util.newGuid();
+        requestData.id = this.requestId;
         requestData.name = this.method + " " + url.parse(this.url).pathname;
         requestData.url = this.url;
         requestData.source = this.sourceIKeyHash;
@@ -89,8 +91,8 @@ class ServerRequestParser extends RequestParser {
         newTags[ServerRequestParser.keys.sessionId] = tags[ServerRequestParser.keys.sessionId] || this._getId("ai_session");
         newTags[ServerRequestParser.keys.userId] = tags[ServerRequestParser.keys.userId] || this._getId("ai_user");
         newTags[ServerRequestParser.keys.userAgent] = tags[ServerRequestParser.keys.userAgent] || this.userAgent;
-        newTags[ServerRequestParser.keys.operationName] = tags[ServerRequestParser.keys.operationName] || this.method + " " + url.parse(this.url).pathname;
-        newTags[ServerRequestParser.keys.operationParentId] = tags[ServerRequestParser.keys.operationParentId] || this.parentId;
+        newTags[ServerRequestParser.keys.operationName] = this.getOperationName(tags);
+        newTags[ServerRequestParser.keys.operationParentId] = this.getOperationParentId(tags);
         newTags[ServerRequestParser.keys.operationId] = this.getOperationId(tags);
 
         return newTags;
@@ -98,6 +100,18 @@ class ServerRequestParser extends RequestParser {
 
     public getOperationId(tags:{[key: string]:string}) {
         return tags[ServerRequestParser.keys.operationId] || this.operationId;
+    }
+
+    public getOperationParentId(tags:{[key: string]:string}) {
+        return tags[ServerRequestParser.keys.operationParentId] || this.parentId || this.getOperationId(tags);
+    }
+
+    public getOperationName(tags:{[key: string]:string}) {
+        return tags[ServerRequestParser.keys.operationName] || this.method + " " + url.parse(this.url).pathname;
+    }
+
+    public getRequestId() {
+        return this.requestId;
     }
 
     private _getAbsoluteUrl(request:http.ServerRequest):string {

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -54,8 +54,6 @@ class AutoCollectServerRequests {
         if (this._isAutoCorrelating) {
             correlationContext = {
                 operationId: Util.newGuid(),
-                req: request,
-                res: response
             };
         }
         CorrelationContextManager.enterNewContext(correlationContext);
@@ -115,7 +113,7 @@ class AutoCollectServerRequests {
 
         // Establish the definitive operationId. Update the correlation context with the result
         // This can be either the value from ServerRequestParser or from the correlation context.
-        // ServerRequestParser always wins.
+        // ServerRequestParser always wins. This value will get restored in track()
         var correlationContext = CorrelationContextManager.getCurrentContext();
         if (correlationContext) {
             correlationContext.operationId = requestParser.getOperationId(client.context.tags) || correlationContext.operationId;
@@ -142,7 +140,7 @@ class AutoCollectServerRequests {
 
         // Establish the definitive operationId. Update the correlation context with the result
         // This can be either the value from ServerRequestParser or from the correlation context.
-        // ServerRequestParser always wins.
+        // ServerRequestParser always wins. This value will get restored in track()
         var correlationContext = CorrelationContextManager.getCurrentContext();
         if (correlationContext) {
             correlationContext.operationId = requestParser.getOperationId(client.context.tags) || correlationContext.operationId;

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -10,7 +10,7 @@ import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
 import ServerRequestParser = require("./ServerRequestParser");
-import CorrelationContextManager = require("./CorrelationContextManager");
+import { CorrelationContextManager, CorrelationContext } from "./CorrelationContextManager";
 
 class AutoCollectServerRequests {
 
@@ -52,10 +52,10 @@ class AutoCollectServerRequests {
     }
 
     private _generateCorrelationContext(request:http.ServerRequest, response:http.ServerResponse) {
-        var correlationContext = null;
+        var correlationContext: CorrelationContext = null;
         if (this._isAutoCorrelating) {
             correlationContext = {
-                operationId: Util.newGuid(),
+                operationId: Util.newGuid()
             };
         }
         CorrelationContextManager.enterNewContext(correlationContext);

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -41,6 +41,8 @@ class AutoCollectServerRequests {
     public useAutoCorrelation(isEnabled:boolean) {
         if (isEnabled && !this._isAutoCorrelating) {
             CorrelationContextManager.enable();
+        } else if (!isEnabled && this._isAutoCorrelating) {
+            CorrelationContextManager.disable();
         }
         this._isAutoCorrelating = isEnabled;
     }

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -55,6 +55,10 @@ class AutoCollectServerRequests {
         return this._isInitialized;
     }
 
+    public isAutoCorrelating() {
+        return this._isAutoCorrelating;
+    }
+
     private _generateCorrelationContext(request:http.ServerRequest, response:http.ServerResponse) {
         var correlationContext: CorrelationContext = null;
         if (this._isAutoCorrelating) {

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -280,10 +280,8 @@ class Client {
             return accepted;
         }     
 
-        var correlationContext = CorrelationContextManager.getCurrentContext();
-        var userCorrelationContext = correlationContext && correlationContext.userProperties;
         contextObjects = contextObjects || {};
-        contextObjects['userProperties'] = userCorrelationContext;
+        contextObjects['correlationContext'] = CorrelationContextManager.getCurrentContext();
 
         for (var i = 0; i < telemetryProcessorsCount; ++i) {
             try {
@@ -322,7 +320,11 @@ class Client {
         }
 
         // Fill in internally-populated values if not already set
-        newTags[this.context.keys.operationId] = newTags[this.context.keys.operationId] || correlationContext.operationId;
+        if (correlationContext) {
+            newTags[this.context.keys.operationId] = newTags[this.context.keys.operationId] || correlationContext.operation.id;
+            newTags[this.context.keys.operationName] = newTags[this.context.keys.operationName] || correlationContext.operation.name;
+            newTags[this.context.keys.operationParentId] = newTags[this.context.keys.operationParentId] || correlationContext.operation.parentId;
+        }
 
         return newTags;
     }

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -27,7 +27,7 @@ class Client {
         Util.random32()]) +
     ":";
     private _sequenceNumber = 0;
-    private _telemetryProcessors: { (envelope: ContractsModule.Contracts.Envelope): boolean; }[] = [];
+    private _telemetryProcessors: { (envelope: ContractsModule.Contracts.Envelope, contextObjects: {[name: string]: any;}): boolean; }[] = [];
 
     public config: Config;
     public context: Context;
@@ -278,8 +278,12 @@ class Client {
 
         if (telemetryProcessorsCount === 0) {
             return accepted;
-        }
+        }     
 
+        var correlationContext = CorrelationContextManager.getCurrentContext();
+        var userCorrelationContext = correlationContext && correlationContext.userProperties;
+        contextObjects = contextObjects || {};
+        contextObjects['userProperties'] = userCorrelationContext;
 
         for (var i = 0; i < telemetryProcessorsCount; ++i) {
             try {

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -223,7 +223,7 @@ class Client {
         envelope.os = os && os.type();
         envelope.osVer = os && os.release();
         envelope.seq = this._sequencePrefix + (this._sequenceNumber++).toString();
-        envelope.tags = this.getTags();
+        envelope.tags = this.getTags(tagOverrides);
         envelope.time = (new Date()).toISOString();
         envelope.ver = 1;
         return envelope;

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -12,7 +12,7 @@ import ContractsModule = require("../Library/Contracts");
 import Channel = require("./Channel");
 import ServerRequestTracking = require("../AutoCollection/ServerRequests");
 import ClientRequestTracking = require("../AutoCollection/ClientRequests");
-import CorrelationContextManager = require("../AutoCollection/CorrelationContextManager");
+import { CorrelationContextManager } from "../AutoCollection/CorrelationContextManager";
 import Sender = require("./Sender");
 import Util = require("./Util");
 import Logging = require("./Logging");

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project provides a [Visual Studio Application Insights](https://azure.micro
 
 The SDK provides automatic collection of incoming HTTP request rates and responses, performance counters (CPU, memory, RPS), and unhandled exceptions. In addition, you can add custom calls to track dependencies, metrics, or other events.
 
+In versions of Node.js > 4.0 (and io.js > 3.3) the SDK provides automatic correlation of dependencies to requests.
 
 ## Requirements ##
 **Install**

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ appInsights.setup("<instrumentation_key>").start();
 
 ## Customized Usage ##
 
-### Disabling auto-collection
+### Disabling automatic collection and correlation
 
 ```javascript
 import appInsights = require("applicationinsights");
@@ -44,6 +44,7 @@ appInsights.setup("<instrumentation_key>")
     .setAutoCollectRequests(false)
     .setAutoCollectPerformance(false)
     .setAutoCollectExceptions(false)
+    .setAutoDependencyCorrelation(false)
     // no telemetry will be sent until .start() is called
     .start();
 ```
@@ -63,12 +64,15 @@ client.trackTrace("trace message");
 ### Telemetry Processor
 
 ```javascript
-public addTelemetryProcessor(telemetryProcessor: (envelope: ContractsModule.Contracts.Envelope) => boolean)
+public addTelemetryProcessor(telemetryProcessor: (envelope: ContractsModule.Contracts.Envelope, context: { http.RequestOptions, http.ClientRequest, http.ClientResponse, userProperties }) => boolean)
 ```
 
 Adds a telemetry processor to the collection. Telemetry processors will be called one by one, in the order they were added, before the telemetry item is pushed for sending. 
 If one of the telemetry processors returns false then the telemetry item will not be sent. 
 If one of the telemetry processors throws an error then the telemetry item will not be sent.
+
+All telemetry processors receive the envelope to modify before sending. They also receive a context object with relevant request information (if available)
+as well as the request storage object returned by `appInsights.getCorrelationContext()` (if automatic dependency correlation is enabled).
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ appInsights.setup("<instrumentation_key>")
     .start();
 ```
 
+> Be sure to call `require("applicationinsights")` before your other imports. This allows the SDK to do patching necessary for tracking correlation state before other libraries use patched methods. If you encounter conflicts with other libraries doing similar patching, place this import below those libraries.
+
 ### Disabling automatic collection
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project provides a [Visual Studio Application Insights](https://azure.micro
 
 The SDK provides automatic collection of incoming HTTP request rates and responses, performance counters (CPU, memory, RPS), and unhandled exceptions. In addition, you can add custom calls to track dependencies, metrics, or other events.
 
-In versions of Node.js > 4.0 (and io.js > 3.3) the SDK provides automatic correlation of dependencies to requests.
+In versions of Node.js > 4.0 (and io.js > 3.3) the SDK provides automatic correlation of dependencies to requests (off by default, see Customized Usage below to enable).
 
 ## Requirements ##
 **Install**
@@ -37,7 +37,17 @@ appInsights.setup("<instrumentation_key>").start();
 
 ## Customized Usage ##
 
-### Disabling automatic collection and correlation
+### Enabling automatic correlation
+
+```javascript
+import appInsights = require("applicationinsights");
+appInsights.setup("<instrumentation_key>")
+    .setAutoDependencyCorrelation(true)
+    // no telemetry will be sent until .start() is called
+    .start();
+```
+
+### Disabling automatic collection
 
 ```javascript
 import appInsights = require("applicationinsights");
@@ -46,7 +56,6 @@ appInsights.setup("<instrumentation_key>")
     .setAutoCollectPerformance(false)
     .setAutoCollectExceptions(false)
     .setAutoCollectDependencies(false)
-    .setAutoDependencyCorrelation(false)
     // no telemetry will be sent until .start() is called
     .start();
 ```
@@ -66,7 +75,7 @@ client.trackTrace("trace message");
 ### Telemetry Processor
 
 ```javascript
-public addTelemetryProcessor(telemetryProcessor: (envelope: ContractsModule.Contracts.Envelope, context: { http.RequestOptions, http.ClientRequest, http.ClientResponse, userProperties }) => boolean)
+public addTelemetryProcessor(telemetryProcessor: (envelope: ContractsModule.Contracts.Envelope, context: { http.RequestOptions, http.ClientRequest, http.ClientResponse, correlationContext }) => boolean)
 ```
 
 Adds a telemetry processor to the collection. Telemetry processors will be called one by one, in the order they were added, before the telemetry item is pushed for sending. 

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -10,10 +10,20 @@ import sinon = require("sinon");
 if (CorrelationContextManager.isNodeVersionCompatible()) {
     describe("AutoCollection/CorrelationContextManager", () => {
         var testContext: CorrelationContext = {
-            operationId: "test"
+            operation: {
+                id: "test",
+                name: "test",
+                parentId: "test"
+            },
+            customProperties: {}
         };
         var testContext2: CorrelationContext = {
-            operationId: "test2"
+            operation: {
+                id: "test2",
+                name: "test2",
+                parentId: "test2"
+            },
+            customProperties: {}
         };
 
         describe("#getCurrentContext()", () => {
@@ -133,10 +143,20 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
 } else {
     describe("AutoCollection/CorrelationContextManager[IncompatibleVersion!]", () => {
         var testContext: CorrelationContext = {
-            operationId: "test"
+            operation: {
+                id: "test",
+                name: "test",
+                parentId: "test"
+            },
+            customProperties: {}
         };
         var testContext2: CorrelationContext = {
-            operationId: "test2"
+            operation: {
+                id: "test2",
+                name: "test2",
+                parentId: "test2"
+            },
+            customProperties: {}
         };
 
         describe("#getCurrentContext()", () => {

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -1,0 +1,132 @@
+///<reference path="..\..\typings\globals\node\index.d.ts" />
+///<reference path="..\..\typings\globals\mocha\index.d.ts" />
+///<reference path="..\..\typings\globals\sinon\index.d.ts" />
+
+import { CorrelationContextManager, CorrelationContext } from "../../AutoCollection/CorrelationContextManager";
+
+import assert = require("assert");
+import sinon = require("sinon");
+
+
+describe("AutoCollection/CorrelationContextManager", () => {
+    var testContext: CorrelationContext = {
+        operationId: "test"
+    };
+    var testContext2: CorrelationContext = {
+        operationId: "test2"
+    };
+
+    describe("#getCurrentContext()", () => {
+        afterEach(()=>{
+            // Mocha's async "done" methods cause future tests to be in the same context chain
+            // Reset the context each time
+            CorrelationContextManager.enable();
+            CorrelationContextManager.runWithContext(null, ()=>null);
+        });
+        it("should return null if not in a context", () => {
+            CorrelationContextManager.enable();
+
+            assert.equal(CorrelationContextManager.getCurrentContext(), null);
+        });
+        it("should return null if the ContextManager is disabled (outside context)", () => {
+            CorrelationContextManager.disable();
+
+            assert.equal(CorrelationContextManager.getCurrentContext(), null);
+        });
+        it("should return null if the ContextManager is disabled (inside context)", (done) => {
+            CorrelationContextManager.enable();
+
+            CorrelationContextManager.runWithContext(testContext, ()=>{
+                CorrelationContextManager.disable();
+                assert.equal(CorrelationContextManager.getCurrentContext(), null);
+                done();
+            });
+        });
+        it("should return the context if in a context", (done) => {
+            CorrelationContextManager.enable();
+
+            CorrelationContextManager.runWithContext(testContext, ()=>{
+                assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
+                done();
+            });
+        });
+        it("should return the context if called by an asynchronous callback in a context", (done) => {
+            CorrelationContextManager.enable();
+
+            CorrelationContextManager.runWithContext(testContext, ()=>{
+                process.nextTick(()=>{
+                    assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
+                    done();
+                });
+            });
+        });
+        it("should return the correct context to asynchronous callbacks occuring in parallel", (done) => {
+            CorrelationContextManager.enable();
+
+            CorrelationContextManager.runWithContext(testContext, ()=>{
+                process.nextTick(()=>{
+                    assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
+                });
+            });
+
+            CorrelationContextManager.runWithContext(testContext2, ()=>{
+                process.nextTick(()=>{
+                    assert.equal(CorrelationContextManager.getCurrentContext(), testContext2);
+                });
+            });
+
+            setTimeout(()=>done(), 10);
+        });
+    });
+
+    describe("#runWithContext()", () => {
+        it("should run the supplied function", () => {
+            CorrelationContextManager.enable();
+            var fn = sinon.spy();
+
+            CorrelationContextManager.runWithContext(testContext, fn);
+
+            assert(fn.calledOnce);
+        });
+    });
+
+    describe("#wrapCallback()", () => {
+        it("should return the supplied function if disabled", () => {
+            CorrelationContextManager.disable();
+            var fn = sinon.spy();
+
+            var wrapped = CorrelationContextManager.wrapCallback(fn);
+
+            assert.equal(wrapped, fn);
+        });
+        it("should return a function that calls the supplied function if enabled", () => {
+            CorrelationContextManager.enable();
+            var fn = sinon.spy();
+
+            var wrapped = CorrelationContextManager.wrapCallback(fn);
+            wrapped();
+
+            assert.notEqual(wrapped, fn);
+            assert(fn.calledOnce);
+        });
+        it("should return a function that restores the context available at call-time into the supplied function if enabled", (done) => {
+            CorrelationContextManager.enable();
+
+            var sharedFn = ()=> {
+                assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
+            };
+
+            CorrelationContextManager.runWithContext(testContext, ()=>{
+                sharedFn = CorrelationContextManager.wrapCallback(sharedFn);
+            });
+
+            CorrelationContextManager.runWithContext(testContext2, ()=>{
+                setTimeout(()=>{
+                    sharedFn();
+                }, 8);
+            });
+
+            setTimeout(()=>done(), 10);
+        });
+    });
+});

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -7,126 +7,242 @@ import { CorrelationContextManager, CorrelationContext } from "../../AutoCollect
 import assert = require("assert");
 import sinon = require("sinon");
 
+if (CorrelationContextManager.isNodeVersionCompatible()) {
+    describe("AutoCollection/CorrelationContextManager", () => {
+        var testContext: CorrelationContext = {
+            operationId: "test"
+        };
+        var testContext2: CorrelationContext = {
+            operationId: "test2"
+        };
 
-describe("AutoCollection/CorrelationContextManager", () => {
-    var testContext: CorrelationContext = {
-        operationId: "test"
-    };
-    var testContext2: CorrelationContext = {
-        operationId: "test2"
-    };
+        describe("#getCurrentContext()", () => {
+            afterEach(()=>{
+                // Mocha's async "done" methods cause future tests to be in the same context chain
+                // Reset the context each time
+                CorrelationContextManager.enable();
+                CorrelationContextManager.runWithContext(null, ()=>null);
+            });
+            it("should return null if not in a context", () => {
+                CorrelationContextManager.enable();
 
-    describe("#getCurrentContext()", () => {
-        afterEach(()=>{
-            // Mocha's async "done" methods cause future tests to be in the same context chain
-            // Reset the context each time
-            CorrelationContextManager.enable();
-            CorrelationContextManager.runWithContext(null, ()=>null);
-        });
-        it("should return null if not in a context", () => {
-            CorrelationContextManager.enable();
-
-            assert.equal(CorrelationContextManager.getCurrentContext(), null);
-        });
-        it("should return null if the ContextManager is disabled (outside context)", () => {
-            CorrelationContextManager.disable();
-
-            assert.equal(CorrelationContextManager.getCurrentContext(), null);
-        });
-        it("should return null if the ContextManager is disabled (inside context)", (done) => {
-            CorrelationContextManager.enable();
-
-            CorrelationContextManager.runWithContext(testContext, ()=>{
-                CorrelationContextManager.disable();
                 assert.equal(CorrelationContextManager.getCurrentContext(), null);
-                done();
             });
-        });
-        it("should return the context if in a context", (done) => {
-            CorrelationContextManager.enable();
+            it("should return null if the ContextManager is disabled (outside context)", () => {
+                CorrelationContextManager.disable();
 
-            CorrelationContextManager.runWithContext(testContext, ()=>{
-                assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
-                done();
+                assert.equal(CorrelationContextManager.getCurrentContext(), null);
             });
-        });
-        it("should return the context if called by an asynchronous callback in a context", (done) => {
-            CorrelationContextManager.enable();
+            it("should return null if the ContextManager is disabled (inside context)", (done) => {
+                CorrelationContextManager.enable();
 
-            CorrelationContextManager.runWithContext(testContext, ()=>{
-                process.nextTick(()=>{
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    CorrelationContextManager.disable();
+                    assert.equal(CorrelationContextManager.getCurrentContext(), null);
+                    done();
+                });
+            });
+            it("should return the context if in a context", (done) => {
+                CorrelationContextManager.enable();
+
+                CorrelationContextManager.runWithContext(testContext, ()=>{
                     assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
                     done();
                 });
             });
-        });
-        it("should return the correct context to asynchronous callbacks occuring in parallel", (done) => {
-            CorrelationContextManager.enable();
+            it("should return the context if called by an asynchronous callback in a context", (done) => {
+                CorrelationContextManager.enable();
 
-            CorrelationContextManager.runWithContext(testContext, ()=>{
-                process.nextTick(()=>{
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    process.nextTick(()=>{
+                        assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
+                        done();
+                    });
+                });
+            });
+            it("should return the correct context to asynchronous callbacks occuring in parallel", (done) => {
+                CorrelationContextManager.enable();
+
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    process.nextTick(()=>{
+                        assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
+                    });
+                });
+
+                CorrelationContextManager.runWithContext(testContext2, ()=>{
+                    process.nextTick(()=>{
+                        assert.equal(CorrelationContextManager.getCurrentContext(), testContext2);
+                    });
+                });
+
+                setTimeout(()=>done(), 10);
+            });
+        });
+
+        describe("#runWithContext()", () => {
+            it("should run the supplied function", () => {
+                CorrelationContextManager.enable();
+                var fn = sinon.spy();
+
+                CorrelationContextManager.runWithContext(testContext, fn);
+
+                assert(fn.calledOnce);
+            });
+        });
+
+        describe("#wrapCallback()", () => {
+            it("should return the supplied function if disabled", () => {
+                CorrelationContextManager.disable();
+                var fn = sinon.spy();
+
+                var wrapped = CorrelationContextManager.wrapCallback(fn);
+
+                assert.equal(wrapped, fn);
+            });
+            it("should return a function that calls the supplied function if enabled", () => {
+                CorrelationContextManager.enable();
+                var fn = sinon.spy();
+
+                var wrapped = CorrelationContextManager.wrapCallback(fn);
+                wrapped();
+
+                assert.notEqual(wrapped, fn);
+                assert(fn.calledOnce);
+            });
+            it("should return a function that restores the context available at call-time into the supplied function if enabled", (done) => {
+                CorrelationContextManager.enable();
+
+                var sharedFn = ()=> {
                     assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
+                };
+
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    sharedFn = CorrelationContextManager.wrapCallback(sharedFn);
+                });
+
+                CorrelationContextManager.runWithContext(testContext2, ()=>{
+                    setTimeout(()=>{
+                        sharedFn();
+                    }, 8);
+                });
+
+                setTimeout(()=>done(), 10);
+            });
+        });
+    });
+} else {
+    describe("AutoCollection/CorrelationContextManager[IncompatibleVersion!]", () => {
+        var testContext: CorrelationContext = {
+            operationId: "test"
+        };
+        var testContext2: CorrelationContext = {
+            operationId: "test2"
+        };
+
+        describe("#getCurrentContext()", () => {
+            it("should return null if not in a context", () => {
+                CorrelationContextManager.enable();
+
+                assert.equal(CorrelationContextManager.getCurrentContext(), null);
+            });
+            it("should return null if the ContextManager is disabled (outside context)", () => {
+                CorrelationContextManager.disable();
+
+                assert.equal(CorrelationContextManager.getCurrentContext(), null);
+            });
+            it("should return null if the ContextManager is disabled (inside context)", (done) => {
+                CorrelationContextManager.enable();
+
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    CorrelationContextManager.disable();
+                    assert.equal(CorrelationContextManager.getCurrentContext(), null);
+                    done();
                 });
             });
+            it("should return null if in a context", (done) => {
+                CorrelationContextManager.enable();
 
-            CorrelationContextManager.runWithContext(testContext2, ()=>{
-                process.nextTick(()=>{
-                    assert.equal(CorrelationContextManager.getCurrentContext(), testContext2);
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    assert.equal(CorrelationContextManager.getCurrentContext(), null);
+                    done();
                 });
             });
+            it("should return null if called by an asynchronous callback in a context", (done) => {
+                CorrelationContextManager.enable();
 
-            setTimeout(()=>done(), 10);
-        });
-    });
-
-    describe("#runWithContext()", () => {
-        it("should run the supplied function", () => {
-            CorrelationContextManager.enable();
-            var fn = sinon.spy();
-
-            CorrelationContextManager.runWithContext(testContext, fn);
-
-            assert(fn.calledOnce);
-        });
-    });
-
-    describe("#wrapCallback()", () => {
-        it("should return the supplied function if disabled", () => {
-            CorrelationContextManager.disable();
-            var fn = sinon.spy();
-
-            var wrapped = CorrelationContextManager.wrapCallback(fn);
-
-            assert.equal(wrapped, fn);
-        });
-        it("should return a function that calls the supplied function if enabled", () => {
-            CorrelationContextManager.enable();
-            var fn = sinon.spy();
-
-            var wrapped = CorrelationContextManager.wrapCallback(fn);
-            wrapped();
-
-            assert.notEqual(wrapped, fn);
-            assert(fn.calledOnce);
-        });
-        it("should return a function that restores the context available at call-time into the supplied function if enabled", (done) => {
-            CorrelationContextManager.enable();
-
-            var sharedFn = ()=> {
-                assert.equal(CorrelationContextManager.getCurrentContext(), testContext);
-            };
-
-            CorrelationContextManager.runWithContext(testContext, ()=>{
-                sharedFn = CorrelationContextManager.wrapCallback(sharedFn);
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    process.nextTick(()=>{
+                        assert.equal(CorrelationContextManager.getCurrentContext(), null);
+                        done();
+                    });
+                });
             });
+            it("should return null to asynchronous callbacks occuring in parallel", (done) => {
+                CorrelationContextManager.enable();
 
-            CorrelationContextManager.runWithContext(testContext2, ()=>{
-                setTimeout(()=>{
-                    sharedFn();
-                }, 8);
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    process.nextTick(()=>{
+                        assert.equal(CorrelationContextManager.getCurrentContext(), null);
+                    });
+                });
+
+                CorrelationContextManager.runWithContext(testContext2, ()=>{
+                    process.nextTick(()=>{
+                        assert.equal(CorrelationContextManager.getCurrentContext(), null);
+                    });
+                });
+
+                setTimeout(()=>done(), 10);
             });
+        });
 
-            setTimeout(()=>done(), 10);
+        describe("#runWithContext()", () => {
+            it("should run the supplied function", () => {
+                CorrelationContextManager.enable();
+                var fn = sinon.spy();
+
+                CorrelationContextManager.runWithContext(testContext, fn);
+
+                assert(fn.calledOnce);
+            });
+        });
+
+        describe("#wrapCallback()", () => {
+            it("should return the supplied function if disabled", () => {
+                CorrelationContextManager.disable();
+                var fn = sinon.spy();
+
+                var wrapped = CorrelationContextManager.wrapCallback(fn);
+
+                assert.equal(wrapped, fn);
+            });
+            it("should return the supplied function if enabled", () => {
+                CorrelationContextManager.enable();
+                var fn = sinon.spy();
+
+                var wrapped = CorrelationContextManager.wrapCallback(fn);
+
+                assert.equal(wrapped, fn);
+            });
+            it("should not return a function that restores a null context at call-time into the supplied function if enabled", (done) => {
+                CorrelationContextManager.enable();
+
+                var sharedFn = ()=> {
+                    assert.equal(CorrelationContextManager.getCurrentContext(), null);
+                };
+
+                CorrelationContextManager.runWithContext(testContext, ()=>{
+                    sharedFn = CorrelationContextManager.wrapCallback(sharedFn);
+                });
+
+                CorrelationContextManager.runWithContext(testContext2, ()=>{
+                    setTimeout(()=>{
+                        sharedFn();
+                    }, 8);
+                });
+
+                setTimeout(()=>done(), 10);
+            });
         });
     });
-});
+}

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -646,9 +646,13 @@ describe("Library/Client", () => {
             mockData.properties = {};
             var env = client.getEnvelope(mockData);
             assert.deepEqual(env.tags, client.context.tags, "tags are set by default");
-            var customTag = { custom: "tag" };
+            var customTag = { "ai.cloud.roleInstance": "override" };
+            var expected = {};
+            for(var tag in client.context.tags) {
+                expected[tag] = customTag[tag] || client.context.tags[tag];
+            }
             env = client.getEnvelope(mockData, <any>customTag);
-            assert.deepEqual(env.tags, customTag)
+            assert.deepEqual(env.tags, expected)
         });
 
         it("should set sequence numbers correctly", () => {

--- a/Tests/applicationInsights.tests.ts
+++ b/Tests/applicationInsights.tests.ts
@@ -109,7 +109,7 @@ describe("ApplicationInsights", () => {
             assert.ok(Exceptions.INSTANCE.isInitialized());
             assert.ok(Performance.INSTANCE.isInitialized());
             assert.ok(ServerRequests.INSTANCE.isInitialized());
-            assert.ok(ServerRequests.INSTANCE.isAutoCorrelating());
+            assert.ok(!ServerRequests.INSTANCE.isAutoCorrelating());
             assert.ok(ClientRequests.INSTANCE.isInitialized());
         });
 

--- a/Tests/applicationInsights.tests.ts
+++ b/Tests/applicationInsights.tests.ts
@@ -109,6 +109,7 @@ describe("ApplicationInsights", () => {
             assert.ok(Exceptions.INSTANCE.isInitialized());
             assert.ok(Performance.INSTANCE.isInitialized());
             assert.ok(ServerRequests.INSTANCE.isInitialized());
+            assert.ok(ServerRequests.INSTANCE.isAutoCorrelating());
             assert.ok(ClientRequests.INSTANCE.isInitialized());
         });
 
@@ -119,12 +120,14 @@ describe("ApplicationInsights", () => {
                 .setAutoCollectPerformance(false)
                 .setAutoCollectRequests(false)
                 .setAutoCollectDependencies(false)
+                .setAutoDependencyCorrelation(false)
                 .start();
 
             assert.ok(!Console.INSTANCE.isInitialized());
             assert.ok(!Exceptions.INSTANCE.isInitialized());
             assert.ok(!Performance.INSTANCE.isInitialized());
             assert.ok(!ServerRequests.INSTANCE.isInitialized());
+            assert.ok(!ServerRequests.INSTANCE.isAutoCorrelating());
             assert.ok(!ClientRequests.INSTANCE.isInitialized());
         });
     });

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -23,6 +23,7 @@ class ApplicationInsights {
     private static _isRequests = true;
     private static _isDependencies = true;
     private static _isOfflineMode = false;
+    private static _isCorrelating = true;
 
     private static _console: AutoCollectConsole;
     private static _exceptions: AutoCollectExceptions;
@@ -150,6 +151,20 @@ class ApplicationInsights {
         ApplicationInsights._isDependencies = value;
         if (ApplicationInsights._isStarted) {
             ApplicationInsights._clientRequests.enable(value);
+        }
+
+        return ApplicationInsights;
+    }
+
+    /**
+     * Sets the state of dependency correlation (enabled by default)
+     * @param value if true dependencies will be correlated with requests
+     * @returns {ApplicationInsights} this class
+     */
+    public static setAutoDependencyCorrelation(value: boolean) {
+        ApplicationInsights._isCorrelating = value;
+        if (ApplicationInsights._isStarted) {
+            ApplicationInsights._serverRequests.enable(value);
         }
 
         return ApplicationInsights;

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -1,4 +1,4 @@
-import CorrelationContextManager = require("./AutoCollection/CorrelationContextManager");
+import CorrelationContextManager = require("./AutoCollection/CorrelationContextManager"); // Keep this first
 import AutoCollectConsole = require("./AutoCollection/Console");
 import AutoCollectExceptions = require("./AutoCollection/Exceptions");
 import AutoCollectPerformance = require("./AutoCollection/Performance");

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -24,7 +24,7 @@ class ApplicationInsights {
     private static _isRequests = true;
     private static _isDependencies = true;
     private static _isOfflineMode = false;
-    private static _isCorrelating = true;
+    private static _isCorrelating = false;
 
     private static _console: AutoCollectConsole;
     private static _exceptions: AutoCollectExceptions;
@@ -95,16 +95,9 @@ class ApplicationInsights {
      * This method will return null if automatic dependency correlation is disabled.
      * @returns A plain object for request storage or null if automatic dependency correlation is disabled.
      */
-    public static getCorrelationContext() {
+    public static getCorrelationContext(): CorrelationContextManager.CorrelationContext {
         if (this._isCorrelating) {
-            var correlationContext = CorrelationContextManager.CorrelationContextManager.getCurrentContext();
-            if (correlationContext){
-                // Lazy create user properties so that we don't carry around an empty object with requests unless required.
-                if(!correlationContext.userProperties) {
-                    correlationContext.userProperties = {};
-                }
-                return correlationContext.userProperties;
-            }
+            return CorrelationContextManager.CorrelationContextManager.getCurrentContext();
         }
 
         return null;

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -77,6 +77,7 @@ class ApplicationInsights {
             ApplicationInsights._console.enable(ApplicationInsights._isConsole);
             ApplicationInsights._exceptions.enable(ApplicationInsights._isExceptions);
             ApplicationInsights._performance.enable(ApplicationInsights._isPerformance);
+            ApplicationInsights._serverRequests.useAutoCorrelation(ApplicationInsights._isCorrelating);
             ApplicationInsights._serverRequests.enable(ApplicationInsights._isRequests);
             ApplicationInsights._clientRequests.enable(ApplicationInsights._isDependencies);
         } else {
@@ -164,7 +165,7 @@ class ApplicationInsights {
     public static setAutoDependencyCorrelation(value: boolean) {
         ApplicationInsights._isCorrelating = value;
         if (ApplicationInsights._isStarted) {
-            ApplicationInsights._serverRequests.enable(value);
+            ApplicationInsights._serverRequests.useAutoCorrelation(value);
         }
 
         return ApplicationInsights;

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -1,3 +1,4 @@
+import CorrelationContextManager = require("./AutoCollection/CorrelationContextManager");
 import AutoCollectConsole = require("./AutoCollection/Console");
 import AutoCollectExceptions = require("./AutoCollection/Exceptions");
 import AutoCollectPerformance = require("./AutoCollection/Performance");
@@ -32,6 +33,10 @@ class ApplicationInsights {
     private static _clientRequests: AutoCollectClientRequests;
 
     private static _isStarted = false;
+
+    public static getContext() {
+        return CorrelationContextManager.CorrelationContextManager;
+    }
 
     /**
      * Initializes a client with the given instrumentation key, if this is not specified, the value will be

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,2 @@
+[0203/150119:ERROR:tcp_listen_socket.cc(76)] Could not bind socket to 127.0.0.1:6004
+[0203/150119:ERROR:node_debugger.cc(86)] Cannot start debugger server

--- a/debug.log
+++ b/debug.log
@@ -1,2 +1,0 @@
-[0203/150119:ERROR:tcp_listen_socket.cc(76)] Could not bind socket to 127.0.0.1:6004
-[0203/150119:ERROR:node_debugger.cc(86)] Cannot start debugger server

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mocha": "3.1.2",
     "node-mocks-http": "1.2.3",
     "sinon": "1.17.6",
-    "typescript": "1.8.9",
+    "typescript": "2.0.10",
     "typings": "2.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "typings": "2.0.0"
   },
   "dependencies": {
-    "async-hook": "^1.7.1"
+    "async-hook": "1.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "typings": "2.0.0"
   },
   "dependencies": {
-    "async-hook": "1.7.1"
+    "zone.js": "0.7.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "sinon": "1.17.6",
     "typescript": "1.8.9",
     "typings": "2.0.0"
+  },
+  "dependencies": {
+    "async-hook": "^1.7.1"
   }
 }


### PR DESCRIPTION
This adds a "Correlation Context" shared between all code handling a given request (using the Zone.js library). This correlation context is used to share an operation id with requests and all dependencies. It is off by default but can be disabled.

This is best effort. A "wrap" method is supplied for end-users to manually fix any issues with automatic correlation if necessary. Even if automatic correlation fails, dependencies will still be recorded. These dependencies will either be missing a request association or will be associated to a different request.

A portion of the correlation context is provided for end user use and is passed in to the context object given to telemetry processors.

Automatic correlation is supported in Node > 4.0 or io.js > 3.3. Our unit tests indicate errors from timer patching in versions less than this.