### PR TITLE
Fix CustomPropertiesImpl.serializeToHeader

### DIFF
--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -269,7 +269,7 @@ class CustomPropertiesImpl implements PrivateCustomProperties {
 
     public serializeToHeader() {
         return this.props.map((keyval) => {
-            `${keyval.key}=${keyval.value}`
+            return `${keyval.key}=${keyval.value}`
         }).join(", ");
     }
 


### PR DESCRIPTION
The mapping function was erroneously not returning a value, meaning that the contents of the Correlation-Context header were not preserved.