### PR TITLE
Address 0.22 issues

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,11 +1,19 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "0.1.0",
-    "command": "tsc",
+    "command": "npm",
     "isShellCommand": true,
-    "args": ["-w", "-p", "."],
     "showOutput": "silent",
-    "isWatching": true,
-    "problemMatcher": "$tsc-watch"
+    "suppressTaskName": true,
+    "tasks": [
+        {
+            "taskName": "test",
+            "args": ["run", "test"],
+            "isTestCommand": true
+        },
+        {
+            "taskName": "build",
+            "args": ["run", "build"],
+            "isTestCommand": false
+        }
+    ]
 }

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -8,6 +8,7 @@ import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
 import HttpRequestParser = require("./HttpRequestParser");
 import { CorrelationContextManager, CorrelationContext, PrivateCustomProperties } from "./CorrelationContextManager";
+import AutoColllectPerformance = require("./Performance");
 
 class AutoCollectHttpRequests {
 
@@ -175,6 +176,9 @@ class AutoCollectHttpRequests {
             Logging.info("AutoCollectHttpRequests.trackRequest was called with invalid parameters: ", !request, !response, !client);
             return;
         }
+
+        // Register performance counter monitor
+        AutoColllectPerformance.countRequest(request, response);
 
         // store data about the request
         var correlationContext = CorrelationContextManager.getCurrentContext();

--- a/AutoCollection/Performance.ts
+++ b/AutoCollection/Performance.ts
@@ -56,7 +56,7 @@ class AutoCollectPerformance {
     }
 
     public static countRequest(request: http.ServerRequest, response: http.ServerResponse) {
-        if (!AutoCollectPerformance.INSTANCE || !AutoCollectPerformance.INSTANCE._isEnabled) {
+        if (!AutoCollectPerformance.isEnabled()) {
             return;
         }
 
@@ -81,6 +81,10 @@ class AutoCollectPerformance {
 
     public isInitialized() {
         return this._isInitialized;
+    }
+
+    public static isEnabled() {
+        return AutoCollectPerformance.INSTANCE && AutoCollectPerformance.INSTANCE._isEnabled;
     }
 
     public trackPerformance() {
@@ -128,20 +132,12 @@ class AutoCollectPerformance {
                 // irq (or) % CPU time spent servicing/handling hardware interrupts
                 var irq = (times.irq - lastTimes.irq) || 0;
                 totalIrq += irq;
-
-                var total = (user + sys + nice + idle + irq) || 1; // don"t let this be 0 since it is a divisor
-                // this._client.trackMetric({name: name + "user", value: (user / total) * 100});
             }
 
-            // var combinedName = "% total cpu";
             var combinedTotal = (totalUser + totalSys + totalNice + totalIdle + totalIrq) || 1;
 
             this._client.trackMetric({name: "\\Processor(_Total)\\% Processor Time", value: ((combinedTotal - totalIdle) / combinedTotal) * 100});
             this._client.trackMetric({name: "\\Process(??APP_WIN32_PROC??)\\% Processor Time", value: (totalUser / combinedTotal) * 100});
-            // this._client.trackMetric({name: combinedName + " sys", value: (totalSys / combinedTotal) * 100});
-            // this._client.trackMetric({name: combinedName + " nice", value: (totalNice / combinedTotal) * 100});
-            // this._client.trackMetric({name: combinedName + " idle", value: (totalIdle / combinedTotal) * 100});
-            // this._client.trackMetric({name: combinedName + " irq", value: (totalIrq / combinedTotal) * 100});
         }
 
         this._lastCpus = cpus;
@@ -155,9 +151,6 @@ class AutoCollectPerformance {
         var percentAvailableMem = freeMem / (totalMem || 1);
         this._client.trackMetric({name:"\\Process(??APP_WIN32_PROC??)\\Private Bytes", value: usedMem});
         this._client.trackMetric({name: "\\Memory\\Available Bytes", value: freeMem});
-        // this._client.trackMetric({name: "Memory Total", value: totalMem});
-        // this._client.trackMetric({name: "% Memory Used", value: percentUsedMem * 100});
-        // this._client.trackMetric({name: "% Memory Free", value: percentAvailableMem * 100});
     }
 
     private _trackNetwork() {
@@ -178,10 +171,7 @@ class AutoCollectPerformance {
             var requestsPerSec = intervalRequests / elapsedSeconds;
             var failedRequestsPerSec = intervalFailedRequests / elapsedSeconds;
 
-            // this._client.trackMetric({ name: "Total Requests", value: requests.totalRequestCount });
-            // this._client.trackMetric({ name: "Total Failed Requests", value: requests.totalFailedRequestCount });
             this._client.trackMetric({ name: "\\ASP.NET Applications(??APP_W3SVC_PROC??)\\Requests/Sec", value: requestsPerSec });
-            // this._client.trackMetric({ name: "Failed Requests per Second", value: failedRequestsPerSec });
             this._client.trackMetric({ name: "\\ASP.NET Applications(??APP_W3SVC_PROC??)\\Request Execution Time", value: AutoCollectPerformance._lastRequestExecutionTime });
         }
 

--- a/Library/Channel.ts
+++ b/Library/Channel.ts
@@ -24,10 +24,12 @@ class Channel {
     }
 
     /**
-     * Enable or disable offline mode
+     * Enable or disable disk-backed retry caching to cache events when client is offline (enabled by default)
+     * @param value if true events that occured while client is offline will be cached on disk
+     * @param resendInterval. The wait interval for resending cached events.
      */
-    public setOfflineMode(value: boolean, resendInterval?: number) {
-        this._sender.setOfflineMode(value, resendInterval);
+    public setUseDiskRetryCaching(value: boolean, resendInterval?: number) {
+        this._sender.setDiskRetryMode(value, resendInterval);
     }
 
     /**

--- a/Library/Client.ts
+++ b/Library/Client.ts
@@ -81,7 +81,6 @@ class Client {
      * @param telemetry      Object encapsulating tracking options
      */
     public trackEvent(telemetry: EventTelemetry): void {
-
         this.track(telemetry, TelemetryType.Event);
     }
 
@@ -135,9 +134,9 @@ class Client {
 
             // Ideally we would have a central place for "internal" telemetry processors and users can configure which ones are in use.
             // This will do for now. Otherwise clearTelemetryProcessors() would be problematic.
-            var sampledIn = TelemetryProcessors.samplingTelemetryProcessor(envelope, { correlationContext: CorrelationContextManager.getCurrentContext() });
+            accepted = accepted && TelemetryProcessors.samplingTelemetryProcessor(envelope, { correlationContext: CorrelationContextManager.getCurrentContext() });
 
-            if (accepted && sampledIn) {
+            if (accepted) {
                 this.channel.send(envelope);
             }
         }

--- a/Library/Config.ts
+++ b/Library/Config.ts
@@ -10,29 +10,33 @@ class Config {
     public static legacy_ENV_iKey = "APPINSIGHTS_INSTRUMENTATION_KEY";
     public static ENV_profileQueryEndpoint = "APPINSIGHTS_PROFILE_QUERY_ENDPOINT";
 
+    /** An identifier for your Application Insights resource */
     public instrumentationKey: string;
+    /** The id for cross-component correlation. READ ONLY. */
     public correlationId: string;
-    public sessionRenewalMs: number;
-    public sessionExpirationMs: number;
+    /** The ingestion endpoint to send telemetry payloads to */
     public endpointUrl: string;
+    /** The maximum number of telemetry items to include in a payload to the ingestion endpoint (Default 250) */
     public maxBatchSize: number;
+    /** The maximum amount of time to wait for a payload to reach maxBatchSize (Default 1500) */
     public maxBatchIntervalMs: number;
+    /** A flag indicating if telemetry transmission is disabled (Default false) */
     public disableAppInsights: boolean;
+    /** The percentage of telemetry items tracked that should be transmitted (Default 100) */
     public samplingPercentage: number;
+    /** The time to wait before retrying to retrieve the id for cross-component correlation (Default 30000) */
     public correlationIdRetryIntervalMs: number;
+    /** A list of domains to exclude from cross-component header injection */
+    public correlationHeaderExcludedDomains: string[];
 
     private endpointBase: string = "https://dc.services.visualstudio.com";
     private setCorrelationId: (v: string) => void;
     private _profileQueryEndpoint: string;
-
-    // A list of domains for which correlation headers will not be added.
-    public correlationHeaderExcludedDomains: string[];
+    
 
     constructor(instrumentationKey?: string) {
         this.instrumentationKey = instrumentationKey || Config._getInstrumentationKey();
         this.endpointUrl = `${this.endpointBase}/v2/track`;
-        this.sessionRenewalMs = 30 * 60 * 1000;
-        this.sessionExpirationMs = 24 * 60 * 60 * 1000;
         this.maxBatchSize = 250;
         this.maxBatchIntervalMs = 15000;
         this.disableAppInsights = false;

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -20,22 +20,22 @@ class Sender {
     private _storageDirectory: string;
     private _onSuccess: (response: string) => void;
     private _onError: (error: Error) => void;
-    private _enableOfflineMode: boolean;
+    private _enableDiskRetryMode: boolean;
     protected _resendInterval: number;
 
     constructor(config: Config, onSuccess?: (response: string) => void, onError?: (error: Error) => void) {
         this._config = config;
         this._onSuccess = onSuccess;
         this._onError = onError;
-        this._enableOfflineMode = false;
+        this._enableDiskRetryMode = false;
         this._resendInterval = Sender.WAIT_BETWEEN_RESEND;
     }
 
     /**
     * Enable or disable offline mode
     */
-    public setOfflineMode(value: boolean, resendInterval?: number) {
-        this._enableOfflineMode = value;
+    public setDiskRetryMode(value: boolean, resendInterval?: number) {
+        this._enableDiskRetryMode = value;
         if (typeof resendInterval === 'number' && resendInterval >= 0) {
             this._resendInterval = Math.floor(resendInterval);
         }
@@ -96,7 +96,7 @@ class Sender {
                         callback(responseString);
                     }
 
-                    if (this._enableOfflineMode) {
+                    if (this._enableDiskRetryMode) {
                         // try to send any cached events if the user is back online
                         if (res.statusCode === 200) {
                             setTimeout(() => this._sendFirstFileOnDisk(), this._resendInterval);
@@ -128,7 +128,7 @@ class Sender {
                     callback(errorMessage);
                 }
 
-                if (this._enableOfflineMode) {
+                if (this._enableDiskRetryMode) {
                     this._storeToDisk(payload);
                 }
             });
@@ -139,7 +139,7 @@ class Sender {
     }
 
     public saveOnCrash(payload: string) {
-        if (this._enableOfflineMode) {
+        if (this._enableDiskRetryMode) {
             this._storeToDiskSync(payload);
         }
     }

--- a/README.md
+++ b/README.md
@@ -3,17 +3,24 @@
 [![npm version](https://badge.fury.io/js/applicationinsights.svg)](http://badge.fury.io/js/applicationinsights)
 [![Build Status](https://travis-ci.org/Microsoft/ApplicationInsights-node.js.svg?branch=master)](https://travis-ci.org/Microsoft/ApplicationInsights-node.js)
 
-[Azure Application Insights][] gathers correlated metrics, logs, and exceptions
-for each transaction (request) in a distributed system and reports these in the
-Azure Portal. Add this Node.js SDK to Node.js services in your system to include
-deep info about Node.js processes and their external dependencies such as
-database and cache services to those reports.
+[Azure Application Insights][] monitors your backend services and components after
+you deploy them to help you [discover and rapidly diagnose performance and other
+issues][]. Add this SDK to your Node.js services to include deep info about Node.js 
+processes and their external dependencies such as database and cache services.
+You can use this SDK for your Node.js services hosted anywhere: your datacenter,
+Azure VMs and Web Apps, and even other public clouds.
 
 [Azure Application Insights]: https://azure.microsoft.com/documentation/articles/app-insights-overview/
+[discover and rapidly diagnose performance and other issues]: https://docs.microsoft.com/azure/application-insights/app-insights-detect-triage-diagnose
 
-By default this library tracks incoming and outgoing HTTP requests, several
-system metrics, and exceptions. You can track more aspects of your app and
-system using the API described below.
+This library tracks the following out-of-the-box:
+- Incoming and outgoing HTTP requests
+- Important system metrics such as CPU usage
+- Unhandled exceptions
+- Events from many popular third-party libraries ([see Automatic third-party instrumentation](#automatic-third-party-instrumentation))
+
+You can manually track more aspects of your app and system using the API described in the
+[Track custom telemetry](#track-custom-telemetry) section.
 
 ## Getting Started
 
@@ -26,6 +33,8 @@ system using the API described below.
      ```bash
      npm install --save applicationinsights
      ```
+     > *Note:* If you're using TypeScript, do not install a separate "typings" package.
+     > This NPM package contains built-in typings.
 4. As early as possible in your app's code, load the Application Insights
    package:
      ```javascript
@@ -39,12 +48,13 @@ system using the API described below.
 6. Finally, start automatically collecting and sending data by calling
    `appInsights.start();`.
 
-[these instructions]: https://azure.microsoft.com/documentation/articles/app-insights-create-new-resource/
+[these instructions]: https://docs.microsoft.com/azure/application-insights/app-insights-nodejs
 
 
 ## Basic Usage
 
-To track HTTP requests, unhandled exceptions and system metrics:
+For out-of-the-box collection of HTTP requests, popular third-party library events,
+unhandled exceptions, and system metrics:
 
 ```javascript
 let appInsights = require("applicationinsights");
@@ -118,7 +128,7 @@ for information about exactly which versions of these packages are patched.
 The `bunyan`, `winston`, and `console` patches will generate Application Insights Trace events based on whether `setAutoCollectConsole` is enabled.
 The rest will generate Application Insights Dependency events based on whether `setAutoCollectDependencies` is enabled.
 
-## Track custom metrics
+## Track custom telemetry
 
 You can track any request, event, metric or exception using the Application
 Insights client. Examples follow:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ appInsights.setup("<instrumentation_key>")
     .setAutoCollectExceptions(true)
     .setAutoCollectDependencies(true)
     .setAutoCollectConsole(true)
+    .setUseDiskRetryCaching(true)
     .start();
 ```
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ let appInsights = require("applicationinsights");
 appInsights.setup("_ikey-A_").start();
 
 // track some events manually under another ikey
-let otherClient = appInsights.createClient("_ikey-B_");
+let otherClient = new appInsights.Client("_ikey-B_");
 otherClient.trackEvent({name: "my custom event"});
 ```
 
@@ -223,7 +223,7 @@ otherClient.trackEvent({name: "my custom event"});
 
     ```javascript
     let appInsights = require("applicationinsights");
-    let client = appInsights.createClient();
+    let client = new appInsights.Client();
 
     var success = false;
     let startTime = Date.now();

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Add code such as the following to enable sampling:
 ```javascript
 const appInsights = require("applicationinsights");
 appInsights.setup("<instrumentation_key>");
-appInsights.client.config.samplingPercentage = 33; // 33% of all telemetry will be sent to Application Insights
+appInsights.defaultClient.config.samplingPercentage = 33; // 33% of all telemetry will be sent to Application Insights
 appInsights.start();
 ```
 
@@ -136,7 +136,7 @@ Insights client. Examples follow:
 ```javascript
 let appInsights = require("applicationinsights");
 appInsights.setup().start(); // assuming ikey in env var. start() can be omitted to disable any non-custom data
-let client = appInsights.client;
+let client = appInsights.defaultClient;
 client.trackEvent({name: "my custom event", properties: {customProperty: "custom property value"}});
 client.trackException({exception: new Error("handled exceptions can be logged with this method")});
 client.trackMetric({name: "custom metric", value: 3});
@@ -193,7 +193,7 @@ function removeStackTraces ( envelope, context ) {
   return true;
 }
 
-appInsights.client.addTelemetryProcessor(removeStackTraces);
+appInsights.defaultClient.addTelemetryProcessor(removeStackTraces);
 ```
 
 More info on the telemetry API is available in [the docs][].
@@ -237,7 +237,7 @@ otherClient.trackEvent({name: "my custom event"});
 * Assign custom properties to be included with all events
 
     ```javascript
-    appInsights.client.commonProperties = {
+    appInsights.defaultClient.commonProperties = {
       environment: process.env.SOME_ENV_VARIABLE
     };
     ```
@@ -248,14 +248,14 @@ otherClient.trackEvent({name: "my custom event"});
     collection, call `.setAutoCollectRequests(false)` before calling `start()`.
 
     ```javascript
-    appInsights.client.trackRequest({name:"GET /customers", url:"http://myserver/customers", duration:309, resultCode:200, success:true});
+    appInsights.defaultClient.trackRequest({name:"GET /customers", url:"http://myserver/customers", duration:309, resultCode:200, success:true});
     ```
     Alternatively you can track requests using ```trackNodeHttpRequest``` method:   
 
     ```javascript
     var server = http.createServer((req, res) => {
       if ( req.method === "GET" ) {
-          appInsights.client.trackNodeHttpRequest({request:req, response:res});
+          appInsights.defaultClient.trackNodeHttpRequest({request:req, response:res});
       }
       // other work here....
       res.end();
@@ -268,9 +268,31 @@ otherClient.trackEvent({name: "my custom event"});
     let start = Date.now();
     server.on("listening", () => {
       let duration = Date.now() - start;
-      appInsights.client.trackMetric({name: "server startup time", value: duration});
+      appInsights.defaultClient.trackMetric({name: "server startup time", value: duration});
     });
     ```
+
+## Advanced configuration options
+The Client object contains a `config` property with many optional settings for 
+advanced scenarios. These can be set as follows:
+```
+client.config.PROPERTYNAME = VALUE;
+```
+These properties are client specific, so you can configure `appInsights.defaultClient` 
+separately from clients created with `new appInsights.Client()`.
+
+| Property                        | Description                                                                                                |
+| ------------------------------- |------------------------------------------------------------------------------------------------------------|
+| instrumentationKey              | An identifier for your Application Insights resource                                                       |
+| endpointUrl                     | The ingestion endpoint to send telemetry payloads to                                                       |
+| maxBatchSize                    | The maximum number of telemetry items to include in a payload to the ingestion endpoint (Default `250`)    |
+| maxBatchIntervalMs              | The maximum amount of time to wait to for a payload to reach maxBatchSize (Default `15000`)                |
+| disableAppInsights              | A flag indicating if telemetry transmission is disabled (Default `false`)                                  |
+| samplingPercentage              | The percentage of telemetry items tracked that should be transmitted (Default `100`)                       |
+| correlationIdRetryIntervalMs    | The time to wait before retrying to retrieve the id for cross-component correlation (Default `30000`)      |
+| correlationHeaderExcludedDomains| A list of domains to exclude from cross-component correlation header injection (Default See [Config.ts][]) |
+
+[Config.ts]: https://github.com/Microsoft/ApplicationInsights-node.js/blob/develop/Library/Config.ts
 
 ## Branches
 

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -133,7 +133,7 @@ describe("EndToEnd", () => {
         });
 
         it("should send telemetry", (done) => {
-            var client = AppInsights.createClient("iKey");
+            var client = new AppInsights.Client("iKey");
             client.trackEvent({ name: "test event" });
             client.trackException({ exception: new Error("test error") });
             client.trackMetric({ name: "test metric", value: 3 });
@@ -163,7 +163,7 @@ describe("EndToEnd", () => {
 
             var server = http.createServer((req: http.ServerRequest, res: http.ServerResponse) => {
                 setTimeout(() => {
-                    AppInsights.client.flush({
+                    AppInsights.defaultClient.flush({
                         callback: (response) => {
                             assert.ok(response, "response should not be empty");
                             done();
@@ -195,7 +195,7 @@ describe("EndToEnd", () => {
 
             var server = https.createServer(null, (req: http.ServerRequest, res: http.ServerResponse) => {
                 setTimeout(() => {
-                    AppInsights.client.flush({
+                    AppInsights.defaultClient.flush({
                         callback: (response) => {
                             assert.ok(response, "response should not be empty");
                             done();

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -212,7 +212,6 @@ describe("EndToEnd", () => {
     });
 
     describe("Offline mode", () => {
-        var AppInsights = require("../applicationinsights");
         var CorrelationIdManager = require("../Library/CorrelationIdManager");
         var cidStub: sinon.SinonStub = null;
         var writeFile: sinon.SinonStub;
@@ -220,7 +219,7 @@ describe("EndToEnd", () => {
         var readFile: sinon.SinonStub;
 
         beforeEach(() => {
-            AppInsights.client = undefined;
+            AppInsights.defaultClient = undefined;
             cidStub = sinon.stub(CorrelationIdManager, 'queryCorrelationId'); // TODO: Fix method of stubbing requests to allow CID to be part of E2E tests
             this.request = sinon.stub(https, 'request');
             writeFile = sinon.stub(fs, 'writeFile');
@@ -245,7 +244,7 @@ describe("EndToEnd", () => {
         it("disabled by default", (done) => {
             var req = new fakeRequest();
 
-            var client = AppInsights.createClient("key");
+            var client = new AppInsights.Client("key");
 
             client.trackEvent({ name: "test event" });
 
@@ -265,7 +264,7 @@ describe("EndToEnd", () => {
         it("stores data to disk when enabled", (done) => {
             var req = new fakeRequest();
 
-            var client = AppInsights.createClient("key");
+            var client = new AppInsights.Client("key");
             client.channel.setOfflineMode(true);
 
             client.trackEvent({ name: "test event" });
@@ -291,7 +290,7 @@ describe("EndToEnd", () => {
             var res = new fakeResponse();
             res.statusCode = 200;
 
-            var client = AppInsights.createClient("key");
+            var client = new AppInsights.Client("key");
             client.channel.setOfflineMode(true, 0);
 
             client.trackEvent({ name: "test event" });
@@ -317,7 +316,7 @@ describe("EndToEnd", () => {
         it("cache payload synchronously when process crashes", () => {
             var req = new fakeRequest(true);
 
-            var client = AppInsights.createClient("key");
+            var client = new AppInsights.Client("key");
             client.channel.setOfflineMode(true);
 
             client.trackEvent({ name: "test event" });

--- a/Tests/Library/Config.tests.ts
+++ b/Tests/Library/Config.tests.ts
@@ -41,11 +41,21 @@ describe("Library/Config", () => {
             var config = new Config("iKey");
             assert(typeof config.instrumentationKey === "string");
             assert(typeof config.endpointUrl === "string");
-            assert(typeof config.sessionRenewalMs === "number");
-            assert(typeof config.sessionExpirationMs === "number");
             assert(typeof config.maxBatchSize === "number");
             assert(typeof config.maxBatchIntervalMs === "number");
             assert(typeof config.disableAppInsights === "boolean");
+            assert(typeof config.samplingPercentage === "number");
+            assert(typeof config.correlationIdRetryIntervalMs === "number");
+            assert(typeof config.correlationHeaderExcludedDomains === "object");
+        });
+
+        it("should initialize values that we claim in README", () => {
+            var config = new Config("iKey");
+            assert(config.maxBatchSize === 250);
+            assert(config.maxBatchIntervalMs === 15000);
+            assert(config.disableAppInsights === false);
+            assert(config.samplingPercentage === 100);
+            assert(config.correlationIdRetryIntervalMs === 30000);
         });
 
         it("should add azure blob storage domain to excluded list", () => {

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -18,23 +18,23 @@ describe("Library/Sender", () => {
 
     describe("#setOfflineMode(value, resendInterval)", () => {
         it("default resend interval is 60 seconds", () => {
-            sender.setOfflineMode(true);
+            sender.setDiskRetryMode(true);
             assert.equal(Sender.WAIT_BETWEEN_RESEND, sender.getResendInterval());
         });
 
         it("resend interval can be configured", () => {
-            sender.setOfflineMode(true, 0);
+            sender.setDiskRetryMode(true, 0);
             assert.equal(0, sender.getResendInterval());
 
-            sender.setOfflineMode(true, 1234);
+            sender.setDiskRetryMode(true, 1234);
             assert.equal(1234, sender.getResendInterval());
 
-            sender.setOfflineMode(true, 1234.56);
+            sender.setDiskRetryMode(true, 1234.56);
             assert.equal(1234, sender.getResendInterval());
         });
 
         it("resend interval can't be negative", () => {
-            sender.setOfflineMode(true, -1234);
+            sender.setDiskRetryMode(true, -1234);
             assert.equal(Sender.WAIT_BETWEEN_RESEND, sender.getResendInterval());
         });
     });

--- a/Tests/applicationInsights.tests.ts
+++ b/Tests/applicationInsights.tests.ts
@@ -20,7 +20,7 @@ describe("ApplicationInsights", () => {
 
         it("should not warn if setup is called once", () => {
             var warnStub = sinon.stub(console, "warn");
-            AppInsights.client = undefined;
+            AppInsights.defaultClient = undefined;
             AppInsights.setup("key");
             assert.ok(warnStub.notCalled, "warning was not raised");
             warnStub.restore();
@@ -28,7 +28,7 @@ describe("ApplicationInsights", () => {
 
         it("should warn if setup is called twice", () => {
             var warnStub = sinon.stub(console, "warn");
-            AppInsights.client = undefined;
+            AppInsights.defaultClient = undefined;
             AppInsights.setup("key");
             AppInsights.setup("key");
             assert.ok(warnStub.calledOn, "warning was raised");
@@ -37,13 +37,13 @@ describe("ApplicationInsights", () => {
 
         it("should not overwrite default client if called more than once", () => {
             var warnStub = sinon.stub(console, "warn");
-            AppInsights.client = undefined;
+            AppInsights.defaultClient = undefined;
             AppInsights.setup("key");
-            var client = AppInsights.client;
+            var client = AppInsights.defaultClient;
             AppInsights.setup("key");
             AppInsights.setup("key");
             AppInsights.setup("key");
-            assert.ok(client === AppInsights.client, "client is not overwritten");
+            assert.ok(client === AppInsights.defaultClient, "client is not overwritten");
             warnStub.restore();
         });
     });
@@ -64,7 +64,7 @@ describe("ApplicationInsights", () => {
             HttpDependencies.INSTANCE = undefined;
         });
 
-        afterEach(() => AppInsights.client = undefined);
+        afterEach(() => AppInsights.defaultClient = undefined);
 
         it("should warn if start is called before setup", () => {
             var warnStub = sinon.stub(console, "warn");
@@ -90,7 +90,7 @@ describe("ApplicationInsights", () => {
         var HttpDependencies = require("../AutoCollection/HttpDependencies");
 
         beforeEach(() => {
-            AppInsights.client = undefined;
+            AppInsights.defaultClient = undefined;
             Console.INSTANCE = undefined;
             Exceptions.INSTANCE = undefined;
             Performance.INSTANCE = undefined;
@@ -133,7 +133,7 @@ describe("ApplicationInsights", () => {
         var Contracts = require("../Declarations/Contracts");
 
         it("should provide access to severity levels", () => {
-            assert.equal(AppInsights.contracts.SeverityLevel.Information, Contracts.SeverityLevel.Information);
+            assert.equal(AppInsights.Contracts.SeverityLevel.Information, Contracts.SeverityLevel.Information);
         });
     });
 });

--- a/Tests/js/endToEnd.js
+++ b/Tests/js/endToEnd.js
@@ -4,7 +4,7 @@ describe('module', function () {
     describe('#require', function () {
         it('loads the applicationinsights module', function (done) {
             // TODO(joshgav): do not use `assert`
-            assert.doesNotThrow(() => require('../..'));
+            assert.doesNotThrow(function() { return require('../..') });
             done();
         });
     });

--- a/Tests/js/endToEnd.js
+++ b/Tests/js/endToEnd.js
@@ -4,7 +4,7 @@ describe('module', function () {
     describe('#require', function () {
         it('loads the applicationinsights module', function (done) {
             // TODO(joshgav): do not use `assert`
-            assert.doesNotThrow(require('../..'));
+            assert.doesNotThrow(() => require('../..'));
             done();
         });
     });

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -235,7 +235,7 @@ export class Configuration {
      */
     public static setInternalLogging(enableDebugLogging = false, enableWarningLogging = true) {
         Logging.enableDebug = enableDebugLogging;
-        Logging.disableWarnings = enableWarningLogging;
+        Logging.disableWarnings = !enableWarningLogging;
         return Configuration;
     }
 }

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -44,7 +44,7 @@ export let defaultClient: Client;
  * @param instrumentationKey the instrumentation key to use. Optional, if
  * this is not specified, the value will be read from the environment
  * variable APPINSIGHTS_INSTRUMENTATIONKEY.
- * @returns {ConfigurationBuilder} the configuration class to initialize
+ * @returns {Configuration} the configuration class to initialize
  * and start the SDK.
  */
 export function setup(instrumentationKey?: string) {
@@ -129,7 +129,7 @@ export class Configuration {
     /**
      * Sets the state of console tracking (enabled by default)
      * @param value if true console activity will be sent to Application Insights
-     * @returns {ApplicationInsights} this class
+     * @returns {Configuration} this class
      */
     public static setAutoCollectConsole(value: boolean) {
         _isConsole = value;
@@ -143,7 +143,7 @@ export class Configuration {
     /**
      * Sets the state of exception tracking (enabled by default)
      * @param value if true uncaught exceptions will be sent to Application Insights
-     * @returns {ApplicationInsights} this class
+     * @returns {Configuration} this class
      */
     public static setAutoCollectExceptions(value: boolean) {
         _isExceptions = value;
@@ -157,7 +157,7 @@ export class Configuration {
     /**
      * Sets the state of performance tracking (enabled by default)
      * @param value if true performance counters will be collected every second and sent to Application Insights
-     * @returns {ApplicationInsights} this class
+     * @returns {Configuration} this class
      */
     public static setAutoCollectPerformance(value: boolean) {
         _isPerformance = value;
@@ -171,7 +171,7 @@ export class Configuration {
     /**
      * Sets the state of request tracking (enabled by default)
      * @param value if true requests will be sent to Application Insights
-     * @returns {ApplicationInsights} this class
+     * @returns {Configuration} this class
      */
     public static setAutoCollectRequests(value: boolean) {
         _isRequests = value;
@@ -185,7 +185,7 @@ export class Configuration {
     /**
      * Sets the state of dependency tracking (enabled by default)
      * @param value if true dependencies will be sent to Application Insights
-     * @returns {ApplicationInsights} this class
+     * @returns {Configuration} this class
      */
     public static setAutoCollectDependencies(value: boolean) {
         _isDependencies = value;
@@ -199,7 +199,7 @@ export class Configuration {
     /**
      * Sets the state of automatic dependency correlation (enabled by default)
      * @param value if true dependencies will be correlated with requests
-     * @returns {ApplicationInsights} this class
+     * @returns {Configuration} this class
      */
     public static setAutoDependencyCorrelation(value: boolean) {
         _isCorrelating = value;
@@ -216,7 +216,7 @@ export class Configuration {
      * For enable for additional clients, use client.channel.setUseDiskRetryCaching(true).
      * @param value if true events that occured while client is offline will be cached on disk
      * @param resendInterval. The wait interval for resending cached events.
-     * @returns {ApplicationInsights} this class
+     * @returns {Configuration} this class
      */
     public static setUseDiskRetryCaching(value: boolean, resendInterval?: number) {
         _isDiskRetry = value;
@@ -231,7 +231,7 @@ export class Configuration {
      * Enables debug and warning logging for AppInsights itself.
      * @param enableDebugLogging if true, enables debug logging
      * @param enableWarningLogging if true, enables warning logging
-     * @returns {ApplicationInsights} this class
+     * @returns {Configuration} this class
      */
     public static setInternalLogging(enableDebugLogging = false, enableWarningLogging = true) {
         Logging.enableDebug = enableDebugLogging;

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -66,6 +66,27 @@ export function setup(instrumentationKey?: string) {
     return Configuration;
 }
 
+/**
+ * Starts automatic collection of telemetry. Prior to calling start no
+ * telemetry will be *automatically* collected, though manual collection 
+ * is enabled.
+ * @returns {ApplicationInsights} this class
+ */
+export function start() {
+    if(!!defaultClient) {
+        _isStarted = true;
+        _console.enable(_isConsole);
+        _exceptions.enable(_isExceptions);
+        _performance.enable(_isPerformance);
+        _serverRequests.useAutoCorrelation(_isCorrelating);
+        _serverRequests.enable(_isRequests);
+        _clientRequests.enable(_isDependencies);
+    } else {
+        Logging.warn("Start cannot be called before setup");
+    }
+
+    return Configuration;
+}
 
 /**
  * Returns an object that is shared across all code handling a given request.
@@ -102,28 +123,8 @@ export function wrapWithCorrelationContext<T extends Function>(fn: T): T {
  * The active configuration for global SDK behaviors, such as autocollection.
  */
 export class Configuration {
-
-    /**
-     * Starts automatic collection of telemetry. Prior to calling start no
-     * telemetry will be *automatically* collected, though manual collection 
-     * is enabled.
-     * @returns {ApplicationInsights} this class
-     */
-    public static start() {
-        if(!!defaultClient) {
-            _isStarted = true;
-            _console.enable(_isConsole);
-            _exceptions.enable(_isExceptions);
-            _performance.enable(_isPerformance);
-            _serverRequests.useAutoCorrelation(_isCorrelating);
-            _serverRequests.enable(_isRequests);
-            _clientRequests.enable(_isDependencies);
-        } else {
-            Logging.warn("Start cannot be called before setup");
-        }
-
-        return Configuration;
-    }
+    // Convenience shortcut to ApplicationInsights.start
+    public static start = start;
 
     /**
      * Sets the state of console tracking (enabled by default)

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -4,285 +4,276 @@ import AutoCollectExceptions = require("./AutoCollection/Exceptions");
 import AutoCollectPerformance = require("./AutoCollection/Performance");
 import AutoCollectHttpDependencies = require("./AutoCollection/HttpDependencies");
 import AutoCollectHttpRequests = require("./AutoCollection/HttpRequests");
-import NodeClient = require("./Library/NodeClient");
 import Config = require("./Library/Config");
 import Context = require("./Library/Context");
-import Contracts = require("./Declarations/Contracts");
 import Logging = require("./Library/Logging");
 import Util = require("./Library/Util");
 
 /**
- * A singleton meta class for:
- *   * setting library-wide configuration options
- *   * setting up and starting the default client
- *   * creating additional clients
+* The default client, initialized when setup was called. To initialize a different client
+* with its own configuration, use `new Client(instrumentationKey?)`.
+*/
+export let defaultClient: Client;
+
+// We export these imports so that SDK users may use these classes directly.
+// They're exposed using "export import" so that types are passed along as expected
+export import Client = require("./Library/NodeClient");
+export import Contracts = require("./Declarations/Contracts");
+
+let _isConsole = true;
+let _isExceptions = true;
+let _isPerformance = true;
+let _isRequests = true;
+let _isDependencies = true;
+let _isOfflineMode = false;
+let _isCorrelating = true;
+
+let _console: AutoCollectConsole;
+let _exceptions: AutoCollectExceptions;
+let _performance: AutoCollectPerformance;
+let _serverRequests: AutoCollectHttpRequests;
+let _clientRequests: AutoCollectHttpDependencies;
+
+let _isStarted = false;
+
+/**
+ * Creates a new client with the given instrumentation key. If this is not
+ * specified, we try to read it from the environment variable
+ * APPINSIGHTS_INSTRUMENTATIONKEY.
+ * @returns {ApplicationInsights/Client} a new client
  */
-class ApplicationInsights {
-
-    /**
-    * Retrieves the default client, initialized when ApplicationInsights.setup was called. If you would like to initialize a different client
-    * potentially using different configuration options, use createClient API
-    */
-    public static client: NodeClient;
-    public static contracts = Contracts;
-
-    private static _isConsole = true;
-    private static _isExceptions = true;
-    private static _isPerformance = true;
-    private static _isRequests = true;
-    private static _isDependencies = true;
-    private static _isOfflineMode = false;
-    private static _isCorrelating = true;
-
-    private static _console: AutoCollectConsole;
-    private static _exceptions: AutoCollectExceptions;
-    private static _performance: AutoCollectPerformance;
-    private static _serverRequests: AutoCollectHttpRequests;
-    private static _clientRequests: AutoCollectHttpDependencies;
-
-    private static _isStarted = false;
-
-    /**
-     * Creates a new client with the given instrumentation key. If this is not
-     * specified, we try to read it from the environment variable
-     * APPINSIGHTS_INSTRUMENTATIONKEY.
-     * @returns {ApplicationInsights/Client} a new client
-     */
-    public static createClient(instrumentationKey?: string) {
-        return new NodeClient(instrumentationKey);
-    }
-
-    /**
-     * Initializes the default client. Should be called after setting
-     * configuration options.
-     * 
-     * @param instrumentationKey the instrumentation key to use. Optional, if
-     * this is not specified, the value will be read from the environment
-     * variable APPINSIGHTS_INSTRUMENTATIONKEY.
-     * @returns {ApplicationInsights} this class
-     */
-    public static setup(instrumentationKey?: string) {
-        if(!ApplicationInsights.client) {
-            ApplicationInsights.client = ApplicationInsights.createClient(instrumentationKey);
-            ApplicationInsights._console = new AutoCollectConsole(ApplicationInsights.client);
-            ApplicationInsights._exceptions = new AutoCollectExceptions(ApplicationInsights.client);
-            ApplicationInsights._performance = new AutoCollectPerformance(ApplicationInsights.client);
-            ApplicationInsights._serverRequests = new AutoCollectHttpRequests(ApplicationInsights.client);
-            ApplicationInsights._clientRequests = new AutoCollectHttpDependencies(ApplicationInsights.client);
-        } else {
-            Logging.info("The default client is already setup");
-        }
-
-        if (ApplicationInsights.client && ApplicationInsights.client.channel) {
-            ApplicationInsights.client.channel.setOfflineMode(ApplicationInsights._isOfflineMode);
-        }
-
-        return ApplicationInsights;
-    }
-
-    /**
-     * Starts automatic collection of telemetry. Prior to calling start no
-     * telemetry will be *automatically* collected, though manual collection 
-     * is enabled.
-     * @returns {ApplicationInsights} this class
-     */
-    public static start() {
-        if(!!this.client) {
-            ApplicationInsights._isStarted = true;
-            ApplicationInsights._console.enable(ApplicationInsights._isConsole);
-            ApplicationInsights._exceptions.enable(ApplicationInsights._isExceptions);
-            ApplicationInsights._performance.enable(ApplicationInsights._isPerformance);
-            ApplicationInsights._serverRequests.useAutoCorrelation(ApplicationInsights._isCorrelating);
-            ApplicationInsights._serverRequests.enable(ApplicationInsights._isRequests);
-            ApplicationInsights._clientRequests.enable(ApplicationInsights._isDependencies);
-        } else {
-            Logging.warn("Start cannot be called before setup");
-        }
-
-        return ApplicationInsights;
-    }
-
-    /**
-     * Returns an object that is shared across all code handling a given request.
-     * This can be used similarly to thread-local storage in other languages.
-     * Properties set on this object will be available to telemetry processors.
-     * 
-     * Do not store sensitive information here.
-     * Custom properties set on this object can be exposed in a future SDK
-     * release via outgoing HTTP headers.
-     * This is to allow for correlating data cross-component.
-     * 
-     * This method will return null if automatic dependency correlation is disabled.
-     * @returns A plain object for request storage or null if automatic dependency correlation is disabled.
-     */
-    public static getCorrelationContext(): CorrelationContextManager.CorrelationContext {
-        if (this._isCorrelating) {
-            return CorrelationContextManager.CorrelationContextManager.getCurrentContext();
-        }
-
-        return null;
-    }
-
-    /**
-     * Returns a function that will get the same correlation context within its
-     * function body as the code executing this function.
-     * Use this method if automatic dependency correlation is not propagating
-     * correctly to an asynchronous callback.
-     */
-    public static wrapWithCorrelationContext<T extends Function>(fn: T): T {
-        return CorrelationContextManager.CorrelationContextManager.wrapCallback(fn);
-    }
-
-    /**
-     * Sets the state of console tracking (enabled by default)
-     * @param value if true console activity will be sent to Application Insights
-     * @returns {ApplicationInsights} this class
-     */
-    public static setAutoCollectConsole(value: boolean) {
-        ApplicationInsights._isConsole = value;
-        if (ApplicationInsights._isStarted){
-            ApplicationInsights._console.enable(value);
-        }
-
-        return ApplicationInsights;
-    }
-
-    /**
-     * Sets the state of exception tracking (enabled by default)
-     * @param value if true uncaught exceptions will be sent to Application Insights
-     * @returns {ApplicationInsights} this class
-     */
-    public static setAutoCollectExceptions(value: boolean) {
-        ApplicationInsights._isExceptions = value;
-        if (ApplicationInsights._isStarted){
-            ApplicationInsights._exceptions.enable(value);
-        }
-
-        return ApplicationInsights;
-    }
-
-    /**
-     * Sets the state of performance tracking (enabled by default)
-     * @param value if true performance counters will be collected every second and sent to Application Insights
-     * @returns {ApplicationInsights} this class
-     */
-    public static setAutoCollectPerformance(value: boolean) {
-        ApplicationInsights._isPerformance = value;
-        if (ApplicationInsights._isStarted){
-            ApplicationInsights._performance.enable(value);
-        }
-
-        return ApplicationInsights;
-    }
-
-    /**
-     * Sets the state of request tracking (enabled by default)
-     * @param value if true requests will be sent to Application Insights
-     * @returns {ApplicationInsights} this class
-     */
-    public static setAutoCollectRequests(value: boolean) {
-        ApplicationInsights._isRequests = value;
-        if (ApplicationInsights._isStarted) {
-            ApplicationInsights._serverRequests.enable(value);
-        }
-
-        return ApplicationInsights;
-    }
-
-    /**
-     * Sets the state of dependency tracking (enabled by default)
-     * @param value if true dependencies will be sent to Application Insights
-     * @returns {ApplicationInsights} this class
-     */
-    public static setAutoCollectDependencies(value: boolean) {
-        ApplicationInsights._isDependencies = value;
-        if (ApplicationInsights._isStarted) {
-            ApplicationInsights._clientRequests.enable(value);
-        }
-
-        return ApplicationInsights;
-    }
-
-    /**
-     * Sets the state of automatic dependency correlation (enabled by default)
-     * @param value if true dependencies will be correlated with requests
-     * @returns {ApplicationInsights} this class
-     */
-    public static setAutoDependencyCorrelation(value: boolean) {
-        ApplicationInsights._isCorrelating = value;
-        if (ApplicationInsights._isStarted) {
-            ApplicationInsights._serverRequests.useAutoCorrelation(value);
-        }
-
-        return ApplicationInsights;
-    }
-
-     /**
-     * Enable or disable offline mode to cache events when client is offline (disabled by default)
-     * @param value if true events that occured while client is offline will be cached on disk
-     * @param resendInterval. The wait interval for resending cached events.
-     * @returns {ApplicationInsights} this class
-     */
-    public static setOfflineMode(value: boolean, resendInterval?: number) {
-        ApplicationInsights._isOfflineMode = value;
-        if (ApplicationInsights.client && ApplicationInsights.client.channel){
-            ApplicationInsights.client.channel.setOfflineMode(value, resendInterval);
-        }
-
-        return ApplicationInsights;
-    }
-
-    /**
-     * Enables debug and warning logging for AppInsights itself.
-     * @param enableWarningLogging also show warnings
-     * @returns {ApplicationInsights} this class
-     */
-    public static enableVerboseLogging(enableWarningLogging = true) {
-        Logging.enableDebug = true;
-        Logging.disableWarnings = !enableWarningLogging;
-        return ApplicationInsights;
-    }
-
-    /**
-     * Disables debug and warning logging for AppInsights itself.
-     * @returns {ApplicationInsights} this class
-     */
-    public static disableVerboseLogging() {
-        Logging.enableDebug = false;
-        Logging.disableWarnings = true;
-        return ApplicationInsights;
-    }
-
-    /**
-     * Deprecate me!!
-     */
-    public static disableConsoleLogging() {
-        console.warn('disableConsoleLogging has been deprecated in favor of disableVerboseLogging');
-        this.disableVerboseLogging();
-    }
-
-    /**
-      * Disposes the default client and all the auto collectors so they can be reinitialized with different configuration
-      */
-    public static dispose() {
-        ApplicationInsights.client = null;
-        ApplicationInsights._isStarted = false;
-        if (ApplicationInsights._console) {
-            ApplicationInsights._console.dispose();
-        }
-        if (ApplicationInsights._exceptions) {
-            ApplicationInsights._exceptions.dispose();
-        }
-        if (ApplicationInsights._performance) {
-            ApplicationInsights._performance.dispose();
-        }
-        if(ApplicationInsights._serverRequests) {
-            ApplicationInsights._serverRequests.dispose();
-        }
-        if(ApplicationInsights._clientRequests) {
-            ApplicationInsights._clientRequests.dispose();
-        }
-    }
+export function createClient(instrumentationKey?: string) {
+    return new Client(instrumentationKey);
 }
 
-export = ApplicationInsights;
+/**
+ * Initializes the default client. Should be called after setting
+ * configuration options.
+ * 
+ * @param instrumentationKey the instrumentation key to use. Optional, if
+ * this is not specified, the value will be read from the environment
+ * variable APPINSIGHTS_INSTRUMENTATIONKEY.
+ * @returns {ApplicationInsights} this class
+ */
+export function setup(instrumentationKey?: string) {
+    if(!defaultClient) {
+        defaultClient = createClient(instrumentationKey);
+        _console = new AutoCollectConsole(defaultClient);
+        _exceptions = new AutoCollectExceptions(defaultClient);
+        _performance = new AutoCollectPerformance(defaultClient);
+        _serverRequests = new AutoCollectHttpRequests(defaultClient);
+        _clientRequests = new AutoCollectHttpDependencies(defaultClient);
+    } else {
+        Logging.info("The default client is already setup");
+    }
+
+    if (defaultClient && defaultClient.channel) {
+        defaultClient.channel.setOfflineMode(_isOfflineMode);
+    }
+
+    return ApplicationInsights;
+}
+
+/**
+ * Starts automatic collection of telemetry. Prior to calling start no
+ * telemetry will be *automatically* collected, though manual collection 
+ * is enabled.
+ * @returns {ApplicationInsights} this class
+ */
+export function start() {
+    if(!!this.defaultClient) {
+        _isStarted = true;
+        _console.enable(_isConsole);
+        _exceptions.enable(_isExceptions);
+        _performance.enable(_isPerformance);
+        _serverRequests.useAutoCorrelation(_isCorrelating);
+        _serverRequests.enable(_isRequests);
+        _clientRequests.enable(_isDependencies);
+    } else {
+        Logging.warn("Start cannot be called before setup");
+    }
+
+    return ApplicationInsights;
+}
+
+/**
+ * Returns an object that is shared across all code handling a given request.
+ * This can be used similarly to thread-local storage in other languages.
+ * Properties set on this object will be available to telemetry processors.
+ * 
+ * Do not store sensitive information here.
+ * Custom properties set on this object can be exposed in a future SDK
+ * release via outgoing HTTP headers.
+ * This is to allow for correlating data cross-component.
+ * 
+ * This method will return null if automatic dependency correlation is disabled.
+ * @returns A plain object for request storage or null if automatic dependency correlation is disabled.
+ */
+export function getCorrelationContext(): CorrelationContextManager.CorrelationContext {
+    if (this._isCorrelating) {
+        return CorrelationContextManager.CorrelationContextManager.getCurrentContext();
+    }
+
+    return null;
+}
+
+/**
+ * Returns a function that will get the same correlation context within its
+ * function body as the code executing this function.
+ * Use this method if automatic dependency correlation is not propagating
+ * correctly to an asynchronous callback.
+ */
+export function wrapWithCorrelationContext<T extends Function>(fn: T): T {
+    return CorrelationContextManager.CorrelationContextManager.wrapCallback(fn);
+}
+
+/**
+ * Sets the state of console tracking (enabled by default)
+ * @param value if true console activity will be sent to Application Insights
+ * @returns {ApplicationInsights} this class
+ */
+export function setAutoCollectConsole(value: boolean) {
+    _isConsole = value;
+    if (_isStarted){
+        _console.enable(value);
+    }
+
+    return ApplicationInsights;
+}
+
+/**
+ * Sets the state of exception tracking (enabled by default)
+ * @param value if true uncaught exceptions will be sent to Application Insights
+ * @returns {ApplicationInsights} this class
+ */
+export function setAutoCollectExceptions(value: boolean) {
+    _isExceptions = value;
+    if (_isStarted){
+        _exceptions.enable(value);
+    }
+
+    return ApplicationInsights;
+}
+
+/**
+ * Sets the state of performance tracking (enabled by default)
+ * @param value if true performance counters will be collected every second and sent to Application Insights
+ * @returns {ApplicationInsights} this class
+ */
+export function setAutoCollectPerformance(value: boolean) {
+    _isPerformance = value;
+    if (_isStarted){
+        _performance.enable(value);
+    }
+
+    return ApplicationInsights;
+}
+
+/**
+ * Sets the state of request tracking (enabled by default)
+ * @param value if true requests will be sent to Application Insights
+ * @returns {ApplicationInsights} this class
+ */
+export function setAutoCollectRequests(value: boolean) {
+    _isRequests = value;
+    if (_isStarted) {
+        _serverRequests.enable(value);
+    }
+
+    return ApplicationInsights;
+}
+
+/**
+ * Sets the state of dependency tracking (enabled by default)
+ * @param value if true dependencies will be sent to Application Insights
+ * @returns {ApplicationInsights} this class
+ */
+export function setAutoCollectDependencies(value: boolean) {
+    _isDependencies = value;
+    if (_isStarted) {
+        _clientRequests.enable(value);
+    }
+
+    return ApplicationInsights;
+}
+
+/**
+ * Sets the state of automatic dependency correlation (enabled by default)
+ * @param value if true dependencies will be correlated with requests
+ * @returns {ApplicationInsights} this class
+ */
+export function setAutoDependencyCorrelation(value: boolean) {
+    _isCorrelating = value;
+    if (_isStarted) {
+        _serverRequests.useAutoCorrelation(value);
+    }
+
+    return ApplicationInsights;
+}
+
+    /**
+ * Enable or disable offline mode to cache events when client is offline (disabled by default)
+ * @param value if true events that occured while client is offline will be cached on disk
+ * @param resendInterval. The wait interval for resending cached events.
+ * @returns {ApplicationInsights} this class
+ */
+export function setOfflineMode(value: boolean, resendInterval?: number) {
+    _isOfflineMode = value;
+    if (defaultClient && defaultClient.channel){
+        defaultClient.channel.setOfflineMode(value, resendInterval);
+    }
+
+    return ApplicationInsights;
+}
+
+/**
+ * Enables debug and warning logging for AppInsights itself.
+ * @param enableWarningLogging also show warnings
+ * @returns {ApplicationInsights} this class
+ */
+export function enableVerboseLogging(enableWarningLogging = true) {
+    Logging.enableDebug = true;
+    Logging.disableWarnings = !enableWarningLogging;
+    return ApplicationInsights;
+}
+
+/**
+ * Disables debug and warning logging for AppInsights itself.
+ * @returns {ApplicationInsights} this class
+ */
+export function disableVerboseLogging() {
+    Logging.enableDebug = false;
+    Logging.disableWarnings = true;
+    return ApplicationInsights;
+}
+
+/**
+ * Deprecate me!!
+ */
+export function disableConsoleLogging() {
+    console.warn('disableConsoleLogging has been deprecated in favor of disableVerboseLogging');
+    this.disableVerboseLogging();
+}
+
+/**
+     * Disposes the default client and all the auto collectors so they can be reinitialized with different configuration
+    */
+export function dispose() {
+    defaultClient = null;
+    _isStarted = false;
+    if (_console) {
+        _console.dispose();
+    }
+    if (_exceptions) {
+        _exceptions.dispose();
+    }
+    if (_performance) {
+        _performance.dispose();
+    }
+    if(_serverRequests) {
+        _serverRequests.dispose();
+    }
+    if(_clientRequests) {
+        _clientRequests.dispose();
+    }
+}

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -20,7 +20,7 @@ let _isExceptions = true;
 let _isPerformance = true;
 let _isRequests = true;
 let _isDependencies = true;
-let _isOfflineMode = false;
+let _isDiskRetry = true;
 let _isCorrelating = true;
 
 let _console: AutoCollectConsole;
@@ -60,7 +60,7 @@ export function setup(instrumentationKey?: string) {
     }
 
     if (defaultClient && defaultClient.channel) {
-        defaultClient.channel.setOfflineMode(_isOfflineMode);
+        defaultClient.channel.setUseDiskRetryCaching(_isDiskRetry);
     }
 
     return Configuration;
@@ -210,16 +210,18 @@ export class Configuration {
         return Configuration;
     }
 
-        /**
-     * Enable or disable offline mode to cache events when client is offline (disabled by default)
+    /**
+     * Enable or disable disk-backed retry caching to cache events when client is offline (enabled by default)
+     * Note that this method only applies to the default client. Disk-backed retry caching is disabled by default for additional clients.
+     * For enable for additional clients, use client.channel.setUseDiskRetryCaching(true).
      * @param value if true events that occured while client is offline will be cached on disk
      * @param resendInterval. The wait interval for resending cached events.
      * @returns {ApplicationInsights} this class
      */
-    public static setOfflineMode(value: boolean, resendInterval?: number) {
-        _isOfflineMode = value;
+    public static setUseDiskRetryCaching(value: boolean, resendInterval?: number) {
+        _isDiskRetry = value;
         if (defaultClient && defaultClient.channel){
-            defaultClient.channel.setOfflineMode(value, resendInterval);
+            defaultClient.channel.setUseDiskRetryCaching(value, resendInterval);
         }
 
         return Configuration;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "applicationinsights",
   "license": "MIT",
   "bugs": "https://github.com/Microsoft/ApplicationInsights-node.js/issues",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Microsoft Application Insights module for Node.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "performance monitoring",
     "application insights",
     "microsoft",
-    "azure"
+    "azure",
+    "tracing",
+    "telemetry",
+    "analytics",
+    "apm"
   ],
   "contributors": [
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "target": "es5",
         "module": "commonjs",
+        "moduleResolution": "node",
         "sourceMap": true,
         "declaration": true,
         "noImplicitAny": true,


### PR DESCRIPTION
Addresses #269, #282, #289, #155. This also renames "offline mode" to "disk retry caching", adds it to documentation, and makes it enabled by default for the default client instance.

Of particular note is the changes for #269. Our current SDK with integrated typings has an issue where it's difficult to do things like this:
```var client: Client = appInsights.client```
This is because you don't have a direct reference to the `Client` class. Instead you must do `var client: typeof appInsights.client = appInsights.client`.

Similar issues are also present when using the contracts objects.

To solve this, this PR restructures our main applicationinsights module entry point, removing the class and placing the methods into a plain module and directly exporting `Client` and `Contracts`. This allows for direct reference to `Client`, for example, in the following ways:
```
// Previously unsupported es6 syntax
import { Client } from 'applicationinsights';
var client: Client = new Client(ikey);
-- or --
// Require syntax
var appInsights = require('applicationinsights');
var client: appInsights.Client = new appInsights.Client(ikey);
var defaultClient: appInsights.Client = appInsights.defaultClient
```

This removes the `createClient` API method in favor of the above approach and renames the default client from `appInsights.client` to `appInsights.defaultClient` for additional clarity.

For technical reasons for compatibility with this restructuring, the configuration builder approach when initializing this SDK is now inside it's own class, `Configuration`. The `setup` method returns this class, so the following snippet still works as is:
```
appInsights.setup("<instrumentation_key>")
    .setAutoDependencyCorrelation(true)
    .setAutoCollectRequests(true)
    .setAutoCollectPerformance(true)
    .setAutoCollectExceptions(true)
    .setAutoCollectDependencies(true)
    .setAutoCollectConsole(true)
    .start();
```
However, if you wish to configure options outside of this builder scenario, you can no longer call `setX` methods directly on `appInsights`. Instead, they are available directly from `appInsights.Configuration.setX`
