### PR TITLE
Updating how cross-application correlations are tracked

### DIFF
--- a/AutoCollection/ClientRequestParser.ts
+++ b/AutoCollection/ClientRequestParser.ts
@@ -6,7 +6,6 @@ import Contracts = require("../Declarations/Contracts");
 import Client = require("../Library/Client");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
-import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
 import RequestParser = require("./RequestParser");
 
 /**
@@ -38,17 +37,7 @@ class ClientRequestParser extends RequestParser {
      */
     public onResponse(response: http.ClientResponse, properties?: { [key: string]: string }) {
         this._setStatus(response.statusCode, undefined, properties);
-        const contextHeaders = response.headers && response.headers[RequestResponseHeaders.requestContextHeader];
-        if (contextHeaders) {
-            const keyValues = contextHeaders.split(",");
-            for(let i = 0; i < keyValues.length; ++i) {
-                const keyValue = keyValues[i].split("=");
-                if (keyValue.length == 2 && keyValue[0] == RequestResponseHeaders.requestContextTargetKey) {
-                    this.correlationId = keyValue[1];
-                    break;
-                }
-            }
-        }
+        this.correlationId = Util.getCorrelationContextTarget(response);
     }
 
     /**

--- a/AutoCollection/ClientRequests.ts
+++ b/AutoCollection/ClientRequests.ts
@@ -79,16 +79,23 @@ class AutoCollectClientRequests {
 
         let requestParser = new ClientRequestParser(requestOptions, request);
 
-        // Add the source ikey hash to the request headers, if a value was not already provided.
+        // Add the source correlationId to the request headers, if a value was not already provided.
         // The getHeader/setHeader methods aren't available on very old Node versions, and
         // are not included in the v0.10 type declarations currently used. So check if the
         // methods exist before invoking them.
-        if (client.config && client.config.instrumentationKeyHash &&
+        if (client.config && client.config.correlationId &&
             Util.canIncludeCorrelationHeader(client, requestParser.getUrl()) &&
-            request['getHeader'] && request['setHeader'] &&
-            !request['getHeader'](RequestResponseHeaders.sourceInstrumentationKeyHeader)) {
-            request['setHeader'](RequestResponseHeaders.sourceInstrumentationKeyHeader,
-                client.config.instrumentationKeyHash);
+            request['getHeader'] && request['setHeader']) {
+            const correlationHeader = request['getHeader'](RequestResponseHeaders.requestContextHeader);
+            if (correlationHeader) {
+                const components = correlationHeader.split(",");
+                const key = `${RequestResponseHeaders.requestContextSourceKey}=`;
+                if (!components.some((value) => value.substring(0,key.length) === key)) {
+                    request['setHeader'](RequestResponseHeaders.requestContextHeader, `${correlationHeader},${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
+                }
+            } else {
+                request['setHeader'](RequestResponseHeaders.requestContextHeader, `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
+            }
         }
 
         // Collect dependency telemetry about the request when it finishes.

--- a/AutoCollection/ServerRequestParser.ts
+++ b/AutoCollection/ServerRequestParser.ts
@@ -34,18 +34,7 @@ class ServerRequestParser extends RequestParser {
             this.rawHeaders = request.headers || (<any>request).rawHeaders;
             this.socketRemoteAddress = (<any>request).socket && (<any>request).socket.remoteAddress;
             this.userAgent = request.headers && request.headers["user-agent"];
-
-            if (request.headers && request.headers[RequestResponseHeaders.requestContextHeader]) {
-                const keyValues = request.headers[RequestResponseHeaders.requestContextHeader].split(",");
-                for(let i = 0; i < keyValues.length; ++i) {
-                    const keyValue = keyValues[i].split("=");
-                    if (keyValue.length == 2 && keyValue[0] == RequestResponseHeaders.requestContextTargetKey) {
-                        this.sourceCorrelationId = keyValue[1];
-                        break;
-                    }
-                }
-            }
-
+            this.sourceCorrelationId = Util.getCorrelationContextTarget(request);
             this.parentId =
                 request.headers && request.headers[RequestResponseHeaders.parentIdHeader];
             this.operationId =

--- a/AutoCollection/ServerRequestParser.ts
+++ b/AutoCollection/ServerRequestParser.ts
@@ -34,7 +34,7 @@ class ServerRequestParser extends RequestParser {
             this.rawHeaders = request.headers || (<any>request).rawHeaders;
             this.socketRemoteAddress = (<any>request).socket && (<any>request).socket.remoteAddress;
             this.userAgent = request.headers && request.headers["user-agent"];
-            this.sourceCorrelationId = Util.getCorrelationContextTarget(request);
+            this.sourceCorrelationId = Util.getCorrelationContextTarget(request, RequestResponseHeaders.requestContextSourceKey);
             this.parentId =
                 request.headers && request.headers[RequestResponseHeaders.parentIdHeader];
             this.operationId =

--- a/AutoCollection/ServerRequestParser.ts
+++ b/AutoCollection/ServerRequestParser.ts
@@ -19,7 +19,7 @@ class ServerRequestParser extends RequestParser {
     private connectionRemoteAddress:string;
     private legacySocketRemoteAddress:string;
     private userAgent: string;
-    private sourceIKeyHash: string;
+    private sourceCorrelationId: string;
     private parentId: string;
     private operationId: string;
     private requestId: string;
@@ -34,8 +34,18 @@ class ServerRequestParser extends RequestParser {
             this.rawHeaders = request.headers || (<any>request).rawHeaders;
             this.socketRemoteAddress = (<any>request).socket && (<any>request).socket.remoteAddress;
             this.userAgent = request.headers && request.headers["user-agent"];
-            this.sourceIKeyHash =
-                request.headers && request.headers[RequestResponseHeaders.sourceInstrumentationKeyHeader];
+
+            if (request.headers && request.headers[RequestResponseHeaders.requestContextHeader]) {
+                const keyValues = request.headers[RequestResponseHeaders.requestContextHeader].split(",");
+                for(let i = 0; i < keyValues.length; ++i) {
+                    const keyValue = keyValues[i].split("=");
+                    if (keyValue.length == 2 && keyValue[0] == RequestResponseHeaders.requestContextTargetKey) {
+                        this.sourceCorrelationId = keyValue[1];
+                        break;
+                    }
+                }
+            }
+
             this.parentId =
                 request.headers && request.headers[RequestResponseHeaders.parentIdHeader];
             this.operationId =
@@ -64,7 +74,7 @@ class ServerRequestParser extends RequestParser {
         requestData.id = this.requestId;
         requestData.name = this.method + " " + url.parse(this.url).pathname;
         requestData.url = this.url;
-        requestData.source = this.sourceIKeyHash;
+        requestData.source = this.sourceCorrelationId;
         requestData.duration = Util.msToTimeSpan(this.duration);
         requestData.responseCode = this.statusCode ? this.statusCode.toString() : null;
         requestData.success = this._isSuccess();

--- a/Library/Config.ts
+++ b/Library/Config.ts
@@ -1,4 +1,5 @@
-import crypto = require('crypto');
+import https = require('https');
+import url = require('url');
 
 class Config {
 
@@ -10,33 +11,38 @@ class Config {
     public static legacy_ENV_iKey = "APPINSIGHTS_INSTRUMENTATION_KEY";
 
     public instrumentationKey: string;
-    public instrumentationKeyHash: string;
+    public correlationId: string;
     public sessionRenewalMs: number;
     public sessionExpirationMs: number;
+    public endpointBase: string;
     public endpointUrl: string;
     public maxBatchSize: number;
     public maxBatchIntervalMs: number;
     public disableAppInsights: boolean;
     public samplingPercentage: number;
+    public correlationIdRetryInterval: number;
 
     // A list of domains for which correlation headers will not be added.
     public correlationHeaderExcludedDomains: string[];
 
     constructor(instrumentationKey?: string) {
         this.instrumentationKey = instrumentationKey || Config._getInstrumentationKey();
-        this.instrumentationKeyHash = Config._getStringHashBase64(this.instrumentationKey);
-        this.endpointUrl = "https://dc.services.visualstudio.com/v2/track";
+        this.endpointBase = "https://dc.services.visualstudio.com";
+        this.endpointUrl = `${this.endpointBase}/v2/track`;
         this.sessionRenewalMs = 30 * 60 * 1000;
         this.sessionExpirationMs = 24 * 60 * 60 * 1000;
         this.maxBatchSize = 250;
         this.maxBatchIntervalMs = 15000;
         this.disableAppInsights = false;
         this.samplingPercentage = 100;
+        this.correlationIdRetryInterval = 30 * 1000;
         this.correlationHeaderExcludedDomains = [
             "*.blob.core.windows.net", 
             "*.blob.core.chinacloudapi.cn",
             "*.blob.core.cloudapi.de",
             "*.blob.core.usgovcloudapi.net"];
+        
+        this.queryCorrelationId();
     }
 
     private static _getInstrumentationKey(): string {
@@ -52,11 +58,43 @@ class Config {
         return iKey;
     }
 
-    private static _getStringHashBase64(value: string): string {
-        let hash = crypto.createHash('sha256');
-        hash.update(value);
-        let result = hash.digest('base64');
-        return result;
+    private queryCorrelationId() {
+        // GET request to `${this.endpointBase}/api/profiles/${this.instrumentationKey}/appId`
+        // If it 404s, the iKey is bad and we should give up
+        // If it fails otherwise, try again later
+        const appIdUrl = url.parse(`${this.endpointBase}/api/profiles/${this.instrumentationKey}/appId`);
+        const requestOptions = {
+            protocol: appIdUrl.protocol,
+            hostname: appIdUrl.host,
+            path: appIdUrl.pathname,
+            method: 'GET',
+            // Ensure this request is not captured by auto-collection.
+            // Note: we don't refer to the property in ClientRequestParser because that would cause a cyclical dependency
+            disableAppInsightsAutoCollection: true
+        };
+
+        const fetchAppId = () => {
+            const req = https.request(requestOptions, (res) => {
+                if (res.statusCode === 200) {
+                    // Success; extract the appId from the body
+                    let appId = "";
+                    res.setEncoding("utf-8");
+                    res.on('data', function (data) {
+                        appId += data;
+                    });
+                    res.on('end', () => {
+                        this.correlationId = `cid-v1:${appId}`;
+                    });
+                } else if (res.statusCode >= 400 && res.statusCode < 500) {
+                    // Not found, probably a bad key. Do not try again.
+                } else {
+                    // Retry after timeout.
+                    setTimeout(fetchAppId, this.correlationIdRetryInterval);
+                }
+            });
+            req.end();
+        }
+        
     }
 }
 

--- a/Library/CorrelationIdManager.ts
+++ b/Library/CorrelationIdManager.ts
@@ -5,6 +5,8 @@ import url = require('url');
 class CorrelationIdManager {
     public static correlationIdPrefix: "cid-v1:";
 
+    // To avoid extraneous HTTP requests, we maintain a queue of callbacks waiting on a particular appId lookup,
+    // as well as a cache of completed lookups so future requests can be resolved immediately.
     private static pendingLookups: {[key: string]: Function[]} = {};
     private static completedLookups: {[key: string]: string} = {};
 

--- a/Library/CorrelationIdManager.ts
+++ b/Library/CorrelationIdManager.ts
@@ -1,0 +1,67 @@
+import https = require('https');
+import url = require('url');
+
+class CorrelationIdManager {
+    public static correlationIdPrefix: "cid-v1:";
+
+    private static pendingLookups: {[key: string]: Function[]} = {};
+    private static completedLookups: {[key: string]: string} = {};
+
+    public static queryCorrelationId(endpointBase: string, instrumentationKey: string, correlationIdRetryInterval: number, callback: (correlationId: string) => void) {
+        // GET request to `${this.endpointBase}/api/profiles/${this.instrumentationKey}/appId`
+        // If it 404s, the iKey is bad and we should give up
+        // If it fails otherwise, try again later
+        const appIdUrlString = `${endpointBase}/api/profiles/${instrumentationKey}/appId`;
+        const appIdUrl = url.parse(appIdUrlString);
+
+        if (CorrelationIdManager.completedLookups[appIdUrlString]) {
+            callback(CorrelationIdManager.completedLookups[appIdUrlString]);
+            return;
+        } else if (CorrelationIdManager.pendingLookups[appIdUrlString]) {
+            CorrelationIdManager.pendingLookups[appIdUrlString].push(callback);
+            return;
+        }
+
+        CorrelationIdManager.pendingLookups[appIdUrlString] = [callback];
+
+        const requestOptions = {
+            protocol: appIdUrl.protocol,
+            hostname: appIdUrl.host,
+            path: appIdUrl.pathname,
+            method: 'GET',
+            // Ensure this request is not captured by auto-collection.
+            // Note: we don't refer to the property in ClientRequestParser because that would cause a cyclical dependency
+            disableAppInsightsAutoCollection: true
+        };
+
+        const fetchAppId = () => {
+            const req = https.request(requestOptions, (res) => {
+                if (res.statusCode === 200) {
+                    // Success; extract the appId from the body
+                    let appId = "";
+                    res.setEncoding("utf-8");
+                    res.on('data', function (data) {
+                        appId += data;
+                    });
+                    res.on('end', () => {
+                        const result = CorrelationIdManager.correlationIdPrefix + appId;
+                        CorrelationIdManager.completedLookups[appIdUrlString] = result;
+                        CorrelationIdManager.pendingLookups[appIdUrlString].forEach((cb) => cb(result));
+                        delete CorrelationIdManager.pendingLookups[appIdUrlString];
+                    });
+                } else if (res.statusCode >= 400 && res.statusCode < 500) {
+                    // Not found, probably a bad key. Do not try again.
+                } else {
+                    // Retry after timeout.
+                    setTimeout(fetchAppId, correlationIdRetryInterval);
+                }
+            });
+            if (req) {
+                req.end();
+            }
+        };
+        fetchAppId();
+    }
+}
+
+export = CorrelationIdManager;

--- a/Library/RequestResponseHeaders.ts
+++ b/Library/RequestResponseHeaders.ts
@@ -1,15 +1,17 @@
 export = {
+
+    requestContextHeader: "Request-Context",
     /**
      * Source instrumentation header that is added by an application while making http
      * requests and retrieved by the other application when processing incoming requests.
      */
