### PR TITLE
Fixing correlation header parsing

### DIFF
--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -259,9 +259,9 @@ class CustomPropertiesImpl implements PrivateCustomProperties {
         this.addHeaderData(header);
     }
     
-    public addHeaderData(header: string) {
-        header = header || "";
-        this.props = header.split(", ").map((keyval) => {
+    public addHeaderData(header?: string) {
+        const keyvals = header ? header.split(", ") || [];
+        this.props = keyvals.map((keyval) => {
             const parts = keyval.split("=");
             return {key: parts[0], value: parts[1]};
         }).concat(this.props);

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -260,7 +260,7 @@ class CustomPropertiesImpl implements PrivateCustomProperties {
     }
     
     public addHeaderData(header?: string) {
-        const keyvals = header ? header.split(", ") || [];
+        const keyvals = header ? header.split(", ") : [];
         this.props = keyvals.map((keyval) => {
             const parts = keyval.split("=");
             return {key: parts[0], value: parts[1]};


### PR DESCRIPTION
When no correlation-context was sent, it was mis-parsed as having an empty value rather than no value.
With this fix, it should now handle the case of no correlation-context, as well as invalid values such as `"foo="`, `"=foo"`, and `"foo"` as `{key: "foo", value: ''}`, `{key: '', value: 'foo'}`, and `{key: 'foo', value: ''}` respectively.