### PR TITLE
Updated diagnostic-channel, added subscribers for winston and pg

### DIFF
--- a/AutoCollection/diagnostic-channel/initialization.ts
+++ b/AutoCollection/diagnostic-channel/initialization.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-import {bunyan, console as consoleModule, mongodb, mysql, redis} from "diagnostic-channel-publishers";
+import {bunyan, console as consoleModule, mongodb, mongodbCore, mysql, redis, pg, pgPool, winston} from "diagnostic-channel-publishers";
 
 if (!process.env["APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL"]) {
     const individualOptOuts = process.env["APPLICATION_INSIGHTS_NO_PATCH_MODULES"] || "";
     const unpatchedModules = individualOptOuts.split(",");
-    const modules: {[key: string] : any} = {bunyan, console: consoleModule, mongodb, mysql, redis};
+    const modules: {[key: string] : any} = {bunyan, console: consoleModule, mongodb, mongodbCore, mysql, redis, pg, pgPool, winston};
     for (const mod in modules) {
         if (unpatchedModules.indexOf(mod) === -1) {
            modules[mod].enable();

--- a/AutoCollection/diagnostic-channel/postgres.sub.ts
+++ b/AutoCollection/diagnostic-channel/postgres.sub.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+import Client = require("../../Library/Client");
+import {channel, IStandardEvent} from "diagnostic-channel";
+
+import {pg} from "diagnostic-channel-publishers";
+
+let clients: Client[] = [];
+
+export const subscriber = (event: IStandardEvent<pg.IPostgresData>) => {
+    clients.forEach((client) => {
+        const q = event.data.query;
+        const sql = q.preparable.text || q.plan || q.text || "unknown query";
+        const success = !event.data.error;
+        const conn = `${event.data.database.host}:${event.data.database.port}`;
+        client.trackDependency(
+                conn,
+                sql,
+                event.data.duration | 0,
+                success,
+                "postgres");
+    });
+};
+
+export function enable(enabled: boolean, client: Client) {
+    if (enabled) {
+        if (clients.length === 0) {
+            channel.subscribe<pg.IPostgresData>("postgres", subscriber);
+        };
+        clients.push(client);
+    } else {
+        clients = clients.filter((c) => c != client);
+        if (clients.length === 0) {
+            channel.unsubscribe("postgres", subscriber);
+        }
+    }
+}

--- a/AutoCollection/diagnostic-channel/winston.sub.ts
+++ b/AutoCollection/diagnostic-channel/winston.sub.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+import Client = require("../../Library/Client");
+import {SeverityLevel} from "../../Declarations/Contracts";
+
+import {channel, IStandardEvent} from "diagnostic-channel";
+
+import {winston} from "diagnostic-channel-publishers";
+
+let clients: Client[] = [];
+
+const winstonToAILevelMap: {[key: string]: (og: string) => number} = {
+    syslog(og: string) {
+        return {
+            emerg: SeverityLevel.Critical,
+            alert: SeverityLevel.Critical,
+            crit: SeverityLevel.Critical,
+            error: SeverityLevel.Error,
+            warning: SeverityLevel.Warning,
+            notice: SeverityLevel.Information,
+            info: SeverityLevel.Information,
+            debug: SeverityLevel.Verbose
+        }[og] || SeverityLevel.Information;
+    },
+    npm(og: string) {
+        return {
+            error: SeverityLevel.Critical,
+            warn: SeverityLevel.Warning,
+            info: SeverityLevel.Information,
+            verbose: SeverityLevel.Verbose,
+            debug: SeverityLevel.Verbose,
+            silly: SeverityLevel.Verbose
+        }[og] || SeverityLevel.Information;
+    },
+    unknown(og: string) {
+        return SeverityLevel.Information;
+    }
+};
+
+const subscriber = (event: IStandardEvent<winston.IWinstonData>) => {
+    clients.forEach((client) => {
+        const AIlevel = winstonToAILevelMap[event.data.levelKind](event.data.level);
+        client.trackTrace(event.data.message, AIlevel, event.data.meta);
+    });
+};
+
+export function enable(enabled: boolean, client: Client) {
+    if (enabled) {
+        if (clients.length === 0) {
+            channel.subscribe<winston.IWinstonData>("winston", subscriber);
+        };
+        clients.push(client);
+    } else {
+        clients = clients.filter((c) => c != client);
+        if (clients.length === 0) {
+            channel.unsubscribe("winston", subscriber);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -104,15 +104,19 @@ appInsights.start();
 ### Automatic third-party instrumentation
 
 In order to track context across asynchronous calls, some changes are required in third party libraries such as mongodb and redis.
-By default ApplicationInsights will use `diagnostic-channel-publishers` to monkey-patch some of these libraries.
+By default ApplicationInsights will use [`diagnostic-channel-publishers`](https://github.com/Microsoft/node-diagnostic-channel/tree/master/src/diagnostic-channel-publishers)
+to monkey-patch some of these libraries.
 This can be disabled by setting the `APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL` environment variable. Note that by setting that
 environment variable, events may no longer be correctly associated with the right operation. Individual monkey-patches can be
 disabled by setting the `APPLICATION_INSIGHTS_NO_PATCH_MODULES` environment variable to a comma separated list of packages to
 disable, e.g. `APPLICATION_INSIGHTS_NO_PATCH_MODULES=console,redis` to avoid patching the `console` and `redis` packages.
 
-Currently there are 6 packages which are instrumented: `bunyan`, `console`, `mongodb`, `mongodb-core`, `mysql` and `redis`.
+Currently there are 9 packages which are instrumented: `bunyan`, `console`, `mongodb`, `mongodb-core`, `mysql`, `redis`, `winston`,
+`pg`, and `pg-pool`. Visit the [diagnostic-channel-publishers' README](https://github.com/Microsoft/node-diagnostic-channel/blob/master/src/diagnostic-channel-publishers/README.md)
+for information about exactly which versions of these packages are patched.
 
-The `bunyan` package and `console` messages will generate Application Insights Trace events based on whether `setAutoCollectConsole` is enabled. The `mongodb`, `mysql` and `redis` packages will generate Application Insights Dependency events based on whether `setAutoCollectDependencies` is enabled.
+The `bunyan`, `winston`, and `console` patches will generate Application Insights Trace events based on whether `setAutoCollectConsole` is enabled.
+The rest will generate Application Insights Dependency events based on whether `setAutoCollectDependencies` is enabled.
 
 ## Track custom metrics
 

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "sinon": "1.17.6"
   },
   "dependencies": {
-    "zone.js": "0.7.6",
-    "diagnostic-channel": "0.1.0",
-    "diagnostic-channel-publishers": "0.1.3"
+    "diagnostic-channel": "0.2.0",
+    "diagnostic-channel-publishers": "0.2.1",
+    "zone.js": "0.7.6"
   }
 }


### PR DESCRIPTION
Fixes #256

diagnostic-channel-publishers@0.2.0 added new publishers for pg@6.x, pg-pool@1.x, and winston@2.x, so I have added subscribers for those as well. Finally, I noticed that mongoCore was not being brought in and enabled by default, so I fixed that as well.

I checked that it built and passed all tests as well.