### PR TITLE
Copying all descriptors of error properties

### DIFF
--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -214,10 +214,7 @@ export class CorrelationContextManager {
         for(var i=0; i<props.length; i++) {
             var propertyName = props[i];
             if (!AppInsightsAsyncCorrelatedErrorWrapper[propertyName]) {
-                Object.defineProperty(AppInsightsAsyncCorrelatedErrorWrapper, propertyName, {
-                    value: orig[propertyName],
-                    enumerable: orig.propertyIsEnumerable(propertyName)
-                });
+                Object.defineProperty(AppInsightsAsyncCorrelatedErrorWrapper, propertyName, Object.getOwnPropertyDescriptor(orig, propertyName));
             }
         }
         global.Error = AppInsightsAsyncCorrelatedErrorWrapper;


### PR DESCRIPTION
Without this change, attempting to enable async context tracking before `require("morgan")` would result in errors when `depd` attempted to set some properties on `Error` which were implicitly non-writable.

With this change, the methods that are just copied across will have exactly the same descriptor as the original method, so the replacement should be transparent.