### PR TITLE
Fix validateStringMap function

### DIFF
--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -140,10 +140,11 @@ class Util {
                 var property = obj[field];
                 var propertyType = typeof property;
                 if (propertyType !== "string") {
-                    if (property && typeof property.toString === "function") {
+                    if (property != null && typeof property.toString === "function") {
                         property = property.toString();
                     } else {
-                        property = "invalid property type: " + propertyType;
+                        Logging.info("key: " + field + ", invalid property type: " + propertyType);
+                        continue;
                     }
                 }
 

--- a/Tests/Library/Util.tests.ts
+++ b/Tests/Library/Util.tests.ts
@@ -160,6 +160,7 @@ describe("Library/Util", () => {
             assert.equal(Util.validateStringMap(() => null), undefined);
             assert.deepEqual(Util.validateStringMap({ a: {} }), { a: "[object Object]" });
             assert.deepEqual(Util.validateStringMap({ a: 3, b: "test" }), { a: "3", b: "test" });
+            assert.deepEqual(Util.validateStringMap({ a: 0, b: null, c: undefined, d: [], e: '', f: -1 }), { a: "0", d: "", e: "", f: "-1" });
         });
     });
 


### PR DESCRIPTION
Fix for #182. 

With this change, the `validateStringMap` function will correctly process properties with number 0 as value. It will also drop invalid values, instead of changing them to `invalid property type: ...`. 