### PR TITLE
setting userAuthUserId tag from ai_authUser cookie field

### DIFF
--- a/AutoCollection/HttpRequestParser.ts
+++ b/AutoCollection/HttpRequestParser.ts
@@ -66,7 +66,7 @@ class HttpRequestParser extends RequestParser {
             id: this.requestId,
             name: this.method + " " + url.parse(this.url).pathname,
             url: this.url,
-            /* 
+            /*
             See https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/25d695e6a906fbe977f67be3966d25dbf1c50a79/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs#L250
             for reference
             */
@@ -109,6 +109,7 @@ class HttpRequestParser extends RequestParser {
         newTags[HttpRequestParser.keys.locationIp] = tags[HttpRequestParser.keys.locationIp] || this._getIp();
         newTags[HttpRequestParser.keys.sessionId] = tags[HttpRequestParser.keys.sessionId] || this._getId("ai_session");
         newTags[HttpRequestParser.keys.userId] = tags[HttpRequestParser.keys.userId] || this._getId("ai_user");
+        newTags[HttpRequestParser.keys.userAuthUserId] = tags[HttpRequestParser.keys.userAuthUserId] || this._getId("ai_authUser");
         newTags[HttpRequestParser.keys.operationName] = this.getOperationName(tags);
         newTags[HttpRequestParser.keys.operationParentId] = this.getOperationParentId(tags);
         newTags[HttpRequestParser.keys.operationId] = this.getOperationId(tags);

--- a/Tests/AutoCollection/HttpRequestParser.tests.ts
+++ b/Tests/AutoCollection/HttpRequestParser.tests.ts
@@ -139,6 +139,7 @@ describe("AutoCollection/HttpRequestParser", () => {
             var newTags = helper.getRequestTags(originalTags);
             assert.equal(newTags[(<any>HttpRequestParser).keys.locationIp], '123.123.123.123');
             assert.equal(newTags[(<any>HttpRequestParser).keys.userId], 'cookieUser');
+            assert.equal(newTags[(<any>HttpRequestParser).keys.userAuthUserId], 'cookieAuthUser');
             assert.equal(newTags[(<any>HttpRequestParser).keys.userAgent], undefined);
             assert.equal(newTags[(<any>HttpRequestParser).keys.operationName], 'GET /search');
             assert.equal(newTags[(<any>HttpRequestParser).keys.operationId], 'operationId');

--- a/Tests/AutoCollection/HttpRequestParser.tests.ts
+++ b/Tests/AutoCollection/HttpRequestParser.tests.ts
@@ -102,7 +102,7 @@ describe("AutoCollection/HttpRequestParser", () => {
             headers: {
                 host: "bing.com",
                 "x-forwarded-for": "123.123.123.123",
-                "cookie": "ai_user=cookieUser|time;ai_session=cookieSession|time",
+                "cookie": "ai_user=cookieUser|time;ai_session=cookieSession|time;ai_authUser=cookieAuthUser|time",
                 "x-ms-request-id": "parentRequestId",
                 "x-ms-request-root-id": "operationId",
             }
@@ -114,6 +114,7 @@ describe("AutoCollection/HttpRequestParser", () => {
             var originalTags: {[key: string]:string} = {
                 [(<any>HttpRequestParser).keys.locationIp]: 'originalIp',
                 [(<any>HttpRequestParser).keys.userId]: 'originalUserId',
+                [(<any>HttpRequestParser).keys.userAuthUserId]: 'originalAuthUserId',
                 [(<any>HttpRequestParser).keys.userAgent]: 'originalUserAgent',
                 [(<any>HttpRequestParser).keys.operationName]: 'originalOperationName',
                 [(<any>HttpRequestParser).keys.operationId]: 'originalOperationId',
@@ -122,6 +123,7 @@ describe("AutoCollection/HttpRequestParser", () => {
             var newTags = helper.getRequestTags(originalTags);
             assert.equal(newTags[(<any>HttpRequestParser).keys.locationIp], 'originalIp');
             assert.equal(newTags[(<any>HttpRequestParser).keys.userId], 'originalUserId');
+            assert.equal(newTags[(<any>HttpRequestParser).keys.userAuthUserId], 'originalAuthUserId');
             assert.equal(newTags[(<any>HttpRequestParser).keys.userAgent], 'originalUserAgent');
             assert.equal(newTags[(<any>HttpRequestParser).keys.operationName], 'originalOperationName');
             assert.equal(newTags[(<any>HttpRequestParser).keys.operationId], 'originalOperationId');


### PR DESCRIPTION
A small contribution to populate `userAuthUserId`  from `ai_authUser` cookie field (like `ai_user`)

Seems that also concerns #356 