### PR TITLE
Fix fractional millisecond conversion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
      "files.exclude": {
         "**/*.js": { "when": "$(basename).ts"},
         "**/*.js.map": true,
-        "**/*.d.ts": true
+        "**/*.d.ts": true,
+        "out/": true
      },
     "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -129,12 +129,12 @@ class Util {
         var hour = "" + Math.floor(totalms / (1000 * 60 * 60)) % 24;
         var days = Math.floor(totalms / (1000 * 60 * 60 * 24));
 
-        var secPadding = sec.indexOf(".") < 2 ? "0" : "";
+        sec = sec.indexOf(".") < 2 ? "0" + sec : sec;
         min = min.length < 2 ? "0" + min : min;
         hour = hour.length < 2 ? "0" + hour : hour;
         var daysText = days > 0 ? days + "." : "";
 
-        return daysText + hour + ":" + min + ":" + secPadding + sec;
+        return daysText + hour + ":" + min + ":" + sec;
     }
 
     /**

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -124,19 +124,17 @@ class Util {
             totalms = 0;
         }
 
-        var ms = "" + totalms % 1000;
-        var sec = "" + Math.floor(totalms / 1000) % 60;
+        var sec = ((totalms / 1000) % 60).toFixed(7).replace(/0{0,4}$/, "");
         var min = "" + Math.floor(totalms / (1000 * 60)) % 60;
         var hour = "" + Math.floor(totalms / (1000 * 60 * 60)) % 24;
         var days = Math.floor(totalms / (1000 * 60 * 60 * 24));
 
-        ms = ms.length === 1 ? "00" + ms : ms.length === 2 ? "0" + ms : ms;
-        sec = sec.length < 2 ? "0" + sec : sec;
+        var secPadding = sec.indexOf(".") < 2 ? "0" : "";
         min = min.length < 2 ? "0" + min : min;
         hour = hour.length < 2 ? "0" + hour : hour;
         var daysText = days > 0 ? days + "." : "";
 
-        return daysText + hour + ":" + min + ":" + sec + "." + ms;
+        return daysText + hour + ":" + min + ":" + secPadding + sec;
     }
 
     /**

--- a/Tests/Library/Util.tests.ts
+++ b/Tests/Library/Util.tests.ts
@@ -152,6 +152,7 @@ describe("Library/Util", () => {
             test(24 * 60 * 60 * 1000, "1.00:00:00.000", "hours overflow");
             test(11 * 3600000 + 11 * 60000 + 11111, "11:11:11.111", "all digits");
             test(5 * 86400000 + 13 * 3600000 + 9 * 60000 + 8 * 1000 + 789, "5.13:09:08.789", "all digits with days");
+            test(1001.505, "00:00:01.001505", "fractional milliseconds");
         });
 
         it("should handle invalid input", () => {

--- a/Tests/Library/Util.tests.ts
+++ b/Tests/Library/Util.tests.ts
@@ -153,6 +153,10 @@ describe("Library/Util", () => {
             test(11 * 3600000 + 11 * 60000 + 11111, "11:11:11.111", "all digits");
             test(5 * 86400000 + 13 * 3600000 + 9 * 60000 + 8 * 1000 + 789, "5.13:09:08.789", "all digits with days");
             test(1001.505, "00:00:01.001505", "fractional milliseconds");
+            test(1001.5, "00:00:01.0015", "fractional milliseconds - not all precision 1");
+            test(1001.55, "00:00:01.00155", "fractional milliseconds - not all precision 2");
+            test(1001.5059, "00:00:01.0015059", "fractional milliseconds - all digits");
+            test(1001.50559, "00:00:01.0015056", "fractional milliseconds - too many digits, round up");
         });
 
         it("should handle invalid input", () => {


### PR DESCRIPTION
Addresses #270 

@KamilSzostak perhaps JS SDK should use this as well instead of rounding to integer milliseconds?

This change adds support for a variable amount of subsecond precision (min 3 digits, max 7).