### PR TITLE
Adding option to selectively disable module patches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ node_js:
   - "iojs"
   - "iojs-v1.0.4" 
 before_install:
-  - npm install -g npm
+  - npm install -g npm@4.5.0
 before_script:
   - npm install

--- a/AutoCollection/diagnostic-channel/initialization.ts
+++ b/AutoCollection/diagnostic-channel/initialization.ts
@@ -1,8 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-import {enable} from "diagnostic-channel-publishers";
+import {bunyan, console as consoleModule, mongodb, mysql, redis} from "diagnostic-channel-publishers";
 
 if (!process.env["APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL"]) {
-    enable();
+    const individualOptOuts = process.env["APPLICATION_INSIGHTS_NO_PATCH_MODULES"] || "";
+    const unpatchedModules = individualOptOuts.split(",");
+    const modules = {bunyan, console: consoleModule, mongodb, mysql, redis};
+    for (const mod in modules) {
+        if (unpatchedModules.indexOf(mod) === -1) {
+           modules[mod].enable();
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@ appInsights.start();
 
 ### Automatic third-party instrumentation
 
-In order to track context across asynchronous calls, some changes are required in third party libraries such as mongodb and redis. By default ApplicationInsights will use `diagnostic-channel-publishers` to monkey-patch some of these libraries. This can be disabled by setting the `APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL` environment variable. Note that by setting that environment variable, events may no longer be correctly associated with the right operation.
+In order to track context across asynchronous calls, some changes are required in third party libraries such as mongodb and redis.
+By default ApplicationInsights will use `diagnostic-channel-publishers` to monkey-patch some of these libraries.
+This can be disabled by setting the `APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL` environment variable. Note that by setting that
+environment variable, events may no longer be correctly associated with the right operation. Individual monkey-patches can be
+disabled by setting the `APPLICATION_INSIGHTS_NO_PATCH_MODULES` environment variable to a comma separated list of packages to
+disable, e.g. `APPLICATION_INSIGHTS_NO_PATCH_MODULES=console,redis` to avoid patching the `console` and `redis` packages.
 
 Currently there are 6 packages which are instrumented: `bunyan`, `console`, `mongodb`, `mongodb-core`, `mysql` and `redis`.
 


### PR DESCRIPTION
This allows an environment variable to specify individual monkey patches to disable. E.g. `APPLICATION_INSIGHTS_NO_PATCH_MODULES=console,redis` would result in the `console` and `redis` packages not applying their patches.