### PR TITLE
Rename Client -> TelemetryClient for API consistency 

### DIFF
--- a/AutoCollection/Console.ts
+++ b/AutoCollection/Console.ts
@@ -1,4 +1,4 @@
-import Client = require("../Library/TelemetryClient");
+import TelemetryClient = require("../Library/TelemetryClient");
 import Logging = require("../Library/Logging");
 
 import {enable as enableConsole} from "./diagnostic-channel/console.sub";
@@ -12,10 +12,10 @@ class AutoCollectConsole {
     public static INSTANCE: AutoCollectConsole;
     private static _methodNames = ["debug", "info", "log", "warn", "error"];
 
-    private _client: Client;
+    private _client: TelemetryClient;
     private _isInitialized: boolean;
 
-    constructor(client: Client) {
+    constructor(client: TelemetryClient) {
         if(!!AutoCollectConsole.INSTANCE) {
             throw new Error("Console logging adapter tracking should be configured from the applicationInsights object");
         }

--- a/AutoCollection/Console.ts
+++ b/AutoCollection/Console.ts
@@ -1,4 +1,4 @@
-import Client = require("../Library/Client");
+import Client = require("../Library/TelemetryClient");
 import Logging = require("../Library/Logging");
 
 import {enable as enableConsole} from "./diagnostic-channel/console.sub";

--- a/AutoCollection/Exceptions.ts
+++ b/AutoCollection/Exceptions.ts
@@ -1,7 +1,7 @@
 import http = require("http");
 
 import Contracts = require("../Declarations/Contracts");
-import Client = require("../Library/TelemetryClient");
+import TelemetryClient = require("../Library/TelemetryClient");
 import Sender = require("../Library/Sender");
 import Queue = require("../Library/Channel");
 import Util = require("../Library/Util");
@@ -14,10 +14,10 @@ class AutoCollectExceptions {
 
     private _exceptionListenerHandle: (reThrow: boolean, error: Error) => void;
     private _rejectionListenerHandle: (reThrow: boolean, error: Error) => void;
-    private _client: Client;
+    private _client: TelemetryClient;
     private _isInitialized: boolean;
 
-    constructor(client: Client) {
+    constructor(client: TelemetryClient) {
         if (!!AutoCollectExceptions.INSTANCE) {
             throw new Error("Exception tracking should be configured from the applicationInsights object");
         }

--- a/AutoCollection/Exceptions.ts
+++ b/AutoCollection/Exceptions.ts
@@ -1,7 +1,7 @@
 import http = require("http");
 
 import Contracts = require("../Declarations/Contracts");
-import Client = require("../Library/Client");
+import Client = require("../Library/TelemetryClient");
 import Sender = require("../Library/Sender");
 import Queue = require("../Library/Channel");
 import Util = require("../Library/Util");

--- a/AutoCollection/HttpDependencies.ts
+++ b/AutoCollection/HttpDependencies.ts
@@ -2,7 +2,7 @@ import http = require("http");
 import https = require("https");
 import url = require("url");
 
-import Client = require("../Library/Client");
+import TelemetryClient = require("../Library/TelemetryClient");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
@@ -22,11 +22,11 @@ class AutoCollectHttpDependencies {
 
     private static requestNumber = 1;
 
-    private _client: Client;
+    private _client: TelemetryClient;
     private _isEnabled: boolean;
     private _isInitialized: boolean;
 
-    constructor(client: Client) {
+    constructor(client: TelemetryClient) {
         if (!!AutoCollectHttpDependencies.INSTANCE) {
             throw new Error("Client request tracking should be configured from the applicationInsights object");
         }
@@ -82,7 +82,7 @@ class AutoCollectHttpDependencies {
      * Tracks an outgoing request. Because it may set headers this method must be called before
      * writing content to or ending the request.
      */
-    public static trackRequest(client: Client, requestOptions: string | http.RequestOptions | https.RequestOptions, request: http.ClientRequest,
+    public static trackRequest(client: TelemetryClient, requestOptions: string | http.RequestOptions | https.RequestOptions, request: http.ClientRequest,
         properties?: { [key: string]: string }) {
         if (!requestOptions || !request || !client) {
             Logging.info("AutoCollectHttpDependencies.trackRequest was called with invalid parameters: ", !requestOptions, !request, !client);

--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -3,7 +3,7 @@ import https = require("https");
 import url = require("url");
 
 import Contracts = require("../Declarations/Contracts");
-import Client = require("../Library/Client");
+import TelemetryClient = require("../Library/TelemetryClient");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");

--- a/AutoCollection/HttpRequestParser.ts
+++ b/AutoCollection/HttpRequestParser.ts
@@ -2,7 +2,7 @@ import http = require("http");
 import url = require("url");
 
 import Contracts = require("../Declarations/Contracts");
-import Client = require("../Library/Client");
+import Client = require("../Library/TelemetryClient");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");

--- a/AutoCollection/HttpRequestParser.ts
+++ b/AutoCollection/HttpRequestParser.ts
@@ -2,7 +2,7 @@ import http = require("http");
 import url = require("url");
 
 import Contracts = require("../Declarations/Contracts");
-import Client = require("../Library/TelemetryClient");
+import TelemetryClient = require("../Library/TelemetryClient");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -2,7 +2,7 @@ import http = require("http");
 import https = require("https");
 import url = require("url");
 
-import Client = require("../Library/Client");
+import Client = require("../Library/TelemetryClient");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -2,7 +2,7 @@ import http = require("http");
 import https = require("https");
 import url = require("url");
 
-import Client = require("../Library/TelemetryClient");
+import TelemetryClient = require("../Library/TelemetryClient");
 import Logging = require("../Library/Logging");
 import Util = require("../Library/Util");
 import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
@@ -14,12 +14,12 @@ class AutoCollectHttpRequests {
 
     public static INSTANCE:AutoCollectHttpRequests;
 
-    private _client:Client;
+    private _client: TelemetryClient;
     private _isEnabled: boolean;
     private _isInitialized: boolean;
     private _isAutoCorrelating: boolean;
 
-    constructor(client:Client) {
+    constructor(client: TelemetryClient) {
         if (!!AutoCollectHttpRequests.INSTANCE) {
             throw new Error("Server request tracking should be configured from the applicationInsights object");
         }
@@ -153,7 +153,7 @@ class AutoCollectHttpRequests {
     /**
      * Tracks a request synchronously (doesn't wait for response 'finish' event)
      */
-    public static trackRequestSync(client: Client, request: http.ServerRequest, response:http.ServerResponse, ellapsedMilliseconds?: number, properties?:{ [key: string]: string; }, error?: any) {
+    public static trackRequestSync(client: TelemetryClient, request: http.ServerRequest, response:http.ServerResponse, ellapsedMilliseconds?: number, properties?:{ [key: string]: string; }, error?: any) {
         if (!request || !response || !client) {
             Logging.info("AutoCollectHttpRequests.trackRequestSync was called with invalid parameters: ", !request, !response, !client);
             return;
@@ -179,7 +179,7 @@ class AutoCollectHttpRequests {
     /**
      * Tracks a request by listening to the response 'finish' event
      */
-    public static trackRequest(client:Client, request:http.ServerRequest, response:http.ServerResponse, properties?:{ [key: string]: string; }, _requestParser?:HttpRequestParser) {
+    public static trackRequest(client: TelemetryClient, request:http.ServerRequest, response:http.ServerResponse, properties?:{ [key: string]: string; }, _requestParser?:HttpRequestParser) {
         if (!request || !response || !client) {
             Logging.info("AutoCollectHttpRequests.trackRequest was called with invalid parameters: ", !request, !response, !client);
             return;
@@ -219,7 +219,7 @@ class AutoCollectHttpRequests {
     /**
      * Add the target correlationId to the response headers, if not already provided.
      */
-    private static addResponseCorrelationIdHeader(client:Client, response:http.ServerResponse) {
+    private static addResponseCorrelationIdHeader(client: TelemetryClient, response:http.ServerResponse) {
         if (client.config && client.config.correlationId &&
             response.getHeader && response.setHeader && !(<any>response).headersSent) {
             const correlationHeader = response.getHeader(RequestResponseHeaders.requestContextHeader);
@@ -239,7 +239,7 @@ class AutoCollectHttpRequests {
         }
     }
 
-    private static endRequest(client: Client, requestParser: HttpRequestParser, request: http.ServerRequest, response: http.ServerResponse, ellapsedMilliseconds?: number, properties?: { [key: string]: string}, error?: any) {
+    private static endRequest(client: TelemetryClient, requestParser: HttpRequestParser, request: http.ServerRequest, response: http.ServerResponse, ellapsedMilliseconds?: number, properties?: { [key: string]: string}, error?: any) {
         if (error) {
             requestParser.onError(error, properties, ellapsedMilliseconds);
         } else {

--- a/AutoCollection/Performance.ts
+++ b/AutoCollection/Performance.ts
@@ -1,7 +1,7 @@
 import http = require("http");
 import os = require("os");
 
-import Client = require("../Library/TelemetryClient");
+import TelemetryClient = require("../Library/TelemetryClient");
 import Contracts = require("../Declarations/Contracts");
 import Logging = require("../Library/Logging");
 
@@ -13,14 +13,14 @@ class AutoCollectPerformance {
     private static _totalFailedRequestCount: number = 0;
     private static _lastRequestExecutionTime: number = 0;
 
-    private _client: Client;
+    private _client: TelemetryClient;
     private _handle: NodeJS.Timer;
     private _isEnabled: boolean;
     private _isInitialized: boolean;
     private _lastCpus: { model: string; speed: number; times: { user: number; nice: number; sys: number; idle: number; irq: number; }; }[];
     private _lastRequests: { totalRequestCount: number; totalFailedRequestCount: number; time: number; };
 
-    constructor(client: Client) {
+    constructor(client: TelemetryClient) {
         if (!!AutoCollectPerformance.INSTANCE) {
             throw new Error("Performance tracking should be configured from the applicationInsights object");
         }

--- a/AutoCollection/Performance.ts
+++ b/AutoCollection/Performance.ts
@@ -1,7 +1,7 @@
 import http = require("http");
 import os = require("os");
 
-import Client = require("../Library/Client");
+import Client = require("../Library/TelemetryClient");
 import Contracts = require("../Declarations/Contracts");
 import Logging = require("../Library/Logging");
 

--- a/AutoCollection/diagnostic-channel/bunyan.sub.ts
+++ b/AutoCollection/diagnostic-channel/bunyan.sub.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/Client");
+import Client = require("../../Library/TelemetryClient");
 import {SeverityLevel} from "../../Declarations/Contracts";
 
 import {channel, IStandardEvent} from "diagnostic-channel";

--- a/AutoCollection/diagnostic-channel/bunyan.sub.ts
+++ b/AutoCollection/diagnostic-channel/bunyan.sub.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/TelemetryClient");
+import TelemetryClient = require("../../Library/TelemetryClient");
 import {SeverityLevel} from "../../Declarations/Contracts";
 
 import {channel, IStandardEvent} from "diagnostic-channel";
 
 import {bunyan} from "diagnostic-channel-publishers";
 
-let clients: Client[] = [];
+let clients: TelemetryClient[] = [];
 
 // Mapping from bunyan levels defined at https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L256
 const bunyanToAILevelMap: {[key: number] : number} = {
@@ -26,7 +26,7 @@ const subscriber = (event: IStandardEvent<bunyan.IBunyanData>) => {
     });
 };
 
-export function enable(enabled: boolean, client: Client) {
+export function enable(enabled: boolean, client: TelemetryClient) {
     if (enabled) {
         if (clients.length === 0) {
             channel.subscribe<bunyan.IBunyanData>("bunyan", subscriber);

--- a/AutoCollection/diagnostic-channel/console.sub.ts
+++ b/AutoCollection/diagnostic-channel/console.sub.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/Client");
+import Client = require("../../Library/TelemetryClient");
 import {SeverityLevel} from "../../Declarations/Contracts";
 
 import {channel, IStandardEvent} from "diagnostic-channel";

--- a/AutoCollection/diagnostic-channel/console.sub.ts
+++ b/AutoCollection/diagnostic-channel/console.sub.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/TelemetryClient");
+import TelemetryClient = require("../../Library/TelemetryClient");
 import {SeverityLevel} from "../../Declarations/Contracts";
 
 import {channel, IStandardEvent} from "diagnostic-channel";
 
 import {console as consolePub} from "diagnostic-channel-publishers";
 
-let clients: Client[] = [];
+let clients: TelemetryClient[] = [];
 
 const subscriber = (event: IStandardEvent<consolePub.IConsoleData>) => {
     clients.forEach((client) => {
@@ -15,7 +15,7 @@ const subscriber = (event: IStandardEvent<consolePub.IConsoleData>) => {
     });
 };
 
-export function enable(enabled: boolean, client: Client) {
+export function enable(enabled: boolean, client: TelemetryClient) {
     if (enabled) {
         if (clients.length === 0) {
             channel.subscribe<consolePub.IConsoleData>("console", subscriber);

--- a/AutoCollection/diagnostic-channel/mongodb.sub.ts
+++ b/AutoCollection/diagnostic-channel/mongodb.sub.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/Client");
+import TelemetryClient = require("../../Library/TelemetryClient");
 import { channel, IStandardEvent } from "diagnostic-channel";
 
 import { mongodb } from "diagnostic-channel-publishers";
 
-let clients: Client[] = [];
+let clients: TelemetryClient[] = [];
 
 export const subscriber = (event: IStandardEvent<mongodb.IMongoData>) => {
     clients.forEach((client) => {
@@ -28,7 +28,7 @@ export const subscriber = (event: IStandardEvent<mongodb.IMongoData>) => {
     });
 };
 
-export function enable(enabled: boolean, client: Client) {
+export function enable(enabled: boolean, client: TelemetryClient) {
     if (enabled) {
         if (clients.length === 0) {
             channel.subscribe<mongodb.IMongoData>("mongodb", subscriber);

--- a/AutoCollection/diagnostic-channel/mysql.sub.ts
+++ b/AutoCollection/diagnostic-channel/mysql.sub.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/Client");
+import TelemetryClient = require("../../Library/TelemetryClient");
 import {channel, IStandardEvent} from "diagnostic-channel";
 
 import {mysql} from "diagnostic-channel-publishers";
 
-let clients: Client[] = [];
+let clients: TelemetryClient[] = [];
 
 export const subscriber = (event: IStandardEvent<mysql.IMysqlData>) => {
     clients.forEach((client) => {
@@ -30,7 +30,7 @@ export const subscriber = (event: IStandardEvent<mysql.IMysqlData>) => {
     });
 };
 
-export function enable(enabled: boolean, client: Client) {
+export function enable(enabled: boolean, client: TelemetryClient) {
     if (enabled) {
         if (clients.length === 0) {
             channel.subscribe<mysql.IMysqlData>("mysql", subscriber);

--- a/AutoCollection/diagnostic-channel/postgres.sub.ts
+++ b/AutoCollection/diagnostic-channel/postgres.sub.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/TelemetryClient");
+import TelemetryClient = require("../../Library/TelemetryClient");
 import { channel, IStandardEvent } from "diagnostic-channel";
 
 import { pg } from "diagnostic-channel-publishers";
 
-let clients: Client[] = [];
+let clients: TelemetryClient[] = [];
 
 export const subscriber = (event: IStandardEvent<pg.IPostgresData>) => {
     clients.forEach((client) => {
@@ -24,7 +24,7 @@ export const subscriber = (event: IStandardEvent<pg.IPostgresData>) => {
     });
 };
 
-export function enable(enabled: boolean, client: Client) {
+export function enable(enabled: boolean, client: TelemetryClient) {
     if (enabled) {
         if (clients.length === 0) {
             channel.subscribe<pg.IPostgresData>("postgres", subscriber);

--- a/AutoCollection/diagnostic-channel/postgres.sub.ts
+++ b/AutoCollection/diagnostic-channel/postgres.sub.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/Client");
+import Client = require("../../Library/TelemetryClient");
 import { channel, IStandardEvent } from "diagnostic-channel";
 
 import { pg } from "diagnostic-channel-publishers";

--- a/AutoCollection/diagnostic-channel/redis.sub.ts
+++ b/AutoCollection/diagnostic-channel/redis.sub.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/Client");
+import TelemetryClient = require("../../Library/TelemetryClient");
 import { channel, IStandardEvent } from "diagnostic-channel";
 
 import { redis } from "diagnostic-channel-publishers";
 
-let clients: Client[] = [];
+let clients: TelemetryClient[] = [];
 
 export const subscriber = (event: IStandardEvent<redis.IRedisData>) => {
     clients.forEach((client) => {
@@ -28,7 +28,7 @@ export const subscriber = (event: IStandardEvent<redis.IRedisData>) => {
     });
 };
 
-export function enable(enabled: boolean, client: Client) {
+export function enable(enabled: boolean, client: TelemetryClient) {
     if (enabled) {
         if (clients.length === 0) {
             channel.subscribe<redis.IRedisData>("redis", subscriber);

--- a/AutoCollection/diagnostic-channel/winston.sub.ts
+++ b/AutoCollection/diagnostic-channel/winston.sub.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/TelemetryClient");
+import TelemetryClient = require("../../Library/TelemetryClient");
 import { SeverityLevel } from "../../Declarations/Contracts";
 
 import { channel, IStandardEvent } from "diagnostic-channel";
 
 import { winston } from "diagnostic-channel-publishers";
 
-let clients: Client[] = [];
+let clients: TelemetryClient[] = [];
 
 const winstonToAILevelMap: { [key: string]: (og: string) => number } = {
     syslog(og: string) {
@@ -49,7 +49,7 @@ const subscriber = (event: IStandardEvent<winston.IWinstonData>) => {
     });
 };
 
-export function enable(enabled: boolean, client: Client) {
+export function enable(enabled: boolean, client: TelemetryClient) {
     if (enabled) {
         if (clients.length === 0) {
             channel.subscribe<winston.IWinstonData>("winston", subscriber);

--- a/AutoCollection/diagnostic-channel/winston.sub.ts
+++ b/AutoCollection/diagnostic-channel/winston.sub.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
-import Client = require("../../Library/Client");
+import Client = require("../../Library/TelemetryClient");
 import { SeverityLevel } from "../../Declarations/Contracts";
 
 import { channel, IStandardEvent } from "diagnostic-channel";

--- a/Library/NodeClient.ts
+++ b/Library/NodeClient.ts
@@ -1,6 +1,6 @@
 import http = require("http")
 import https = require("https")
-import Client = require("./TelemetryClient")
+import TelemetryClient = require("./TelemetryClient")
 import ServerRequestTracking = require("../AutoCollection/HttpRequests")
 import ClientRequestTracking = require("../AutoCollection/HttpDependencies")
 import NodeHttpDependencyTelemetry = require("./TelemetryTypes/NodeHttpDependencyTelemetry")
@@ -13,7 +13,7 @@ import Logging = require("./Logging")
  * Construct a new TelemetryClient to have an instance with a different configuration than the default client.
  * In most cases, `appInsights.defaultClient` should be used instead.
  */
-class NodeClient extends Client {
+class NodeClient extends TelemetryClient {
 
     /**
      * Log RequestTelemetry from HTTP request and response. This method will log immediately without waitng for request completion

--- a/Library/NodeClient.ts
+++ b/Library/NodeClient.ts
@@ -1,6 +1,6 @@
 import http = require("http")
 import https = require("https")
-import Client = require("./Client")
+import Client = require("./TelemetryClient")
 import ServerRequestTracking = require("../AutoCollection/HttpRequests")
 import ClientRequestTracking = require("../AutoCollection/HttpDependencies")
 import NodeHttpDependencyTelemetry = require("./TelemetryTypes/NodeHttpDependencyTelemetry")
@@ -8,8 +8,10 @@ import NodeHttpRequestTelemetry = require("./TelemetryTypes/NodeHttpRequestTelem
 import Logging = require("./Logging")
 
 /**
- * Application Insights telemetry client for Node.JS extends base Client object to provide Node.JS-specific methods
- * to track incoming and outgoing HTTP requests.
+ * Application Insights Telemetry Client for Node.JS. Provides the Application Insights TelemetryClient API
+ * in addition to Node-specific helper functions.
+ * Construct a new TelemetryClient to have an instance with a different configuration than the default client.
+ * In most cases, `appInsights.defaultClient` should be used instead.
  */
 class NodeClient extends Client {
 

--- a/Library/TelemetryClient.ts
+++ b/Library/TelemetryClient.ts
@@ -25,7 +25,7 @@ import TelemetryType = require("./TelemetryTypes/TelemetryType")
  * Application Insights telemetry client provides interface to track telemetry items, register telemetry initializers and
  * and manually trigger immediate sending (flushing)
  */
-class Client {
+class TelemetryClient {
     private _telemetryProcessors: { (envelope: Contracts.Envelope, contextObjects: { [name: string]: any; }): boolean; }[] = [];
 
     public config: Config;
@@ -193,4 +193,4 @@ class Client {
     }
 }
 
-export = Client;
+export = TelemetryClient;

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -2,7 +2,7 @@
 import url = require("url");
 
 import Logging = require("./Logging");
-import Client = require("../Library/Client");
+import TelemetryClient = require("../Library/TelemetryClient");
 import RequestResponseHeaders = require("./RequestResponseHeaders");
 
 class Util {
@@ -169,7 +169,7 @@ class Util {
      * Checks if a request url is not on a excluded domain list 
      * and if it is safe to add correlation headers
      */
-    public static canIncludeCorrelationHeader(client: Client, requestUrl: string) {
+    public static canIncludeCorrelationHeader(client: TelemetryClient, requestUrl: string) {
         let excludedDomains = client && client.config && client.config.correlationHeaderExcludedDomains;
         if (!excludedDomains || excludedDomains.length == 0 || !requestUrl) {
             return true;

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ let appInsights = require("applicationinsights");
 appInsights.setup("_ikey-A_").start();
 
 // track some events manually under another ikey
-let otherClient = new appInsights.Client("_ikey-B_");
+let otherClient = new appInsights.TelemetryClient("_ikey-B_");
 otherClient.trackEvent({name: "my custom event"});
 ```
 
@@ -224,7 +224,7 @@ otherClient.trackEvent({name: "my custom event"});
 
     ```javascript
     let appInsights = require("applicationinsights");
-    let client = new appInsights.Client();
+    let client = new appInsights.TelemetryClient();
 
     var success = false;
     let startTime = Date.now();
@@ -280,7 +280,7 @@ advanced scenarios. These can be set as follows:
 client.config.PROPERTYNAME = VALUE;
 ```
 These properties are client specific, so you can configure `appInsights.defaultClient` 
-separately from clients created with `new appInsights.Client()`.
+separately from clients created with `new appInsights.TelemetryClient()`.
 
 | Property                        | Description                                                                                                |
 | ------------------------------- |------------------------------------------------------------------------------------------------------------|

--- a/Tests/AutoCollection/Exceptions.tests.ts
+++ b/Tests/AutoCollection/Exceptions.tests.ts
@@ -2,7 +2,7 @@ import assert = require("assert");
 import sinon = require("sinon");
 
 import AutoCollectionExceptions = require("../../AutoCollection/Exceptions");
-import Client = require("../../Library/Client");
+import Client = require("../../Library/TelemetryClient");
 import AppInsights = require("../../applicationinsights");
 
 describe("AutoCollection/Exceptions", () => {

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -133,7 +133,7 @@ describe("EndToEnd", () => {
         });
 
         it("should send telemetry", (done) => {
-            var client = new AppInsights.Client("iKey");
+            var client = new AppInsights.TelemetryClient("iKey");
             client.trackEvent({ name: "test event" });
             client.trackException({ exception: new Error("test error") });
             client.trackMetric({ name: "test metric", value: 3 });
@@ -244,7 +244,7 @@ describe("EndToEnd", () => {
         it("disabled by default for new clients", (done) => {
             var req = new fakeRequest();
 
-            var client = new AppInsights.Client("key");
+            var client = new AppInsights.TelemetryClient("key");
 
             client.trackEvent({ name: "test event" });
 
@@ -285,7 +285,7 @@ describe("EndToEnd", () => {
         it("stores data to disk when enabled", (done) => {
             var req = new fakeRequest();
 
-            var client = new AppInsights.Client("key");
+            var client = new AppInsights.TelemetryClient("key");
             client.channel.setUseDiskRetryCaching(true);
 
             client.trackEvent({ name: "test event" });
@@ -311,7 +311,7 @@ describe("EndToEnd", () => {
             var res = new fakeResponse();
             res.statusCode = 200;
 
-            var client = new AppInsights.Client("key");
+            var client = new AppInsights.TelemetryClient("key");
             client.channel.setUseDiskRetryCaching(true, 0);
 
             client.trackEvent({ name: "test event" });
@@ -337,7 +337,7 @@ describe("EndToEnd", () => {
         it("cache payload synchronously when process crashes", () => {
             var req = new fakeRequest(true);
 
-            var client = new AppInsights.Client("key");
+            var client = new AppInsights.TelemetryClient("key");
             client.channel.setUseDiskRetryCaching(true);
 
             client.trackEvent({ name: "test event" });

--- a/Tests/Library/EnvelopeFactoryTests.ts
+++ b/Tests/Library/EnvelopeFactoryTests.ts
@@ -5,7 +5,7 @@ import http = require("http");
 import EnvelopeFactory = require("../../Library/EnvelopeFactory");
 import ExceptionTelemetry = require("../../Library/TelemetryTypes/ExceptionTelemetry");
 import Contracts = require("../../Declarations/Contracts")
-import Client = require("../../Library/Client")
+import Client = require("../../Library/TelemetryClient")
 import EventTelemetry = require("../../Library/TelemetryTypes/EventTelemetry")
 import TelemetryType = require("../../Library/TelemetryTypes/TelemetryType")
 

--- a/Tests/SampleApp/src/app.ts
+++ b/Tests/SampleApp/src/app.ts
@@ -14,12 +14,9 @@ const app = express();
 const PORT = 8080;
 
 appInsights.setup(process.env.APPINSIGHTS_INSTRUMENTATIONKEY || "test").start().setAutoDependencyCorrelation(true);
-appInsights.enableVerboseLogging(true);
+appInsights.Configuration.setInternalLogging(true);
 
-var appInsightsClient = appInsights.client;
-
-
-
+var appInsightsClient = appInsights.defaultClient;
 
 app.get('/', (req, res) => {
     res.send(
@@ -34,7 +31,7 @@ app.get('/', (req, res) => {
         "    </ul>" +
         "   </p>" +
         "   <p>" +
-        "    <span>ikey: " + appInsights.client.config.instrumentationKey + "<span>" +
+        "    <span>ikey: " + appInsights.defaultClient.config.instrumentationKey + "<span>" +
         "   </p>" +
         "  </body>" +
         "</html>");

--- a/Tests/SampleConsoleApp/src/app.ts
+++ b/Tests/SampleConsoleApp/src/app.ts
@@ -6,7 +6,7 @@ import appInsights = require("../../../");
 
 // https://github.com/Microsoft/ApplicationInsights-node.js/issues/54
 var testAppExitsAfterSendingTelemetry = () => {
-    var c = appInsights.createClient("key");
+    var c = new appInsights.TelemetryClient("key");
     c.trackEvent({name:'some event', properties: { 'version': 'foo' }});
     //c.flush();
     console.log('All done');

--- a/Tests/TelemetryProcessors/SamplingTelemetryProcessor.tests.ts
+++ b/Tests/TelemetryProcessors/SamplingTelemetryProcessor.tests.ts
@@ -1,6 +1,6 @@
 import assert = require("assert");
 import sinon = require("sinon");
-import Client = require("../../Library/Client");
+import Client = require("../../Library/TelemetryClient");
 
 import Sampling = require("../../TelemetryProcessors/SamplingTelemetryProcessor");
 

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -11,7 +11,7 @@ import Util = require("./Library/Util");
 
 // We export these imports so that SDK users may use these classes directly.
 // They're exposed using "export import" so that types are passed along as expected
-export import Client = require("./Library/NodeClient");
+export import TelemetryClient = require("./Library/NodeClient");
 export import Contracts = require("./Declarations/Contracts");
 
 // Default autocollection configuration
@@ -33,9 +33,9 @@ let _isStarted = false;
 
 /**
 * The default client, initialized when setup was called. To initialize a different client
-* with its own configuration, use `new Client(instrumentationKey?)`.
+* with its own configuration, use `new TelemetryClient(instrumentationKey?)`.
 */
-export let defaultClient: Client;
+export let defaultClient: TelemetryClient;
 
 /**
  * Initializes the default client. Should be called after setting
@@ -49,7 +49,7 @@ export let defaultClient: Client;
  */
 export function setup(instrumentationKey?: string) {
     if(!defaultClient) {
-        defaultClient = new Client(instrumentationKey);
+        defaultClient = new TelemetryClient(instrumentationKey);
         _console = new AutoCollectConsole(defaultClient);
         _exceptions = new AutoCollectExceptions(defaultClient);
         _performance = new AutoCollectPerformance(defaultClient);


### PR DESCRIPTION
In preparation for inclusion with https://docs.microsoft.com/en-us/azure/application-insights/app-insights-api-custom-events-metrics documentation.