### PR TITLE
Add calls to enable winston and postgres

### DIFF
--- a/AutoCollection/Console.ts
+++ b/AutoCollection/Console.ts
@@ -3,6 +3,7 @@ import Logging = require("../Library/Logging");
 
 import {enable as enableConsole} from "./diagnostic-channel/console.sub";
 import {enable as enableBunyan} from "./diagnostic-channel/bunyan.sub";
+import {enable as enableWinston} from "./diagnostic-channel/winston.sub";
 
 import "./diagnostic-channel/initialization";
 
@@ -27,6 +28,7 @@ class AutoCollectConsole {
     public enable(isEnabled: boolean) {
         enableConsole(isEnabled, this._client);
         enableBunyan(isEnabled, this._client);
+        enableWinston(isEnabled, this._client);
     }
 
     public isInitialized() {

--- a/AutoCollection/HttpDependencies.ts
+++ b/AutoCollection/HttpDependencies.ts
@@ -12,6 +12,7 @@ import { CorrelationContextManager, CorrelationContext, PrivateCustomProperties 
 import {enable as enableMongodb} from "./diagnostic-channel/mongodb.sub";
 import {enable as enableMysql} from "./diagnostic-channel/mysql.sub";
 import {enable as enableRedis} from "./diagnostic-channel/redis.sub";
+import {enable as enablePostgres} from "./diagnostic-channel/postgres.sub";
 
 import "./diagnostic-channel/initialization";
 
@@ -43,6 +44,7 @@ class AutoCollectHttpDependencies {
         enableMongodb(isEnabled, this._client);
         enableMysql(isEnabled, this._client);
         enableRedis(isEnabled, this._client);
+        enablePostgres(isEnabled, this._client);
     }
 
     public isInitialized() {

--- a/AutoCollection/diagnostic-channel/winston.sub.ts
+++ b/AutoCollection/diagnostic-channel/winston.sub.ts
@@ -11,7 +11,7 @@ let clients: TelemetryClient[] = [];
 
 const winstonToAILevelMap: { [key: string]: (og: string) => number } = {
     syslog(og: string) {
-        return {
+        const map: { [key: string ]: number } = {
             emerg: SeverityLevel.Critical,
             alert: SeverityLevel.Critical,
             crit: SeverityLevel.Critical,
@@ -20,17 +20,21 @@ const winstonToAILevelMap: { [key: string]: (og: string) => number } = {
             notice: SeverityLevel.Information,
             info: SeverityLevel.Information,
             debug: SeverityLevel.Verbose
-        }[og] || SeverityLevel.Information;
+        };
+
+        return map[og] || SeverityLevel.Information;
     },
     npm(og: string) {
-        return {
+        const map: { [key: string]: number } = {
             error: SeverityLevel.Critical,
             warn: SeverityLevel.Warning,
             info: SeverityLevel.Information,
             verbose: SeverityLevel.Verbose,
             debug: SeverityLevel.Verbose,
             silly: SeverityLevel.Verbose
-        }[og] || SeverityLevel.Information;
+        };
+        
+        return map[og] || SeverityLevel.Information;
     },
     unknown(og: string) {
         return SeverityLevel.Information;


### PR DESCRIPTION
I realized that in my last pull request (https://github.com/Microsoft/ApplicationInsights-node.js/pull/303), I forgot/did not realize I had to make explicit calls to enable the subscribers for these two new publishers.