### PR TITLE
Fix CORS error when using library with Browserify

### DIFF
--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -55,6 +55,7 @@ class Sender {
             port: parsedUrl.port,
             path: parsedUrl.pathname,
             method: "POST",
+            withCredentials: false,
             headers: {
                 "Content-Type": "application/x-json-stream"
             }


### PR DESCRIPTION
Customers are starting to use the AppInsights node.js SDK to develop browser applications thanks to [browserify](http://browserify.org/). This creates a shim for any http.request and https.request call so it redirects to XMLHttpRequest. Unforutnately, this shim defaults to setting [withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials).

This specific setting does not like the wildcard value for the `Access-Control-Allow-Origin` header.

[Browserify code](https://github.com/substack/http-browserify/blob/1.7.0/lib/request.js#L18-L20) that causes the problem, that has not been fixed for about 2.5 years now.

Recommended that we add an explicit `withCredentials = false` in the sender library to avoid these exceptions.

```
XMLHttpRequest cannot load https://dc.services.visualstudio.com/v2/track. 
Response to preflight request doesn't pass access control check: The value of the 
'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the 
request's credentials mode is 'include'. Origin 'https://YOURSERVER.ADDRESS.COM/' is therefore 
not allowed access. The credentials mode of requests initiated by the XMLHttpRequest is 
controlled by the withCredentials attribute.
```