### PR TITLE
Fix incorrect path to package.json

### DIFF
--- a/Library/Context.ts
+++ b/Library/Context.ts
@@ -25,7 +25,7 @@ class Context {
 
         try {
             // note: this should return the host package.json
-            var packageJson = require(packageJsonPath || "../../../package.json");
+            var packageJson = require(packageJsonPath || "../../../../package.json");
             if(packageJson) {
                 if (typeof packageJson.version === "string") {
                     version = packageJson.version;


### PR DESCRIPTION
Fix incorrect path to `package.json` in the consuming application.

The file structure was looking in `node_modules` instead of the top-level app folder to get the consuming application's version.

I found this by calling `setInternalLogging(true, true)` during setup in AWS Lambda while trying to diagnose an issue that makes my Lambda function hang when ApplicationInsights is enabled.

```
ApplicationInsights:unable to read app version:  [ { Error: Cannot find module '../../../package.json'
      at Error.AppInsightsAsyncCorrelatedErrorWrapper (/var/task/node_modules/applicationinsights/out/AutoCollection/CorrelationContextManager.js:172:18)
      at Function.Module._resolveFilename (module.js:469:15)
      at Function.Module._load (module.js:417:25)
      at Module.require (module.js:497:17)
      at Module.patchedRequire [as require] (/var/task/node_modules/diagnostic-channel/dist/src/patchRequire.js:14:46)
      at require (internal/module.js:20:19)
      at Context._loadApplicationContext (/var/task/node_modules/applicationinsights/out/Library/Context.js:18:31)
      at new Context (/var/task/node_modules/applicationinsights/out/Library/Context.js:9:14)
      at NodeClient.TelemetryClient (/var/task/node_modules/applicationinsights/out/Library/TelemetryClient.js:26:24)
      at new NodeClient (/var/task/node_modules/applicationinsights/out/Library/NodeClient.js:25:42)
      at Object.telemetry.createClient (/var/task/src/telemetry.js:19:10)
      at Object.telemetry.trackEvent (/var/task/src/telemetry.js:37:17)
      at onLaunch [as launchFunc] (/var/task/src/skill.js:50:15)
      at /var/task/node_modules/alexa-app/index.js:545:41
      at tryCatcher (/var/task/node_modules/bluebird/js/main/util.js:26:23)
      at Promise._settlePromiseFromHandler (/var/task/node_modules/bluebird/js/main/promise.js:510:31)
      at Promise._settlePromiseAt (/var/task/node_modules/bluebird/js/main/promise.js:584:18)
      at Promise._settlePromises (/var/task/node_modules/bluebird/js/main/promise.js:700:14)
      at Async._drainQueue (/var/task/node_modules/bluebird/js/main/async.js:123:16)
      at Async._drainQueues (/var/task/node_modules/bluebird/js/main/async.js:133:10)
      at Immediate.Async.drainQueues (/var/task/node_modules/bluebird/js/main/async.js:15:14)
      at runCallback (timers.js:672:20)
      at tryOnImmediate (timers.js:645:5)
      at processImmediate [as _immediateCallback] (timers.js:617:5) code: 'MODULE_NOT_FOUND' } ]
```

Manually updating the code in the `node_modules` folder to print the value of `version` showed it as `unknown` before the change and `1.0.8` (for my app) after changing the path.

I guess this has come about as either a facet of some file restructuring from some refactoring, or as an artifact of the compilation process from TypeScript into JavaScript when the package is published.