### PR TITLE
Fix SDK crash when Error.prepareStackTrace returns a non-string

### DIFF
--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -170,11 +170,11 @@ export class CorrelationContextManager {
 
             // Is this object set to rewrite the stack?
             // If so, we should turn off some Zone stuff that is prone to break
-            var stackRewrite = orig['stackRewrite'];
-            if (orig['prepareStackTrace']) {
-                orig['stackRewrite'] = false;
-                var stackTrace = orig['prepareStackTrace'];
-                orig['prepareStackTrace'] = (e, s) => {
+            var stackRewrite = (<any>orig).stackRewrite;
+            if ((<any>orig).prepareStackTrace) {
+                (<any>orig).stackRewrite= false;
+                var stackTrace = (<any>orig).prepareStackTrace;
+                (<any>orig).prepareStackTrace = (e, s) => {
                     // Remove some AI and Zone methods from the stack trace
                     // Otherwise we leave side-effects
                     s.splice(0, 3);
@@ -186,7 +186,7 @@ export class CorrelationContextManager {
             orig.apply(this, arguments);
 
             // Restore Zone stack rewriting settings
-            orig['stackRewrite'] = stackRewrite;
+            (<any>orig).stackRewrite = stackRewrite;
             
             // getOwnPropertyNames should be a superset of Object.keys...
             // This appears to not always be the case

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -177,7 +177,20 @@ export class CorrelationContextManager {
                 (<any>orig).prepareStackTrace = (e, s) => {
                     // Remove some AI and Zone methods from the stack trace
                     // Otherwise we leave side-effects
-                    s.splice(0, 3);
+                    var foundOne = false;
+                    for (var i=0; i<s.length; i++) {
+                        if (s[i].getFileName().indexOf("AutoCollection/CorrelationContextManager") === -1) {
+                            if (foundOne) {
+                                break;
+                            }
+                        } else {
+                            foundOne = true;
+                        }
+                    }
+                    // Loop above goes one extra step
+                    i = Math.max(0, i - 1);
+                    
+                    s.splice(0, i);
                     return stackTrace(e, s);
                 }
             }

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -177,11 +177,16 @@ export class CorrelationContextManager {
                 (<any>orig).prepareStackTrace = (e, s) => {
                     // Remove some AI and Zone methods from the stack trace
                     // Otherwise we leave side-effects
+
+                    // Algorithm is to find the first frame on the stack after the first instance(s)
+                    // of AutoCollection/CorrelationContextManager
+                    // Eg. this should return the User frame on an array like below:
+                    //  Zone | Zone | CorrelationContextManager | CorrelationContextManager | User
                     var foundOne = false;
                     for (var i=0; i<s.length; i++) {
                         if (s[i].getFileName().indexOf("AutoCollection/CorrelationContextManager") === -1 &&
                             s[i].getFileName().indexOf("AutoCollection\\CorrelationContextManager") === -1) {
-                                
+
                             if (foundOne) {
                                 break;
                             }

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -179,7 +179,9 @@ export class CorrelationContextManager {
                     // Otherwise we leave side-effects
                     var foundOne = false;
                     for (var i=0; i<s.length; i++) {
-                        if (s[i].getFileName().indexOf("AutoCollection/CorrelationContextManager") === -1) {
+                        if (s[i].getFileName().indexOf("AutoCollection/CorrelationContextManager") === -1 &&
+                            s[i].getFileName().indexOf("AutoCollection\\CorrelationContextManager") === -1) {
+                                
                             if (foundOne) {
                                 break;
                             }

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -85,6 +85,25 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
             });
         });
 
+        describe("#AppInsightsAsyncCorrelatedErrorWrapper", () => {
+            it("should not crash if prepareStackTrace is used", () => {
+                CorrelationContextManager.enable();
+
+                try {
+                    var stackTrace = Error['prepareStackTrace'];
+                    Error['prepareStackTrace'] = function (_, stack) {
+                        Error['prepareStackTrace'] = stackTrace;
+                        return stack;
+                    };
+
+                    var error = new Error();
+                    assert(<any>error.stack instanceof Array);
+                } catch (e) {
+                    assert(false);
+                }
+            })
+        });
+
         describe("#runWithContext()", () => {
             it("should run the supplied function", () => {
                 CorrelationContextManager.enable();

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -112,7 +112,8 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
                 };
 
                 var error = new Error();
-                assert((<any>error.stack)[0].getFileName().indexOf("CorrelationContextManager.tests.js") !== -1);
+                var topOfStack = (<any>error.stack)[0].getFileName();
+                assert(topOfStack.indexOf("CorrelationContextManager.tests.js") !== -1, "Top of stack not expected to be " + topOfStack);
             });
         });
 

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -101,7 +101,19 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
                 } catch (e) {
                     assert(false);
                 }
-            })
+            });
+            it("should remove extra AI+Zone methods if prepareStackTrace is used", () => {
+                CorrelationContextManager.enable();
+
+                var stackTrace = Error['prepareStackTrace'];
+                Error['prepareStackTrace'] = function (_, stack) {
+                    Error['prepareStackTrace'] = stackTrace;
+                    return stack;
+                };
+
+                var error = new Error();
+                assert((<any>error.stack)[0].getFileName().indexOf("CorrelationContextManager.tests.js") !== -1);
+            });
         });
 
         describe("#runWithContext()", () => {


### PR DESCRIPTION
This turns off Zone stack-rewriting which can't handle non-default stack trace formats. This resolves an incompatibility with "caller", which when used in conjunction with this SDK would crash upon use. 