### PR TITLE
don't exclude Declarations folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,7 +18,7 @@ Tests
 .travis.yml
 .ntvs_analysis.dat
 
-Declarations
+/Declarations
 
 Schema
 


### PR DESCRIPTION
#228 moves the Contracts module into the Declarations folder. As a result .npmignore needs to be updated so as not to exclude the Declarations folder when publishing.