### PR TITLE
Fix flaky unit test failures in "Offline mode: disabled by default"

### DIFF
--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -205,10 +205,13 @@ describe("EndToEnd", () => {
 
     describe("Offline mode", () => {
         var AppInsights = require("../applicationinsights");
+        var CorrelationIdManager = require("../Library/CorrelationIdManager");
+        var cidStub: sinon.SinonStub = null;
 
 
         beforeEach(() => {
             AppInsights.client = undefined;
+            cidStub = sinon.stub(CorrelationIdManager, 'queryCorrelationId'); // TODO: Fix method of stubbing requests to allow CID to be part of E2E tests
             this.request = sinon.stub(https, 'request');
             this.writeFile = sinon.stub(fs, 'writeFile');
             this.writeFileSync = sinon.stub(fs, 'writeFileSync');
@@ -219,6 +222,7 @@ describe("EndToEnd", () => {
         });
 
         afterEach(()=> {
+            cidStub.restore();
             this.request.restore();
             this.writeFile.restore();
             this.exists.restore();


### PR DESCRIPTION
Addresses #273 

This test spuriously failed very frequently due to a race condition with the code to get AppId in `CorrelationIdManager`.  Root cause is the way these tests mock out https.request. The AppId call registers an error handler with the mocked request, which immediately calls the registered fail handler, which will sometimes be the test case's callback. This causes the callback to be called multiple times.

The fix here is to stub out the logic that queries for correlation id during the offline mode E2E tests that do this broken mocking of https.request. A full fix later that allows the AppId logic to remain without mocking would be to use more complicated stubs (like the one seen in EndToEnd/Basic Usage)