### PR TITLE
Include typescript definitions in NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,8 +13,8 @@ Tests
 
 # Don't publish source files that aren't needed in package
 *.ts
+!*.d.ts
 *.js.map
-*.d.ts
 .travis.yml
 .ntvs_analysis.dat
 

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -1,5 +1,3 @@
-/// <reference path="../node_modules/zone.js/dist/zone.js.d.ts" />
-
 import http = require("http");
 import Util = require("../Library/Util");
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/Microsoft/ApplicationInsights-node.js"
   },
   "main": "./out/applicationinsights.js",
+  "types": "./out/applicationinsights.d.ts",
   "keywords": [
     "exception monitoring",
     "request monitoring",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,15 @@
         "typeRoots": [
             "./node_modules/@types"
         ]
-    }
+    },
+    "include": [
+        "*.ts",
+        "Tests/**/*.ts"
+    ],
+    "files": [
+        "./node_modules/zone.js/dist/zone.js.d.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
 }


### PR DESCRIPTION
Addresses #227 (and #158) by including types directly on the NPM package, removing the need for @types.

As a side effect, tsc will complain if this is used in a project without types for node (as our public SDK methods have input parameters of types from node, such as http.ServerRequest). This seems reasonable to expect to be available, as you won't get very far in a Node project using TS without node types available :smile:

Zone types are moved from a comment reference to included for compile in tsconfig. This prevents the reference from being included in our exported types (avoiding a build error for anyone missing Zone types)