### PR TITLE
update package install and build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,9 @@
 # Ignore build files
-obj
-*.d.ts
-*.tgz
-package-version
+out/
+obj/
 
 # Except imported Declarations and Typings
 !/Declarations/**
-!/typings/**
 
 # Ignore Node files
 node_modules/**
@@ -27,6 +24,3 @@ node_modules/**
 # Ignore log files
 npm-debug.log
 
-
-*.js.map
-*.js

--- a/Tests/js/endToEnd.js
+++ b/Tests/js/endToEnd.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+
+describe('module', function () {
+    describe('#require', function () {
+        it('loads the applicationinsights module', (done) => {
+            // TODO(joshgav): do not use `assert`
+            assert.doesNotThrow(require('../..'));
+            done();
+        });
+    });
+});

--- a/Tests/js/endToEnd.js
+++ b/Tests/js/endToEnd.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 
 describe('module', function () {
     describe('#require', function () {
-        it('loads the applicationinsights module', (done) => {
+        it('loads the applicationinsights module', function (done) {
             // TODO(joshgav): do not use `assert`
             assert.doesNotThrow(require('../..'));
             done();

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "license": "MIT",
   "bugs": "https://github.com/Microsoft/ApplicationInsights-node.js/issues",
   "version": "0.19.0",
-  "description": "Microsoft Application Insights module for Node.JS",
+  "description": "Microsoft Application Insights module for Node.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/ApplicationInsights-node.js"
   },
-  "main": "applicationinsights",
+  "main": "./out/applicationinsights.js",
   "keywords": [
     "exception monitoring",
     "request monitoring",
@@ -40,19 +40,25 @@
     }
   ],
   "scripts": {
-    "build": "tsc --module commonjs --declaration applicationinsights.ts",
-    "prepublish": "tsc --module commonjs --declaration applicationinsights.ts",
-    "pretest": "find Tests -type f -name \"*.ts\" | xargs tsc --module commonjs",
-    "test": "./node_modules/mocha/bin/mocha ./Tests --recursive"
+    "clean": "rm -rf ./out && rm -rf ./node_modules",
+    "build": "npm run build:deps && npm run build:compile",
+    "build:deps": "npm update --dev",
+    "build:compile": "./node_modules/typescript/bin/tsc --project ./tsconfig.json",
+    "prepare": "npm run build:compile",
+    "prepublishOnly": "npm run build",
+    "pretest": "npm run build",
+    "test": "npm run test:ts && npm run test:js",
+    "test:ts": "./node_modules/mocha/bin/mocha ./out/Tests --recursive",
+    "test:js": "./node_modules/mocha/bin/mocha ./Tests/js --recursive"
   },
   "devDependencies": {
-    "@types/mocha": "^2.2.40",
+    "@types/mocha": "2.2.40",
     "@types/node": "4.2.4",
-    "@types/sinon": "^2.1.2",
+    "@types/sinon": "2.1.2",
+    "typescript": "2.2.2",
     "mocha": "3.1.2",
     "node-mocks-http": "1.2.3",
-    "sinon": "1.17.6",
-    "typescript": "2.0.10"
+    "sinon": "1.17.6"
   },
   "dependencies": {
     "zone.js": "0.7.6"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true,
+        "outDir": "./out",
         "typeRoots": [
             "./node_modules/@types"
         ]


### PR DESCRIPTION
* Adds a prepare script to replace the prepublish script for `npm install` in npm@5+, see https://github.com/npm/npm/issues/10074.
* Built artifacts from tsc are aggregated and stored in ./out for easier workspace management (e.g. `npm run clean`).
* New test case added which isn't transpiled by tsc to test some scenarios. Includes a test for loading the transpiled module, since it's now in ./out.

The actual steps required to install for development and production stay the same as now documented in the README:
  * use `npm install` to install dependencies and for local usage, e.g. with `npm link`,
  * use `npm test` to install, build, and test as before

When installed in production environments, the "prepare" script is not called. We'd continue to rely on prepublish to precompile for dependants.