### PR TITLE
Clear all implicit any usages

### DIFF
--- a/AutoCollection/ClientRequests.ts
+++ b/AutoCollection/ClientRequests.ts
@@ -53,10 +53,10 @@ class AutoCollectClientRequests {
         this._isInitialized = true;
 
         const originalRequest = http.request;
-        http.request = (options, ...requestArgs) => {
+        http.request = (options, ...requestArgs: any[]) => {
             const request: http.ClientRequest = originalRequest.call(
                 http, options, ...requestArgs);
-            if (request && options && !options[AutoCollectClientRequests.disableCollectionRequestOption]) {
+            if (request && options && !(<any>options)[AutoCollectClientRequests.disableCollectionRequestOption]) {
                 AutoCollectClientRequests.trackRequest(this._client, options, request);
             }
             return request;
@@ -67,10 +67,10 @@ class AutoCollectClientRequests {
         // The regex matches versions < 0.11.12 (avoiding a semver package dependency).
         if (/^0\.([0-9]\.)|(10\.)|(11\.([0-9]|10|11)$)/.test(process.versions.node)) {
             const originalHttpsRequest = https.request;
-            https.request = (options, ...requestArgs) => {
+            https.request = (options, ...requestArgs: any[]) => {
                 const request: http.ClientRequest = originalHttpsRequest.call(
                     https, options, ...requestArgs);
-                if (request && options && !options[AutoCollectClientRequests.disableCollectionRequestOption]) {
+                if (request && options && !(<any>options)[AutoCollectClientRequests.disableCollectionRequestOption]) {
                     AutoCollectClientRequests.trackRequest(this._client, options, request);
                 }
                 return request;

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -251,7 +251,7 @@ export class CorrelationContextManager {
     }
 }
 
-class CustomPropertiesImpl implements CustomProperties {
+class CustomPropertiesImpl implements PrivateCustomProperties {
     private static bannedCharacters = /[,=]/;
     private props: {key: string, value:string}[] = [];
 

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -48,55 +48,6 @@ export class CorrelationContextManager {
     public static generateContextObject(operationId: string, parentId?: string, operationName?: string, correlationContextHeader?: string): CorrelationContext {
         parentId = parentId || operationId;
 
-        const bannedCharacters = /[,=]/;
-
-        const customProperties: any = {
-            props: []
-        }
-        customProperties.addHeaderData = function (header: string) {
-            header = header || "";
-            this.props = header.split(", ").map((keyval) => {
-                const parts = keyval.split("=");
-                return {key: parts[0], value: parts[1]};
-            }).concat(this.props);
-        }.bind(customProperties);
-
-        customProperties.serializeToHeader = function () {
-            return this.props.map((keyval) => {
-                `${keyval.key}=${keyval.value}`
-            }).join(", ");
-        }.bind(customProperties);
-
-        customProperties.getProperty = function (prop: string) {
-            for(let i = 0; i < this.props.length; ++i) {
-                const keyval = this.props[i]
-                if (keyval.key === prop) {
-                    return keyval.value;
-                }
-            }
-            return;
-        }.bind(customProperties);
-
-        customProperties.addHeaderData(correlationContextHeader);
-
-        // TODO: Strictly according to the spec, properties which are recieved from
-        // an incoming request should be left untouched, while we may add our own new
-        // properties. The logic here will need to change to track that.
-        customProperties.setProperty = function (prop: string, val: string) {
-            if (bannedCharacters.test(prop) || bannedCharacters.test(val)) {
-                throw new Error("Keys and values must not contain ',' or '='");
-            }
-            for(let i = 0; i < this.props.length; ++i) {
-                const keyval = this.props[i];
-                if (keyval.key === prop) {
-                    keyval.value = val;
-                    return;
-                }
-            }
-            this.props.push({key: prop, value: val});
-        }.bind(customProperties);
-
-
         if (this.enabled) {
             return {
                 operation: {
@@ -104,7 +55,7 @@ export class CorrelationContextManager {
                     id: operationId,
                     parentId: parentId
                 },
-                customProperties
+                customProperties: new CustomPropertiesImpl(correlationContextHeader)
             };
         }
 
@@ -200,8 +151,8 @@ export class CorrelationContextManager {
     // This fixes that.
     private static patchTimers(methodNames: string[]) {
         methodNames.forEach(methodName => {
-            var orig = global[methodName];
-            global[methodName] = function() {
+            var orig = (<any>global)[methodName];
+            (<any>global)[methodName] = function() {
                 var ret = orig.apply(this, arguments);
                 ret.toString = function(){
                     if (this.data && typeof this.data.handleId !== 'undefined') {
@@ -232,7 +183,7 @@ export class CorrelationContextManager {
             if ((<any>orig).prepareStackTrace) {
                 (<any>orig).stackRewrite= false;
                 var stackTrace = (<any>orig).prepareStackTrace;
-                (<any>orig).prepareStackTrace = (e, s) => {
+                (<any>orig).prepareStackTrace = (e: any, s: any) => {
                     // Remove some AI and Zone methods from the stack trace
                     // Otherwise we leave side-effects
 
@@ -274,7 +225,7 @@ export class CorrelationContextManager {
             // We need to proactively make those not enumerable as well as the currently visible properties
             for(var i=0; i < props.length; i++) {
                 var propertyName = props[i];
-                var hiddenPropertyName = Zone['__symbol__'](propertyName);
+                var hiddenPropertyName = (<any>Zone)['__symbol__'](propertyName);
                 Object.defineProperty(this, propertyName, { enumerable: false });
                 Object.defineProperty(this, hiddenPropertyName, { enumerable: false, writable: true });
             }
@@ -289,7 +240,7 @@ export class CorrelationContextManager {
         var props = Object.getOwnPropertyNames(orig);
         for(var i=0; i < props.length; i++) {
             var propertyName = props[i];
-            if (!AppInsightsAsyncCorrelatedErrorWrapper[propertyName]) {
+            if (!(<any>AppInsightsAsyncCorrelatedErrorWrapper)[propertyName]) {
                 Object.defineProperty(AppInsightsAsyncCorrelatedErrorWrapper, propertyName, Object.getOwnPropertyDescriptor(orig, propertyName));
             }
         }
@@ -297,5 +248,55 @@ export class CorrelationContextManager {
         // explicit cast to <any> required to avoid type error for captureStackTrace
         // with latest node.d.ts (despite workaround above)
         global.Error = <any>AppInsightsAsyncCorrelatedErrorWrapper;
+    }
+}
+
+class CustomPropertiesImpl implements CustomProperties {
+    private static bannedCharacters = /[,=]/;
+    private props: {key: string, value:string}[] = [];
+
+    public constructor(header: string) {
+        this.addHeaderData(header);
+    }
+    
+    public addHeaderData(header: string) {
+        header = header || "";
+        this.props = header.split(", ").map((keyval) => {
+            const parts = keyval.split("=");
+            return {key: parts[0], value: parts[1]};
+        }).concat(this.props);
+    }
+
+    public serializeToHeader() {
+        return this.props.map((keyval) => {
+            `${keyval.key}=${keyval.value}`
+        }).join(", ");
+    }
+
+    public getProperty(prop: string) {
+        for(let i = 0; i < this.props.length; ++i) {
+            const keyval = this.props[i]
+            if (keyval.key === prop) {
+                return keyval.value;
+            }
+        }
+        return;
+    }
+
+    // TODO: Strictly according to the spec, properties which are recieved from
+    // an incoming request should be left untouched, while we may add our own new
+    // properties. The logic here will need to change to track that.
+    public setProperty(prop: string, val: string) {
+        if (CustomPropertiesImpl.bannedCharacters.test(prop) || CustomPropertiesImpl.bannedCharacters.test(val)) {
+            throw new Error("Keys and values must not contain ',' or '='");
+        }
+        for (let i = 0; i < this.props.length; ++i) {
+            const keyval = this.props[i];
+            if (keyval.key === prop) {
+                keyval.value = val;
+                return;
+            }
+        }
+        this.props.push({key: prop, value: val});
     }
 }

--- a/AutoCollection/Exceptions.ts
+++ b/AutoCollection/Exceptions.ts
@@ -10,8 +10,8 @@ class AutoCollectExceptions {
 
     public static INSTANCE: AutoCollectExceptions = null;
 
-    private _exceptionListenerHandle;
-    private _rejectionListenerHandle;
+    private _exceptionListenerHandle: (reThrow: boolean, error: Error) => void;
+    private _rejectionListenerHandle: (reThrow: boolean, error: Error) => void;
     private _client: Client;
     private _isInitialized: boolean;
 
@@ -88,7 +88,7 @@ class AutoCollectExceptions {
         return data;
     }
 
-    private static parseStack(stack): _StackFrame[] {
+    private static parseStack(stack: any): _StackFrame[] {
         var parsedStack: _StackFrame[] = undefined;
         if (typeof stack === "string") {
             var frames = stack.split("\n");
@@ -155,11 +155,11 @@ class _StackFrame {
     public static regex = /^([\s]+at)?(.*?)(\@|\s\(|\s)([^\(\@\n]+):([0-9]+):([0-9]+)(\)?)$/;
     public static baseSize = 58; //'{"method":"","level":,"assembly":"","fileName":"","line":}'.length
     public sizeInBytes = 0;
-    public level;
-    public method;
-    public assembly;
-    public fileName;
-    public line;
+    public level: number;
+    public method: string;
+    public assembly: string;
+    public fileName: string;
+    public line: number;
 
     constructor(frame: string, level: number) {
         this.level = level;

--- a/AutoCollection/RequestParser.ts
+++ b/AutoCollection/RequestParser.ts
@@ -37,7 +37,7 @@ abstract class RequestParser {
                 properties["error"] = error.message;
             } else if (typeof error === "object") {
                 for (var key in <any>error) {
-                    properties[key] = error[key] && error[key].toString && error[key].toString();
+                    properties[key] = (<any>error)[key] && (<any>error)[key].toString && (<any>error)[key].toString();
                 }
             }
         }

--- a/AutoCollection/ServerRequestParser.ts
+++ b/AutoCollection/ServerRequestParser.ts
@@ -15,7 +15,7 @@ import CorrelationIdManager = require("../Library/CorrelationIdManager");
 class ServerRequestParser extends RequestParser {
     private static keys = new Contracts.ContextTagKeys();
 
-    private rawHeaders:string[];
+    private rawHeaders: {[key: string] : string};
     private socketRemoteAddress:string;
     private connectionRemoteAddress:string;
     private legacySocketRemoteAddress:string;
@@ -37,7 +37,7 @@ class ServerRequestParser extends RequestParser {
             this.parseHeaders(request, requestId);
             if (request.connection) {
                 this.connectionRemoteAddress = request.connection.remoteAddress;
-                this.legacySocketRemoteAddress = request.connection["socket"] && request.connection["socket"].remoteAddress;
+                this.legacySocketRemoteAddress = (<any>request.connection)["socket"] && (<any>request.connection)["socket"].remoteAddress;
             }
         }
     }

--- a/AutoCollection/diagnostic-channel/bunyan.sub.ts
+++ b/AutoCollection/diagnostic-channel/bunyan.sub.ts
@@ -10,13 +10,14 @@ import {bunyan} from "diagnostic-channel-publishers";
 let clients: Client[] = [];
 
 // Mapping from bunyan levels defined at https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L256
-const bunyanToAILevelMap = {};
-bunyanToAILevelMap[10] = SeverityLevel.Verbose;
-bunyanToAILevelMap[20] = SeverityLevel.Verbose;
-bunyanToAILevelMap[30] = SeverityLevel.Information;
-bunyanToAILevelMap[40] = SeverityLevel.Warning;
-bunyanToAILevelMap[50] = SeverityLevel.Error;
-bunyanToAILevelMap[60] = SeverityLevel.Critical;
+const bunyanToAILevelMap: {[key: number] : number} = {
+    10: SeverityLevel.Verbose,
+    20: SeverityLevel.Verbose,
+    30: SeverityLevel.Information,
+    40: SeverityLevel.Warning,
+    50: SeverityLevel.Error,
+    60: SeverityLevel.Critical,
+};
 
 const subscriber = (event: IStandardEvent<bunyan.IBunyanData>) => {
     clients.forEach((client) => {

--- a/AutoCollection/diagnostic-channel/initialization.ts
+++ b/AutoCollection/diagnostic-channel/initialization.ts
@@ -6,7 +6,7 @@ import {bunyan, console as consoleModule, mongodb, mysql, redis} from "diagnosti
 if (!process.env["APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL"]) {
     const individualOptOuts = process.env["APPLICATION_INSIGHTS_NO_PATCH_MODULES"] || "";
     const unpatchedModules = individualOptOuts.split(",");
-    const modules = {bunyan, console: consoleModule, mongodb, mysql, redis};
+    const modules: {[key: string] : any} = {bunyan, console: consoleModule, mongodb, mysql, redis};
     for (const mod in modules) {
         if (unpatchedModules.indexOf(mod) === -1) {
            modules[mod].enable();

--- a/Library/Channel.ts
+++ b/Library/Channel.ts
@@ -86,7 +86,7 @@ class Channel {
     /**
      * Immediately send buffered data
      */
-    public triggerSend(isNodeCrashing: boolean, callback?: (string) => void) {
+    public triggerSend(isNodeCrashing: boolean, callback?: (v: string) => void) {
         let bufferIsEmpty = this._buffer.length < 1;
         if (!bufferIsEmpty) {
             // compose an array of payloads

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -236,7 +236,7 @@ class Client {
     /**
      * Immediately send all queued telemetry.
      */
-    public sendPendingData(callback?: (string) => void) {
+    public sendPendingData(callback?: (v: string) => void) {
         this.channel.triggerSend(false, callback);
     }
 

--- a/Library/Config.ts
+++ b/Library/Config.ts
@@ -22,7 +22,7 @@ class Config {
     public correlationIdRetryIntervalMs: number;
 
     private endpointBase: string = "https://dc.services.visualstudio.com";
-    private setCorrelationId: (string) => void;
+    private setCorrelationId: (v: string) => void;
     private _profileQueryEndpoint: string;
 
     // A list of domains for which correlation headers will not be added.

--- a/Library/CorrelationIdManager.ts
+++ b/Library/CorrelationIdManager.ts
@@ -54,7 +54,7 @@ class CorrelationIdManager {
                     // Success; extract the appId from the body
                     let appId = "";
                     res.setEncoding("utf-8");
-                    res.on('data', function (data) {
+                    res.on('data', (data: any) => {
                         appId += data;
                     });
                     res.on('end', () => {

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -39,7 +39,7 @@ class Sender {
         }
     }
 
-    public send(payload: Buffer, callback?: (string) => void) {
+    public send(payload: Buffer, callback?: (v: string) => void) {
         var endpointUrl = this._getUrl();
         if (endpointUrl && endpointUrl.indexOf("//") === 0) {
             // use https if the config did not specify a protocol
@@ -54,7 +54,7 @@ class Sender {
             path: parsedUrl.pathname,
             method: "POST",
             withCredentials: false,
-            headers: {
+            headers: <{[key: string] : string}>{
                 "Content-Type": "application/x-json-stream"
             }
         };
@@ -64,7 +64,7 @@ class Sender {
             if (err) {
                 Logging.warn(err);
                 dataToSend = payload; // something went wrong so send without gzip
-                options.headers["Content-Length"] = payload.length;
+                options.headers["Content-Length"] = payload.length.toString();
             } else {
                 options.headers["Content-Encoding"] = "gzip";
                 options.headers["Content-Length"] = buffer.length;
@@ -73,7 +73,7 @@ class Sender {
             Logging.info(Sender.TAG, options);
 
             // Ensure this request is not captured by auto-collection.
-            options[AutoCollectClientRequests.disableCollectionRequestOption] = true;
+            (<any>options)[AutoCollectClientRequests.disableCollectionRequestOption] = true;
 
             var requestCallback = (res:http.ClientResponse) => {
                 res.setEncoding("utf-8");
@@ -140,10 +140,10 @@ class Sender {
         this._storeToDiskSync(payload);
     }
 
-    private _confirmDirExists(direcotry: string, callback: (err) => void): void {
-        fs.exists(direcotry, (exists) => {
+    private _confirmDirExists(directory: string, callback: (err: NodeJS.ErrnoException) => void): void {
+        fs.exists(directory, (exists) => {
             if (!exists) {
-               fs.mkdir(direcotry, (err) => {
+               fs.mkdir(directory, (err) => {
                    callback(err);
                });
             } else {

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -12,13 +12,13 @@ class Util {
     /**
      * helper method to access userId and sessionId cookie
      */
-    public static getCookie(name, cookie) {
+    public static getCookie(name: string, cookie: string) {
         var value = "";
         if (name && name.length && typeof cookie === "string") {
             var cookieName = name + "=";
             var cookies = cookie.split(";");
             for (var i = 0; i < cookies.length; i++) {
-                var cookie = <any>cookies[i];
+                var cookie = cookies[i];
                 cookie = Util.trim(cookie);
                 if (cookie && cookie.indexOf(cookieName) === 0) {
                     value = cookie.substring(cookieName.length, cookies[i].length);

--- a/Tests/AutoCollection/ClientRequestParser.tests.ts
+++ b/Tests/AutoCollection/ClientRequestParser.tests.ts
@@ -15,7 +15,7 @@ describe("AutoCollection/ClientRequestParser", () => {
         };
 
         it("should return correct data for a URL string", () => {
-            request["method"] = "GET";
+            (<any>request)["method"] = "GET";
             let parser = new ClientRequestParser("http://bing.com/search", request);
 
             response.statusCode = 200;
@@ -30,7 +30,7 @@ describe("AutoCollection/ClientRequestParser", () => {
         });
 
         it("should return correct data for a posted URL with query string", () => {
-            request["method"] = "POST";
+            (<any>request)["method"] = "POST";
             let parser = new ClientRequestParser("http://bing.com/search?q=test", request);
 
             response.statusCode = 200;
@@ -50,7 +50,7 @@ describe("AutoCollection/ClientRequestParser", () => {
                 port: 8000,
                 path: "/search?q=test",
             };
-            request["method"] = "POST";
+            (<any>request)["method"] = "POST";
             let parser = new ClientRequestParser(requestOptions, request);
 
             response.statusCode = 200;
@@ -71,7 +71,7 @@ describe("AutoCollection/ClientRequestParser", () => {
                 host: "finance.google.com",
                 path: path + "msft"
             };
-            request["method"] = "GET";
+            (<any>request)["method"] = "GET";
             let parser = new ClientRequestParser(requestOptions, request);
 
             response.statusCode = 200;
@@ -86,7 +86,7 @@ describe("AutoCollection/ClientRequestParser", () => {
         });
 
         it("should return non-success for a request error", () => {
-            request["method"] = "GET";
+            (<any>request)["method"] = "GET";
             let parser = new ClientRequestParser("http://bing.com/search", request);
             parser.onError(new Error("test error message"));
 
@@ -98,7 +98,7 @@ describe("AutoCollection/ClientRequestParser", () => {
         });
 
         it("should return non-success for a response error status", () => {
-            request["method"] = "GET";
+            (<any>request)["method"] = "GET";
             let parser = new ClientRequestParser("http://bing.com/search", request);
 
             response.statusCode = 400;

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -95,9 +95,9 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
                 CorrelationContextManager.enable();
 
                 try {
-                    var stackTrace = Error['prepareStackTrace'];
-                    Error['prepareStackTrace'] = function (_, stack) {
-                        Error['prepareStackTrace'] = stackTrace;
+                    var stackTrace = (<any>Error)['prepareStackTrace'];
+                    (<any>Error)['prepareStackTrace'] = function (_: any, stack: any) {
+                        (<any>Error)['prepareStackTrace'] = stackTrace;
                         return stack;
                     };
 
@@ -110,9 +110,9 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
             it("should remove extra AI+Zone methods if prepareStackTrace is used", () => {
                 CorrelationContextManager.enable();
 
-                var stackTrace = Error['prepareStackTrace'];
-                Error['prepareStackTrace'] = function (_, stack) {
-                    Error['prepareStackTrace'] = stackTrace;
+                var stackTrace = (<any>Error)['prepareStackTrace'];
+                (<any>Error)['prepareStackTrace'] = function (_: any, stack: any) {
+                    (<any>Error)['prepareStackTrace'] = stackTrace;
                     return stack;
                 };
 

--- a/Tests/AutoCollection/Exceptions.tests.ts
+++ b/Tests/AutoCollection/Exceptions.tests.ts
@@ -5,7 +5,7 @@ import AutoCollectionExceptions = require("../../AutoCollection/Exceptions");
 
 describe("AutoCollection/Exceptions", () => {
     describe("#getExceptionData()", () => {
-        var simpleError;
+        var simpleError: Error;
         
         beforeEach(() => {
             try {

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -45,12 +45,12 @@ class fakeResponse {
 class fakeRequest {
     private callbacks: {[event:string]: Function} = Object.create(null);
     public write(): void {}
-    public headers = [];
+    public headers: {[id: string]: string} = {};
     public agent = { protocol: 'http' };
 
     constructor (private failImmediatly: boolean = true, public url: string = undefined) {}
 
-    public on(event: string, callback) {
+    public on(event: string, callback: Function) {
         this.callbacks[event] = callback;
         if (event === "error" && this.failImmediatly) {
             setImmediate(() => this.fail());
@@ -112,7 +112,7 @@ class fakeHttpsServer extends events.EventEmitter {
 describe("EndToEnd", () => {
 
     describe("Basic usage", () => {
-        var sandbox;
+        var sandbox: sinon.SinonSandbox;
 
         beforeEach(() => {
             sandbox = sinon.sandbox.create();
@@ -237,7 +237,7 @@ describe("EndToEnd", () => {
 
             this.request.returns(req);
 
-            client.sendPendingData((response) => {
+            client.sendPendingData((response: any) => {
                 // yield for the caching behavior
                 setImmediate(() => {
                     assert(this.writeFile.callCount === 0);
@@ -256,7 +256,7 @@ describe("EndToEnd", () => {
 
             this.request.returns(req);
 
-            client.sendPendingData((response) => {
+            client.sendPendingData((response: any) => {
                 // yield for the caching behavior
                 setImmediate(() => {
                     assert(this.writeFile.callCount === 1);
@@ -278,7 +278,7 @@ describe("EndToEnd", () => {
             this.request.returns(req);
             this.request.yields(res);
 
-            client.sendPendingData((response) => {
+            client.sendPendingData((response: any) => {
                 // wait until sdk looks for offline files
                 setTimeout(() => {
                     assert(this.readdir.callCount === 1);

--- a/Tests/Library/Channel.tests.ts
+++ b/Tests/Library/Channel.tests.ts
@@ -18,16 +18,16 @@ describe("Library/Channel", () => {
 
     var testEnvelope = new Contracts.Envelope();
     var sender = {
-        saveOnCrash: (str) => null,
-        send: (Buffer) => null
+        saveOnCrash: <(s: string) => void>((str) => null),
+        send: <(b: Buffer) => void>((buffer) => null)
     };
 
     var sendSpy = sinon.spy(sender, "send");
     var saveSpy = sinon.spy(sender, "saveOnCrash");
 
     var channel:ChannelMock;
-    var config;
-    var clock;
+    var config: any;
+    var clock: any;
     before(() => clock = sinon.useFakeTimers());
     after(() => clock.restore());
 

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -44,13 +44,13 @@ describe("Library/Client", () => {
     })
 
     var invalidInputHelper = (name: string) => {
-        assert.doesNotThrow(() => client[name](null, null));
-        assert.doesNotThrow(() => client[name](<any>undefined, <any>undefined));
-        assert.doesNotThrow(() => client[name](<any>{}, <any>{}));
-        assert.doesNotThrow(() => client[name](<any>[], <any>[]));
-        assert.doesNotThrow(() => client[name](<any>"", <any>""));
-        assert.doesNotThrow(() => client[name](<any>1, <any>1));
-        assert.doesNotThrow(() => client[name](<any>true, <any>true));
+        assert.doesNotThrow(() => (<any>client)[name](null, null));
+        assert.doesNotThrow(() => (<any>client)[name](<any>undefined, <any>undefined));
+        assert.doesNotThrow(() => (<any>client)[name](<any>{}, <any>{}));
+        assert.doesNotThrow(() => (<any>client)[name](<any>[], <any>[]));
+        assert.doesNotThrow(() => (<any>client)[name](<any>"", <any>""));
+        assert.doesNotThrow(() => (<any>client)[name](<any>1, <any>1));
+        assert.doesNotThrow(() => (<any>client)[name](<any>true, <any>true));
     };
 
     describe("#constructor()", () => {
@@ -223,7 +223,7 @@ describe("Library/Client", () => {
                 return new eventEmitter.EventEmitter();
             },
             statusCode: 200,
-            headers: {},
+            headers: <{[id: string]: string}>{},
             getHeader: function (name: string) { return this.headers[name]; },
             setHeader: function (name: string, value: string) { this.headers[name] = value; },
         };
@@ -257,7 +257,7 @@ describe("Library/Client", () => {
             agent: {
                 protocol: 'http'
             },
-            headers: {
+            headers: <{[id: string]: string}>{
                 host: "bing.com"
             },
             getHeader: function (name: string) { return this.headers[name]; },
@@ -635,8 +635,8 @@ describe("Library/Client", () => {
             mockData.properties = {};
             var env = client.getEnvelope(mockData);
             assert.deepEqual(env.tags, client.context.tags, "tags are set by default");
-            var customTag = { "ai.cloud.roleInstance": "override" };
-            var expected = {};
+            var customTag = <{[id: string]: string}>{ "ai.cloud.roleInstance": "override" };
+            var expected: {[id: string]: string} = {};
             for(var tag in client.context.tags) {
                 expected[tag] = customTag[tag] || client.context.tags[tag];
             }

--- a/Tests/Library/Config.tests.ts
+++ b/Tests/Library/Config.tests.ts
@@ -18,7 +18,7 @@ describe("Library/Config", () => {
         });
 
         it("should read iKey from environment", () => {
-            var env = {};
+            var env = <{[id: string]: string}>{};
             env[Config.ENV_iKey] = iKey;
             var originalEnv = process.env;
             process.env = env;
@@ -28,7 +28,7 @@ describe("Library/Config", () => {
         });
 
         it("should read iKey from azure environment", () => {
-            var env = {};
+            var env = <{[id: string]: string}>{};
             env[Config.ENV_azurePrefix + Config.ENV_iKey] = iKey;
             var originalEnv = process.env;
             process.env = env;

--- a/Tests/Library/Util.tests.ts
+++ b/Tests/Library/Util.tests.ts
@@ -7,7 +7,7 @@ describe("Library/Util", () => {
 
     describe("#getCookie(name, cookie)", () => {
 
-        var test = (cookie, query, expected) => {
+        var test = (cookie: string, query: string, expected: string) => {
             var actual = Util.getCookie(query, cookie);
             assert.equal(expected, actual, "cookie is parsed correctly");
         }
@@ -93,7 +93,7 @@ describe("Library/Util", () => {
     });
 
     describe("#random32()", () => {
-        let test = (i: number, expected) => {
+        let test = (i: number, expected: number) => {
             let mathStub = sinon.stub(Math, "random", () => i);
             assert.equal(Util.random32(), expected);
             mathStub.restore();
@@ -109,7 +109,7 @@ describe("Library/Util", () => {
     });
 
     describe("#randomu32()", () => {
-        let test = (i: number, expected) => {
+        let test = (i: number, expected: number) => {
             let mathStub = sinon.stub(Math, "random", () => i);
             assert.equal(Util.randomu32(), expected);
             mathStub.restore();
@@ -133,7 +133,7 @@ describe("Library/Util", () => {
     });
 
     describe("#msToTimeSpan(totalMs)", () => {
-        var test = (input, expected, message) => {
+        var test = (input: number, expected: string, message: string) => {
             var actual = Util.msToTimeSpan(input);
             assert.equal(expected, actual, message);
         }
@@ -155,11 +155,11 @@ describe("Library/Util", () => {
         });
 
         it("should handle invalid input", () => {
-            test("", "00:00:00.000", "invalid input");
-            test("'", "00:00:00.000", "invalid input");
+            test(<any>"", "00:00:00.000", "invalid input");
+            test(<any>"'", "00:00:00.000", "invalid input");
             test(NaN, "00:00:00.000", "invalid input");
-            test({}, "00:00:00.000", "invalid input");
-            test([], "00:00:00.000", "invalid input");
+            test(<any>{}, "00:00:00.000", "invalid input");
+            test(<any>[], "00:00:00.000", "invalid input");
             test(-1, "00:00:00.000", "invalid input");
         });
     });
@@ -170,7 +170,7 @@ describe("Library/Util", () => {
             assert.equal(Util.validateStringMap(1), undefined);
             assert.equal(Util.validateStringMap(true), undefined);
             assert.equal(Util.validateStringMap("test"), undefined);
-            assert.equal(Util.validateStringMap(() => null), undefined);
+            assert.equal(Util.validateStringMap(():void => null), undefined);
             assert.deepEqual(Util.validateStringMap({ a: {} }), { a: "[object Object]" });
             assert.deepEqual(Util.validateStringMap({ a: 3, b: "test" }), { a: "3", b: "test" });
             assert.deepEqual(Util.validateStringMap({ a: 0, b: null, c: undefined, d: [], e: '', f: -1 }), { a: "0", d: "", e: "", f: "-1" });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true,
+        "noImplicitAny": true,
         "outDir": "./out",
         "typeRoots": [
             "./node_modules/@types"


### PR DESCRIPTION
Addresses #264 and ensures we don't regress by enforcing this at compile time

@MSLaguana Part of this is a restructure of the CustomProperties object you wrote. There should be no actual code change just placing it into a real class. Could you give a quick look to make sure this is still the same? The previous "pseudo-class" structure wasn't working well with the enforcement of no implicit any added here.