### PR TITLE
Fixed correlationHeaderExcludedDomains only cares about first value

### DIFF
--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -169,7 +169,9 @@ class Util {
 
         for (let i = 0; i < excludedDomains.length; i++) {
             let regex = new RegExp(excludedDomains[i].replace(/\./g,"\.").replace(/\*/g,".*"));
-            return !regex.test(url.parse(requestUrl).hostname);
+            if (regex.test(url.parse(requestUrl).hostname)) {
+                return false;
+            }
         }
 
         return true;

--- a/Tests/Library/Util.tests.ts
+++ b/Tests/Library/Util.tests.ts
@@ -179,7 +179,7 @@ describe("Library/Util", () => {
         });
 
         it("should return false if domain is on the excluded list", () => {
-            let client = <any>{ config: { correlationHeaderExcludedDomains: ["bing.com"] } };
+            let client = <any>{ config: { correlationHeaderExcludedDomains: ["bing.com", "bing.net"] } };
             let url = "http://bing.com/search?q=node";
 
             assert.equal(Util.canIncludeCorrelationHeader(client, url), false);
@@ -187,6 +187,10 @@ describe("Library/Util", () => {
             let urlSecure = "https://bing.com/search?q=node";
 
             assert.equal(Util.canIncludeCorrelationHeader(client, urlSecure), false);
+
+            let secondDomainUrl = "http://bing.net/search?q=node";
+
+            assert.equal(Util.canIncludeCorrelationHeader(client, secondDomainUrl), false);
         });
 
         it("can take wildcards in the excluded domain list", () => {


### PR DESCRIPTION
currently unable to exclude multiple domains in correlationHeader check
