### PR TITLE
Remove throw on CorrelationContext.customProperties.setProperty

### DIFF
--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -5,7 +5,15 @@ import Logging = require("../Library/Logging");
 import {channel} from "diagnostic-channel";
 
 export interface CustomProperties {
+    /**
+     * Get a custom property from the correlation context
+     */
     getProperty(prop: string): string;
+    /**
+     * Store a custom property in the correlation context.
+     * Do not store sensitive information here.
+     * Properties stored here are exposed via outgoing HTTP headers for correlating data cross-component.
+     */
     setProperty(prop: string, val: string): void;
 }
 
@@ -289,7 +297,7 @@ class CustomPropertiesImpl implements PrivateCustomProperties {
     // properties. The logic here will need to change to track that.
     public setProperty(prop: string, val: string) {
         if (CustomPropertiesImpl.bannedCharacters.test(prop) || CustomPropertiesImpl.bannedCharacters.test(val)) {
-            Logging.warn("Correlation context property keys and values must not contain ',' or '='.");
+            Logging.warn("Correlation context property keys and values must not contain ',' or '='. setProperty was called with name: "+prop+" and value: "+ val);
             return;
         }
         for (let i = 0; i < this.props.length; ++i) {

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -1,5 +1,6 @@
 import http = require("http");
 import Util = require("../Library/Util");
+import Logging = require("../Library/Logging");
 
 import {channel} from "diagnostic-channel";
 
@@ -288,7 +289,8 @@ class CustomPropertiesImpl implements PrivateCustomProperties {
     // properties. The logic here will need to change to track that.
     public setProperty(prop: string, val: string) {
         if (CustomPropertiesImpl.bannedCharacters.test(prop) || CustomPropertiesImpl.bannedCharacters.test(val)) {
-            throw new Error("Keys and values must not contain ',' or '='");
+            Logging.warn("Correlation context property keys and values must not contain ',' or '='.");
+            return;
         }
         for (let i = 0; i < this.props.length; ++i) {
             const keyval = this.props[i];

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -297,7 +297,7 @@ class CustomPropertiesImpl implements PrivateCustomProperties {
     // properties. The logic here will need to change to track that.
     public setProperty(prop: string, val: string) {
         if (CustomPropertiesImpl.bannedCharacters.test(prop) || CustomPropertiesImpl.bannedCharacters.test(val)) {
-            Logging.warn("Correlation context property keys and values must not contain ',' or '='. setProperty was called with name: "+prop+" and value: "+ val);
+            Logging.warn("Correlation context property keys and values must not contain ',' or '='. setProperty was called with key: "+prop+" and value: "+ val);
             return;
         }
         for (let i = 0; i < this.props.length; ++i) {

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -297,7 +297,7 @@ class CustomPropertiesImpl implements PrivateCustomProperties {
     // properties. The logic here will need to change to track that.
     public setProperty(prop: string, val: string) {
         if (CustomPropertiesImpl.bannedCharacters.test(prop) || CustomPropertiesImpl.bannedCharacters.test(val)) {
-            Logging.warn("Correlation context property keys and values must not contain ',' or '='. setProperty was called with key: "+prop+" and value: "+ val);
+            Logging.warn("Correlation context property keys and values must not contain ',' or '='. setProperty was called with key: " + prop + " and value: "+ val);
             return;
         }
         for (let i = 0; i < this.props.length; ++i) {

--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -8,13 +8,14 @@ export interface CustomProperties {
     /**
      * Get a custom property from the correlation context
      */
-    getProperty(prop: string): string;
+    getProperty(key: string): string;
     /**
      * Store a custom property in the correlation context.
      * Do not store sensitive information here.
      * Properties stored here are exposed via outgoing HTTP headers for correlating data cross-component.
+     * The characters ',' and '=' are disallowed within keys or values.
      */
-    setProperty(prop: string, val: string): void;
+    setProperty(key: string, value: string): void;
 }
 
 export interface PrivateCustomProperties extends CustomProperties {


### PR DESCRIPTION
Replace with logging. If enabled, diagnostic channel should also convert this into a trace.