### PR TITLE
Updating headers to use new scheme

### DIFF
--- a/AutoCollection/ClientRequestParser.ts
+++ b/AutoCollection/ClientRequestParser.ts
@@ -45,7 +45,7 @@ class ClientRequestParser extends RequestParser {
     /**
      * Gets a dependency data contract object for a completed ClientRequest.
      */
-    public getDependencyData(): Contracts.Data<Contracts.RemoteDependencyData> {
+    public getDependencyData(dependencyId?: string): Contracts.Data<Contracts.RemoteDependencyData> {
         let urlObject = url.parse(this.url);
         urlObject.search = undefined;
         urlObject.hash = undefined;
@@ -64,6 +64,7 @@ class ClientRequestParser extends RequestParser {
             remoteDependency.type = Contracts.RemoteDependencyDataConstants.TYPE_HTTP;
         }
 
+        remoteDependency.id = dependencyId;
         remoteDependency.name = dependencyName;
         remoteDependency.data = this.url;
         remoteDependency.duration = Util.msToTimeSpan(this.duration);

--- a/AutoCollection/ClientRequests.ts
+++ b/AutoCollection/ClientRequests.ts
@@ -20,6 +20,8 @@ class AutoCollectClientRequests {
 
     public static INSTANCE: AutoCollectClientRequests;
 
+    private static requestNumber = 1;
+
     private _client: Client;
     private _isEnabled: boolean;
     private _isInitialized: boolean;
@@ -110,8 +112,15 @@ class AutoCollectClientRequests {
 
             const currentContext = CorrelationContextManager.getCurrentContext();
             if (currentContext && currentContext.operation) {
+                const uniqueParentId = currentContext.operation.parentId + AutoCollectClientRequests.requestNumber++ + '.';
+                request['setHeader'](RequestResponseHeaders.requestIdHeader, uniqueParentId);
+                // Also set legacy headers
                 request['setHeader'](RequestResponseHeaders.parentIdHeader, currentContext.operation.id);
-                request['setHeader'](RequestResponseHeaders.rootIdHeader, currentContext.operation.parentId);
+                request['setHeader'](RequestResponseHeaders.rootIdHeader, uniqueParentId);
+
+                if (currentContext.operation.correlationContextHeader) {
+                    request['setHeader'](RequestResponseHeaders.correlationContextHeader, currentContext.operation.correlationContextHeader);
+                }
             }
         }
 

--- a/AutoCollection/ClientRequests.ts
+++ b/AutoCollection/ClientRequests.ts
@@ -7,7 +7,7 @@ import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
 import ClientRequestParser = require("./ClientRequestParser");
-import { CorrelationContextManager, CorrelationContext } from "./CorrelationContextManager";
+import { CorrelationContextManager, CorrelationContext, PrivateCustomProperties } from "./CorrelationContextManager";
 
 import {enable as enableMongodb} from "./diagnostic-channel/mongodb.sub";
 import {enable as enableMysql} from "./diagnostic-channel/mysql.sub";
@@ -92,7 +92,7 @@ class AutoCollectClientRequests {
         let requestParser = new ClientRequestParser(requestOptions, request);
 
         const currentContext = CorrelationContextManager.getCurrentContext();
-        const uniqueParentId = currentContext && currentContext.operation && (currentContext.operation.parentId + AutoCollectClientRequests.requestNumber++ + '.');
+        const uniqueRequestId = currentContext && currentContext.operation && (currentContext.operation.parentId + AutoCollectClientRequests.requestNumber++ + '.');
 
         // Add the source correlationId to the request headers, if a value was not already provided.
         // The getHeader/setHeader methods aren't available on very old Node versions, and
@@ -114,12 +114,12 @@ class AutoCollectClientRequests {
             }
 
             if (currentContext && currentContext.operation) {
-                request['setHeader'](RequestResponseHeaders.requestIdHeader, uniqueParentId);
+                request['setHeader'](RequestResponseHeaders.requestIdHeader, uniqueRequestId);
                 // Also set legacy headers
                 request['setHeader'](RequestResponseHeaders.parentIdHeader, currentContext.operation.id);
-                request['setHeader'](RequestResponseHeaders.rootIdHeader, uniqueParentId);
+                request['setHeader'](RequestResponseHeaders.rootIdHeader, uniqueRequestId);
 
-                const correlationContextHeader = currentContext.customProperties.serializeToHeader();
+                const correlationContextHeader = (<PrivateCustomProperties>currentContext.customProperties).serializeToHeader();
                 if (correlationContextHeader) {
                     request['setHeader'](RequestResponseHeaders.correlationContextHeader, correlationContextHeader);
                 }
@@ -131,12 +131,12 @@ class AutoCollectClientRequests {
             request.on('response', (response: http.ClientResponse) => {
                 requestParser.onResponse(response, properties);
                 var context : { [name: string]: any; } = { "http.RequestOptions": requestOptions, "http.ClientRequest": request, "http.ClientResponse": response };
-                client.track(requestParser.getDependencyData(uniqueParentId), null, context);
+                client.track(requestParser.getDependencyData(uniqueRequestId), null, context);
             });
             request.on('error', (e: Error) => {
                 requestParser.onError(e, properties);
                 var context : { [name: string]: any; } = { "http.RequestOptions": requestOptions, "http.ClientRequest": request, "Error": e };
-                client.track(requestParser.getDependencyData(uniqueParentId), null, context);
+                client.track(requestParser.getDependencyData(uniqueRequestId), null, context);
             });
         }
     }

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -3,6 +3,16 @@ import Util = require("../Library/Util");
 
 import {channel} from "diagnostic-channel";
 
+export interface CustomProperties {
+    getProperty(prop: string): string;
+    setProperty(prop: string, val: string): void;
+}
+
+export interface PrivateCustomProperties extends CustomProperties {
+    addHeaderData(header: string): void;
+    serializeToHeader(): string;
+}
+
 export interface CorrelationContext {
     operation: {
         name: string;
@@ -11,14 +21,9 @@ export interface CorrelationContext {
     };
 
     /** Do not store sensitive information here. 
-     *  Properties here can be exposed in a future SDK release via outgoing HTTP headers for correlating data cross-component.
+     *  Properties here are exposed via outgoing HTTP headers for correlating data cross-component.
      */
-    customProperties: { 
-        addHeaderData(header: string): void;
-        getProperty(prop: string): string;
-        setProperty(prop: string, val: string): void;
-        serializeToHeader(): string;
-     };
+    customProperties: CustomProperties
 }
 
 export class CorrelationContextManager {

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -8,6 +8,7 @@ export interface CorrelationContext {
         name: string;
         id: string;
         parentId: string; // Always used for dependencies, may be ignored in favor of incoming headers for requests
+        correlationContextHeader?: string;
     };
 
     /** Do not store sensitive information here. 
@@ -35,8 +36,7 @@ export class CorrelationContextManager {
     /**
      *  A helper to generate objects conforming to the CorrelationContext interface
      */
-    public static generateContextObject(parentId?: string, operationName?: string, operationId?: string): CorrelationContext {
-        operationId = operationId || Util.newGuid();
+    public static generateContextObject(operationId: string, parentId?: string, operationName?: string, correlationContextHeader?: string): CorrelationContext {
         parentId = parentId || operationId;
         
         if (this.enabled) {
@@ -44,7 +44,8 @@ export class CorrelationContextManager {
                 operation: {
                     name: operationName,
                     id: operationId,
-                    parentId: parentId
+                    parentId: parentId,
+                    correlationContextHeader: correlationContextHeader
                 },
                 customProperties: {}
             };

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -7,7 +7,7 @@ import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
 import ServerRequestParser = require("./ServerRequestParser");
-import { CorrelationContextManager, CorrelationContext } from "./CorrelationContextManager";
+import { CorrelationContextManager, CorrelationContext, PrivateCustomProperties } from "./CorrelationContextManager";
 
 class AutoCollectServerRequests {
 
@@ -133,7 +133,7 @@ class AutoCollectServerRequests {
             correlationContext.operation.id = requestParser.getOperationId(client.context.tags) || correlationContext.operation.id;
             correlationContext.operation.name = requestParser.getOperationName(client.context.tags) || correlationContext.operation.name;
             correlationContext.operation.parentId = requestParser.getRequestId() || correlationContext.operation.parentId;
-            correlationContext.customProperties.addHeaderData(requestParser.getCorrelationContextHeader());
+            (<PrivateCustomProperties>correlationContext.customProperties).addHeaderData(requestParser.getCorrelationContextHeader());
         }
 
         AutoCollectServerRequests.endRequest(client, requestParser, request, response, ellapsedMilliseconds, properties, error);
@@ -161,7 +161,7 @@ class AutoCollectServerRequests {
             correlationContext.operation.id = requestParser.getOperationId(client.context.tags) || correlationContext.operation.id;
             correlationContext.operation.name = requestParser.getOperationName(client.context.tags) || correlationContext.operation.name;
             correlationContext.operation.parentId = requestParser.getOperationParentId(client.context.tags) || correlationContext.operation.parentId;
-            correlationContext.customProperties.addHeaderData(requestParser.getCorrelationContextHeader());
+            (<PrivateCustomProperties>correlationContext.customProperties).addHeaderData(requestParser.getCorrelationContextHeader());
         }
 
         // response listeners

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -65,7 +65,7 @@ class AutoCollectServerRequests {
             requestParser.getOperationId(this._client.context.tags),
             requestParser.getRequestId(),
             requestParser.getOperationName(this._client.context.tags),
-            requestParser.getCorrelationContext()
+            requestParser.getCorrelationContextHeader()
         );
     }
 
@@ -126,14 +126,14 @@ class AutoCollectServerRequests {
 
         // store data about the request
         var correlationContext = CorrelationContextManager.getCurrentContext();
-        var requestParser = new ServerRequestParser(request, (correlationContext && correlationContext.operation.parentId) || Util.newGuid());
+        var requestParser = new ServerRequestParser(request, (correlationContext && correlationContext.operation.parentId));
 
         // Overwrite correlation context with request parser results
         if (correlationContext) {
             correlationContext.operation.id = requestParser.getOperationId(client.context.tags) || correlationContext.operation.id;
             correlationContext.operation.name = requestParser.getOperationName(client.context.tags) || correlationContext.operation.name;
             correlationContext.operation.parentId = requestParser.getRequestId() || correlationContext.operation.parentId;
-            correlationContext.operation.correlationContextHeader = requestParser.getCorrelationContext();
+            correlationContext.customProperties.addHeaderData(requestParser.getCorrelationContextHeader());
         }
 
         AutoCollectServerRequests.endRequest(client, requestParser, request, response, ellapsedMilliseconds, properties, error);
@@ -150,7 +150,7 @@ class AutoCollectServerRequests {
 
         // store data about the request
         var correlationContext = CorrelationContextManager.getCurrentContext();
-        var requestParser = _requestParser || new ServerRequestParser(request, correlationContext && correlationContext.operation.parentId || Util.newGuid());
+        var requestParser = _requestParser || new ServerRequestParser(request, correlationContext && correlationContext.operation.parentId);
 
         if (Util.canIncludeCorrelationHeader(client, requestParser.getUrl())) {
             AutoCollectServerRequests.addResponseCorrelationIdHeader(client, response);
@@ -161,7 +161,7 @@ class AutoCollectServerRequests {
             correlationContext.operation.id = requestParser.getOperationId(client.context.tags) || correlationContext.operation.id;
             correlationContext.operation.name = requestParser.getOperationName(client.context.tags) || correlationContext.operation.name;
             correlationContext.operation.parentId = requestParser.getOperationParentId(client.context.tags) || correlationContext.operation.parentId;
-            correlationContext.operation.correlationContextHeader = requestParser.getCorrelationContext();
+            correlationContext.customProperties.addHeaderData(requestParser.getCorrelationContextHeader());
         }
 
         // response listeners

--- a/AutoCollection/ServerRequests.ts
+++ b/AutoCollection/ServerRequests.ts
@@ -62,9 +62,10 @@ class AutoCollectServerRequests {
         }
 
         return CorrelationContextManager.generateContextObject(
+            requestParser.getOperationId(this._client.context.tags),
             requestParser.getRequestId(),
             requestParser.getOperationName(this._client.context.tags),
-            requestParser.getOperationId(this._client.context.tags)
+            requestParser.getCorrelationContext()
         );
     }
 
@@ -132,6 +133,7 @@ class AutoCollectServerRequests {
             correlationContext.operation.id = requestParser.getOperationId(client.context.tags) || correlationContext.operation.id;
             correlationContext.operation.name = requestParser.getOperationName(client.context.tags) || correlationContext.operation.name;
             correlationContext.operation.parentId = requestParser.getRequestId() || correlationContext.operation.parentId;
+            correlationContext.operation.correlationContextHeader = requestParser.getCorrelationContext();
         }
 
         AutoCollectServerRequests.endRequest(client, requestParser, request, response, ellapsedMilliseconds, properties, error);
@@ -159,6 +161,7 @@ class AutoCollectServerRequests {
             correlationContext.operation.id = requestParser.getOperationId(client.context.tags) || correlationContext.operation.id;
             correlationContext.operation.name = requestParser.getOperationName(client.context.tags) || correlationContext.operation.name;
             correlationContext.operation.parentId = requestParser.getOperationParentId(client.context.tags) || correlationContext.operation.parentId;
+            correlationContext.operation.correlationContextHeader = requestParser.getCorrelationContext();
         }
 
         // response listeners

--- a/Library/CorrelationIdManager.ts
+++ b/Library/CorrelationIdManager.ts
@@ -2,6 +2,8 @@ import https = require('https');
 import http = require('http');
 import url = require('url');
 
+import Util = require("./Util");
+
 class CorrelationIdManager {
     public static correlationIdPrefix = "cid-v1:";
 
@@ -9,6 +11,9 @@ class CorrelationIdManager {
     // as well as a cache of completed lookups so future requests can be resolved immediately.
     private static pendingLookups: {[key: string]: Function[]} = {};
     private static completedLookups: {[key: string]: string} = {};
+
+    private static requestIdMaxLength = 1024;
+    private static currentRootId = Util.randomu32();
 
     public static queryCorrelationId(endpointBase: string, instrumentationKey: string, correlationIdRetryInterval: number, callback: (correlationId: string) => void) {
         // GET request to `${this.endpointBase}/api/profiles/${this.instrumentationKey}/appId`
@@ -89,6 +94,74 @@ class CorrelationIdManager {
                 delete CorrelationIdManager.pendingLookups[appIdUrlString];
             }
         }
+    }
+
+    /**
+     * Generate a request Id according to https://github.com/lmolkova/correlation/blob/master/hierarchical_request_id.md
+     * @param parentId 
+     */
+    public static generateRequestId(parentId: string): string {
+        if (parentId) {
+            parentId = parentId[0] == '|' ? parentId : '|' + parentId;
+            if (parentId[parentId.length -1] !== '.') {
+                parentId += '.';
+            }
+
+            const suffix = (CorrelationIdManager.currentRootId++).toString(16);
+
+            return CorrelationIdManager.appendSuffix(parentId, suffix, '_')
+        } else {
+            return CorrelationIdManager.generateRootId();
+        }
+    }
+
+    /**
+     * Given a hierarchical identifier of the form |X.*
+     * return the root identifier X
+     * @param id 
+     */
+    public static getRootId(id: string): string {
+        let endIndex = id.indexOf('.');
+        if (endIndex < 0) {
+            endIndex = id.length;
+        }
+
+        const startIndex = id[0] === '|' ? 1 : 0;
+        return id.substring(startIndex, endIndex);
+    }
+
+    private static generateRootId(): string {
+        return '|' + Util.newGuid() + '.';
+    }
+
+    private static appendSuffix(parentId: string, suffix: string, delimiter: string): string {
+        if (parentId.length + suffix.length < CorrelationIdManager.requestIdMaxLength) {
+            return parentId + suffix + delimiter;
+        }
+
+        // Combined identifier would be too long, so we must truncate it.
+        // We need 9 characters of space: 8 for the overflow ID, 1 for the
+        // overflow delimiter '#'
+        let trimPosition = CorrelationIdManager.requestIdMaxLength - 9;
+        if (parentId.length > trimPosition) {
+            for(; trimPosition > 1; --trimPosition) {
+                const c = parentId[trimPosition-1];
+                if (c === '.' || c === '_') {
+                    break;
+                }
+            }
+        }
+
+        if (trimPosition <= 1) {
+            // parentId is not a valid ID
+            return CorrelationIdManager.generateRootId();
+        }
+
+        suffix = Util.randomu32().toString(16);
+        while (suffix.length < 8) {
+            suffix = '0' + suffix;
+        }
+        return parentId.substring(0,trimPosition) + suffix + '#';
     }
 }
 

--- a/Library/RequestResponseHeaders.ts
+++ b/Library/RequestResponseHeaders.ts
@@ -1,6 +1,10 @@
 export = {
 
-    requestContextHeader: "Request-Context",
+    /**
+     * Request-Context header
+     */
+    requestContextHeader: "request-context",
+
     /**
      * Source instrumentation header that is added by an application while making http
      * requests and retrieved by the other application when processing incoming requests.
@@ -14,13 +18,25 @@ export = {
     requestContextTargetKey: "appId",
 
     /**
-     * Header containing the id of the immidiate caller
+     * Request-Id header
+     */
+    requestIdHeader: "request-id",
+
+    /**
+     * Legacy Header containing the id of the immidiate caller
      */
     parentIdHeader: "x-ms-request-id",
 
     /**
-     * Header containing the correlation id that kept the same for every telemetry item
+     * Legacy Header containing the correlation id that kept the same for every telemetry item
      * accross transactions
      */
     rootIdHeader: "x-ms-request-root-id",
+
+    /**
+     * Correlation-Context header
+     * 
+     * Not currently actively used, but the contents should be passed from incoming to outgoing requests
+     */
+    correlationContextHeader: "correlation-context"
 }

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -63,6 +63,13 @@ class Util {
     }
 
     /**
+     * generate a random 32bit number (0x00000000..0xFFFFFFFF).
+     */
+    public static randomu32() {
+        return Util.random32() + 0x80000000;
+    }
+
+    /**
      * generate GUID
      */
     public static newGuid() {

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -3,6 +3,13 @@ import { CorrelationContextManager, CorrelationContext } from "../../AutoCollect
 import assert = require("assert");
 import sinon = require("sinon");
 
+const customProperties = {
+    addHeaderData(header: string) {},
+    getProperty(prop: string) {return ""},
+    setProperty(prop: string, val: string) {},
+    serializeToHeader() {return ""}
+}
+
 if (CorrelationContextManager.isNodeVersionCompatible()) {
     describe("AutoCollection/CorrelationContextManager", () => {
         var testContext: CorrelationContext = {
@@ -11,7 +18,7 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
                 name: "test",
                 parentId: "test"
             },
-            customProperties: {}
+            customProperties
         };
         var testContext2: CorrelationContext = {
             operation: {
@@ -19,7 +26,7 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
                 name: "test2",
                 parentId: "test2"
             },
-            customProperties: {}
+            customProperties
         };
 
         describe("#getCurrentContext()", () => {
@@ -176,7 +183,7 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
                 name: "test",
                 parentId: "test"
             },
-            customProperties: {}
+            customProperties
         };
         var testContext2: CorrelationContext = {
             operation: {
@@ -184,7 +191,7 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
                 name: "test2",
                 parentId: "test2"
             },
-            customProperties: {}
+            customProperties
         };
 
         describe("#getCurrentContext()", () => {

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -4,10 +4,8 @@ import assert = require("assert");
 import sinon = require("sinon");
 
 const customProperties = {
-    addHeaderData(header: string) {},
     getProperty(prop: string) {return ""},
     setProperty(prop: string, val: string) {},
-    serializeToHeader() {return ""}
 }
 
 if (CorrelationContextManager.isNodeVersionCompatible()) {

--- a/Tests/Library/Util.tests.ts
+++ b/Tests/Library/Util.tests.ts
@@ -108,6 +108,22 @@ describe("Library/Util", () => {
         });
     });
 
+    describe("#randomu32()", () => {
+        let test = (i: number, expected) => {
+            let mathStub = sinon.stub(Math, "random", () => i);
+            assert.equal(Util.randomu32(), expected);
+            mathStub.restore();
+        }
+        it("should generate a number in the range [0x00000000..0xFFFFFFFF]", () => {
+            test(0, 0x80000000);
+            test(0.125, 0xA0000000);
+            test(0.25, 0xC0000000);
+            test(0.5, 0x00000000);
+            test(0.75, 0x40000000);
+            test(1.0, 0x80000000);
+        });
+    });
+
     describe("#uint32ArrayToBase64()", () => {
         it("should convert an 32-bit array to Base64", () => {
             assert.equal(Util.int32ArrayToBase64([-1, -1, -1, -1]), "/////////////////////w");


### PR DESCRIPTION
Request IDs are expected to follow https://github.com/lmolkova/correlation/blob/master/hierarchical_request_id.md
and https://github.com/lmolkova/correlation/blob/master/http_protocol_proposal_v1.md

This change defaults to using the new hierarchical ID format, but continues
to interoperate with the legacy format as well.