-    sourceInstrumentationKeyHeader: "x-ms-request-source-ikey",
+    requestContextSourceKey: "appId",
 
     /**
      * Target instrumentation header that is added to the response and retrieved by the
      * calling application when processing incoming responses.
      */
-    targetInstrumentationKeyHeader: "x-ms-request-target-ikey",
+    requestContextTargetKey: "appId",
 
     /**
      * Header containing the id of the immidiate caller

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -161,7 +161,7 @@ class Util {
 
     /**
      * Checks if a request url is not on a excluded domain list 
-     * and if it is safe to add correlation headers (x-ms-request-source-ikey, x-ms-request-target-ikey)
+     * and if it is safe to add correlation headers
      */
     public static canIncludeCorrelationHeader(client: Client, requestUrl: string) {
         let excludedDomains = client && client.config && client.config.correlationHeaderExcludedDomains;

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -180,13 +180,13 @@ class Util {
         return true;
     }
 
-    public static getCorrelationContextTarget(response: http.ClientResponse | http.ServerRequest) {
+    public static getCorrelationContextTarget(response: http.ClientResponse | http.ServerRequest, key: string) {
         const contextHeaders = response.headers && response.headers[RequestResponseHeaders.requestContextHeader];
         if (contextHeaders) {
             const keyValues = contextHeaders.split(",");
             for(let i = 0; i < keyValues.length; ++i) {
                 const keyValue = keyValues[i].split("=");
-                if (keyValue.length == 2 && keyValue[0] == RequestResponseHeaders.requestContextTargetKey) {
+                if (keyValue.length == 2 && keyValue[0] == key) {
                     return keyValue[1];
                 }
             }

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -3,6 +3,7 @@ import url = require("url");
 
 import Logging = require("./Logging");
 import Client = require("../Library/Client");
+import RequestResponseHeaders = require("./RequestResponseHeaders");
 
 class Util {
     public static MAX_PROPERTY_LENGTH = 1024;
@@ -177,6 +178,19 @@ class Util {
         }
 
         return true;
+    }
+
+    public static getCorrelationContextTarget(response: http.ClientResponse | http.ServerRequest) {
+        const contextHeaders = response.headers && response.headers[RequestResponseHeaders.requestContextHeader];
+        if (contextHeaders) {
+            const keyValues = contextHeaders.split(",");
+            for(let i = 0; i < keyValues.length; ++i) {
+                const keyValue = keyValues[i].split("=");
+                if (keyValue.length == 2 && keyValue[0] == RequestResponseHeaders.requestContextTargetKey) {
+                    return keyValue[1];
+                }
+            }
+        }
     }
 }
 export = Util;

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -14,12 +14,14 @@ import Util = require("../../Library/Util")
 describe("Library/Client", () => {
 
     var iKey = "Instrumentation-Key-12345-6789A";
+    var appId = "Application-Key-12345-6789A";
     var name = "name";
     var value = 3;
     var mockData = <any>{ baseData: { properties: {} }, baseType: "BaseTestData" };
     var properties: { [key: string]: string; } = { p1: "p1", p2: "p2", common: "commonArg" };
     var measurements: { [key: string]: number; } = { m1: 1, m2: 2 };
     var client = new Client(iKey);
+    client.config.correlationId = `cid-v1:${appId}`;
     var trackStub: Sinon.SinonStub;
     var triggerStub: Sinon.SinonStub;
     var sendStub: Sinon.SinonStub;
@@ -263,9 +265,10 @@ describe("Library/Client", () => {
         };
 
         afterEach(() => {
-            delete request.headers[RequestResponseHeaders.sourceInstrumentationKeyHeader];
-            delete response.headers[RequestResponseHeaders.targetInstrumentationKeyHeader];
+            delete request.headers[RequestResponseHeaders.requestContextHeader];
+            delete response.headers[RequestResponseHeaders.requestContextHeader];
             client.config = new Config(iKey);
+            client.config.correlationId = `cid-v1:${appId}`;
         });
 
         function parseDuration(duration: string): number {
@@ -353,13 +356,13 @@ describe("Library/Client", () => {
                 assert.equal(duration, 10);
             });
 
-            it('should use source and target ikey headers', () => {
+            it('should use source and target correlationId headers', () => {
                 trackStub.reset();
                 clock.reset();
 
-                // Simulate an incoming request that has a different source ikey hash header.
-                let testIKey = crypto.createHash('sha256').update('Instrumentation-Key-98765-4321A').digest('base64');
-                request.headers[RequestResponseHeaders.sourceInstrumentationKeyHeader] = testIKey;
+                // Simulate an incoming request that has a different source correlationId header.
+                let testCorrelationId = 'cid-v1:Application-Id-98765-4321A';
+                request.headers[RequestResponseHeaders.requestContextHeader] = `${RequestResponseHeaders.requestContextSourceKey}=${testCorrelationId}`;
 
                 client.trackRequest(<any>request, <any>response, properties);
 
@@ -374,22 +377,22 @@ describe("Library/Client", () => {
                 var obj0 = args[0][0];
 
                 assert.equal(obj0.baseType, "Microsoft.ApplicationInsights.RequestData");
-                assert.equal(obj0.baseData.source, testIKey);
+                assert.equal(obj0.baseData.source, testCorrelationId);
 
-                // The client's ikey hash should have been added as the response target ikey header.
-                assert.equal(response.headers[RequestResponseHeaders.targetInstrumentationKeyHeader],
-                    client.config.instrumentationKeyHash);
+                // The client's correlationId should have been added as the response target correlationId header.
+                assert.equal(response.headers[RequestResponseHeaders.requestContextHeader],
+                    `${RequestResponseHeaders.requestContextTargetKey}=${client.config.correlationId}`);
             });
 
-            it('should NOT use source and target ikey headers when url is on the excluded list', () => {
+            it('should NOT use source and target correlationId headers when url is on the excluded list', () => {
                 trackStub.reset();
                 clock.reset();
 
                 client.config.correlationHeaderExcludedDomains = ["bing.com"];
 
                 // Simulate an incoming request that has a different source ikey hash header.
-                let testIKey = crypto.createHash('sha256').update('Instrumentation-Key-98765-4321A').digest('base64');
-                request.headers[RequestResponseHeaders.sourceInstrumentationKeyHeader] = testIKey;
+                let testCorrelationId = 'cid-v1:Application-Id-98765-4321A';
+                request.headers[RequestResponseHeaders.requestContextHeader] = `${RequestResponseHeaders.requestContextSourceKey}=${testCorrelationId}`;
 
                 client.trackRequest(<any>request, <any>response, properties);
 
@@ -404,7 +407,7 @@ describe("Library/Client", () => {
                 var obj0 = args[0][0];
 
                 assert.equal(obj0.baseType, "Microsoft.ApplicationInsights.RequestData");
-                assert.equal(response.headers[RequestResponseHeaders.targetInstrumentationKeyHeader], undefined);
+                assert.equal(response.headers[RequestResponseHeaders.requestContextHeader], undefined);
             });
         });
 
@@ -516,7 +519,7 @@ describe("Library/Client", () => {
                 assert.deepEqual(obj0.baseData.properties, properties);
             });
 
-            it('should use source and target ikey headers', () => {
+            it('should use source and target correlationId headers', () => {
                 trackStub.reset();
                 clock.reset();
                 client.trackDependencyRequest({
@@ -525,16 +528,17 @@ describe("Library/Client", () => {
                     },
                     <any>request, properties);
 
-                // The client's ikey hash should have been added as the request source ikey header.
-                assert.equal(request.headers[RequestResponseHeaders.sourceInstrumentationKeyHeader],
-                    client.config.instrumentationKeyHash);
+                // The client's correlationId should have been added as the request source correlationId header.
+                assert.equal(request.headers[RequestResponseHeaders.requestContextHeader],
+                    `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
 
                 // response event was not emitted yet
                 assert.ok(trackStub.notCalled);
 
-                // Simulate a response from another service that includes a target ikey hash header.
-                response.headers[RequestResponseHeaders.targetInstrumentationKeyHeader] =
-                    crypto.createHash('sha256').update('Instrumentation-Key-98765-4321A').digest('base64');;
+                // Simulate a response from another service that includes a target correlationId header.
+                const targetCorrelationId = "cid-v1:Application-Key-98765-4321A";
+                response.headers[RequestResponseHeaders.requestContextHeader] =
+                    `${RequestResponseHeaders.requestContextTargetKey}=${targetCorrelationId}`;
 
                 // emit response event
                 clock.tick(10);
@@ -543,12 +547,11 @@ describe("Library/Client", () => {
                 var args = trackStub.args;
                 var obj0 = args[0][0];
 
-                assert.equal(obj0.baseData.target, "bing.com | " +
-                    response.headers[RequestResponseHeaders.targetInstrumentationKeyHeader]);
+                assert.equal(obj0.baseData.target, "bing.com | " + targetCorrelationId);
                 assert.equal(obj0.baseData.type, "Http (tracked component)");
             });
 
-            it('should not set source ikey headers when the host is on a excluded domain list', () => {
+            it('should not set source correlationId headers when the host is on a excluded domain list', () => {
                 trackStub.reset();
                 clock.reset();
 
@@ -559,23 +562,8 @@ describe("Library/Client", () => {
                     },
                     <any>request, properties);
 
-                // The client's ikey hash should NOT have been added for excluded domains
-                assert.equal(request.headers[RequestResponseHeaders.sourceInstrumentationKeyHeader], null);
-            });
-
-            it('should not set source ikey headers when the host is on a excluded domain list', () => {
-                trackStub.reset();
-                clock.reset();
-
-                client.config.correlationHeaderExcludedDomains = ["*.domain.com"]
-                client.trackDependencyRequest({
-                        host: 'excluded.domain.com',
-                        path: '/search?q=test'
-                    },
-                    <any>request, properties);
-
-                // The client's ikey hash should NOT have been added for excluded domains
-                assert.equal(request.headers[RequestResponseHeaders.sourceInstrumentationKeyHeader], null);
+                // The client's correlationId should NOT have been added for excluded domains
+                assert.equal(request.headers[RequestResponseHeaders.requestContextHeader], null);
             });
         });
     });

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "clean": "rm -rf ./out && rm -rf ./node_modules",
     "build": "npm run build:deps && npm run build:compile",
     "build:deps": "npm update --dev",
-    "build:compile": "./node_modules/typescript/bin/tsc --project ./tsconfig.json",
+    "build:compile": "tsc --project ./tsconfig.json",
     "prepare": "npm run build:compile",
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",
     "test": "npm run test:ts && npm run test:js",
-    "test:ts": "./node_modules/mocha/bin/mocha ./out/Tests --recursive",
-    "test:js": "./node_modules/mocha/bin/mocha ./Tests/js --recursive"
+    "test:ts": "mocha ./out/Tests --recursive",
+    "test:js": "mocha ./Tests/js --recursive"
   },
   "devDependencies": {
     "@types/mocha": "2.2.40",


### PR DESCRIPTION
Instead of using a hash of the instrumentation key we now use the appId, matching the .NET sdk.
We also use different headers to match the .NET sdk.