### PR TITLE
Remove obsolete fields from envelope

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
         "**/*.js.map": true,
         "**/*.d.ts": true
      },
-     "typescript.tsdk": "./node_modules/typescript/lib"
+    "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -18,15 +18,6 @@ import Util = require("./Util");
 import Logging = require("./Logging");
 
 class Client {
-
-    private _sequencePrefix =
-    Util.int32ArrayToBase64([
-        Util.random32(),
-        Util.random32(),
-        Util.random32(),
-        Util.random32()]) +
-    ":";
-    private _sequenceNumber = 0;
     private _telemetryProcessors: { (envelope: ContractsModule.Contracts.Envelope, contextObjects: {[name: string]: any;}): boolean; }[] = [];
 
     public config: Config;
@@ -211,7 +202,6 @@ class Client {
         var iKey = this.config.instrumentationKey;
         var envelope = new ContractsModule.Contracts.Envelope();
         envelope.data = data;
-        envelope.appVer = this.context.tags[this.context.keys.applicationVersion];
         envelope.iKey = iKey;
 
         // this is kind of a hack, but the envelope name is always the same as the data name sans the chars "data"
@@ -220,9 +210,6 @@ class Client {
             iKey.replace(/-/g, "") +
             "." +
             data.baseType.substr(0, data.baseType.length - 4);
-        envelope.os = os && os.type();
-        envelope.osVer = os && os.release();
-        envelope.seq = this._sequencePrefix + (this._sequenceNumber++).toString();
         envelope.tags = this.getTags(tagOverrides);
         envelope.time = (new Date()).toISOString();
         envelope.ver = 1;
@@ -263,15 +250,7 @@ class Client {
     public clearTelemetryProcessors() {
         this._telemetryProcessors = [];
     }
-
-    /**
-     * Parse an envelope sequence.
-     */
-    public static parseSeq(seq: string): [string, number] {
-        let array = seq.split(":");
-        return [array[0], parseInt(array[1])];
-    }
-
+    
     private runTelemetryProcessors(envelope: ContractsModule.Contracts.Envelope, contextObjects: { [name: string]: any; }): boolean {
         var accepted = true;
         var telemetryProcessorsCount = this._telemetryProcessors.length;

--- a/Library/Contracts.ts
+++ b/Library/Contracts.ts
@@ -96,13 +96,6 @@ export module Contracts {
         public sampleRate:number;
         public seq:string;
         public iKey:string;
-        public flags:number;
-        public deviceId:string;
-        public os:string;
-        public osVer:string;
-        public appId:string;
-        public appVer:string;
-        public userId:string;
         public tags:{ [key: string]: string; };
         public data:Data<Domain>;
         

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -655,17 +655,6 @@ describe("Library/Client", () => {
             assert.deepEqual(env.tags, expected)
         });
 
-        it("should set sequence numbers correctly", () => {
-            var env1 = client.getEnvelope(mockData);
-            var env2 = client.getEnvelope(mockData);
-            var seq1 = Client.parseSeq(env1.seq);
-            assert.equal(seq1[0].length, 22);
-            var seq2 = Client.parseSeq(env2.seq);
-            assert.equal(seq2[0].length, 22);
-            assert.ok(seq1[1] < seq2[1]);
-            assert.equal(seq1[1] + 1, seq2[1]);
-        });
-
         it("should write properties in a specific order", () => {
             let env = client.getEnvelope(mockData);
             let keys = Object.keys(env);
@@ -707,9 +696,7 @@ describe("Library/Client", () => {
 
             var actual = sendStub.firstCall.args[0];
 
-            // make sequence numbers and timestamp equal to leverage deepEqual
-            let seq = Client.parseSeq(expected.seq);
-            expected.seq = seq[0] + ":" + (seq[1] + 1).toString();
+            // make timestamp equal to leverage deepEqual
             expected.time = actual.time;
 
             assert.deepEqual(actual, expected);


### PR DESCRIPTION
Fix #189. 

The latest `Envelope` scheme is [here](https://github.com/Microsoft/ApplicationInsights-Home/blob/master/EndpointSpecs/Schemas/Bond/Envelope.bond). 