### PR TITLE
Fixing CorrelationId

### DIFF
--- a/Library/CorrelationIdManager.ts
+++ b/Library/CorrelationIdManager.ts
@@ -3,7 +3,7 @@ import http = require('http');
 import url = require('url');
 
 class CorrelationIdManager {
-    public static correlationIdPrefix: "cid-v1:";
+    public static correlationIdPrefix = "cid-v1:";
 
     // To avoid extraneous HTTP requests, we maintain a queue of callbacks waiting on a particular appId lookup,
     // as well as a cache of completed lookups so future requests can be resolved immediately.


### PR DESCRIPTION
There was a typo which lead to the `correlationIdPrefix` being null.