### PR TITLE
Adjust the envelope properties initiate order to meet Xpert requirement

### DIFF
--- a/Declarations/Contracts/Generated/Envelope.ts
+++ b/Declarations/Contracts/Generated/Envelope.ts
@@ -48,11 +48,5 @@ import Base = require('./Base');
          */
         public data: Base;
         
-        constructor()
-        {
-            this.ver = 1;
-            this.sampleRate = 100.0;
-            this.tags = {};
-        }
     }
 export = Envelope;

--- a/Library/EnvelopeFactory.ts
+++ b/Library/EnvelopeFactory.ts
@@ -70,24 +70,22 @@ class EnvelopeFactory {
 
         var iKey = config ? config.instrumentationKey || "" : "";
         var envelope = new Contracts.Envelope();
-        envelope.data = data;
+        envelope.time = (new Date()).toISOString();
+        envelope.ver = 1;
+
+        // Exclude metrics from sampling by default
+        envelope.sampleRate = (config && telemetryType !== Contracts.TelemetryType.Metric) ? config.samplingPercentage : 100;
         envelope.iKey = iKey;
 
         // this is kind of a hack, but the envelope name is always the same as the data name sans the chars "data"
         envelope.name =
             "Microsoft.ApplicationInsights." +
-            iKey.replace(/-/g, "") +
+            iKey.replace(/-/g, "").toLowerCase() +
             "." +
             data.baseType.substr(0, data.baseType.length - 4);
-        envelope.tags = this.getTags(context, telemetry.tagOverrides);
-        envelope.time = (new Date()).toISOString();
-        envelope.ver = 1;
-        envelope.sampleRate = config ? config.samplingPercentage : 100;
 
-        // Exclude metrics from sampling by default
-        if (telemetryType === Contracts.TelemetryType.Metric) {
-            envelope.sampleRate = 100;
-        }
+        envelope.tags = this.getTags(context, telemetry.tagOverrides);
+        envelope.data = data;
 
         return envelope;
     }


### PR DESCRIPTION
fix bug #383 The envelope properties init order is not compatible with Xpert (Microsoft Internal).

there fix contains the following parts:

1. adjust the properties init step of creating envelope 
2. set the ikey part as lowercase to consistent with other application insights sdks