### PR TITLE
Update unnecessary use of getClient() in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Insights client. Examples follow:
 
 ```javascript
 let appInsights = require("applicationinsights");
-appInsights.setup().start(); // assuming ikey in env var
-let client = appInsights.getClient();
+appInsights.setup().start(); // assuming ikey in env var. start() can be omitted to disable any non-custom data
+let client = appInsights.client;
 client.trackEvent("my custom event", {customProperty: "custom property value"});
 client.trackException(new Error("handled exceptions can be logged with this method"));
 client.trackMetric("custom metric", 3);


### PR DESCRIPTION
The readme's use of getClient() is confusing because it isn't a scenario that needs a new client, but rather can use the already configured default client. This updates the readme to use appInsights.client instead