### PR TITLE
Remove propagation of role name in correlation headers

### DIFF
--- a/AutoCollection/HttpDependencies.ts
+++ b/AutoCollection/HttpDependencies.ts
@@ -128,16 +128,15 @@ class AutoCollectHttpDependencies {
                 if (correlationHeader) {
                     const components = correlationHeader.split(",");
                     const key = `${RequestResponseHeaders.requestContextSourceKey}=`;
-                    const roleNameKey = `${RequestResponseHeaders.requestContextSourceRoleNameKey}=`;
                     if (!components.some((value) => value.substring(0,key.length) === key)) {
                         telemetry.request.setHeader(
                             RequestResponseHeaders.requestContextHeader, 
-                            `${correlationHeader},${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId},${RequestResponseHeaders.requestContextSourceRoleNameKey}=${client.context.tags[client.context.keys.cloudRole]}`);
+                            `${correlationHeader},${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
                     }
                 } else {
                     telemetry.request.setHeader(
                         RequestResponseHeaders.requestContextHeader, 
-                        `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId},${RequestResponseHeaders.requestContextSourceRoleNameKey}=${client.context.tags[client.context.keys.cloudRole]}`);
+                        `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
                 }
             }
 

--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -15,7 +15,6 @@ import CorrelationIdManager = require("../Library/CorrelationIdManager");
  */
 class HttpDependencyParser extends RequestParser {
     private correlationId: string;
-    private targetRoleName: string;
 
     constructor(requestOptions: string | http.RequestOptions | https.RequestOptions, request: http.ClientRequest) {
         super();
@@ -41,7 +40,6 @@ class HttpDependencyParser extends RequestParser {
     public onResponse(response: http.ClientResponse) {
         this._setStatus(response.statusCode, undefined);
         this.correlationId = Util.getCorrelationContextTarget(response, RequestResponseHeaders.requestContextTargetKey);
-        this.targetRoleName = Util.getCorrelationContextTarget(response, RequestResponseHeaders.requestContextTargetRoleNameKey);
     }
 
     /**
@@ -60,7 +58,7 @@ class HttpDependencyParser extends RequestParser {
         if (this.correlationId) {
             remoteDependencyType = Contracts.RemoteDependencyDataConstants.TYPE_AI;
             if (this.correlationId !== CorrelationIdManager.correlationIdPrefix) {
-                remoteDependencyTarget = urlObject.hostname + " | " + this.correlationId + " | roleName:" + this.targetRoleName;
+                remoteDependencyTarget = urlObject.hostname + " | " + this.correlationId;
             }
         } else {
             remoteDependencyType = Contracts.RemoteDependencyDataConstants.TYPE_HTTP;

--- a/AutoCollection/HttpRequestParser.ts
+++ b/AutoCollection/HttpRequestParser.ts
@@ -21,7 +21,6 @@ class HttpRequestParser extends RequestParser {
     private legacySocketRemoteAddress: string;
     private userAgent: string;
     private sourceCorrelationId: string;
-    private sourceRoleName: string;
     private parentId: string;
     private operationId: string;
     private requestId: string;
@@ -70,7 +69,7 @@ class HttpRequestParser extends RequestParser {
             See https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/25d695e6a906fbe977f67be3966d25dbf1c50a79/Src/Web/Web.Shared.Net/RequestTrackingTelemetryModule.cs#L250
             for reference
             */
-            source: this.sourceCorrelationId + " | roleName:" + this.sourceRoleName,
+            source: this.sourceCorrelationId,
             duration: this.duration,
             resultCode: this.statusCode ? this.statusCode.toString() : null,
             success: this._isSuccess(),
@@ -200,7 +199,6 @@ class HttpRequestParser extends RequestParser {
         this.rawHeaders = request.headers || (<any>request).rawHeaders;
         this.userAgent = request.headers && request.headers["user-agent"];
         this.sourceCorrelationId = Util.getCorrelationContextTarget(request, RequestResponseHeaders.requestContextSourceKey);
-        this.sourceRoleName = Util.getCorrelationContextTarget(request, RequestResponseHeaders.requestContextSourceRoleNameKey);
 
         if (request.headers) {
             this.correlationContextHeader = request.headers[RequestResponseHeaders.correlationContextHeader];

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -230,12 +230,12 @@ class AutoCollectHttpRequests {
                 if (!components.some((value) => value.substring(0,key.length) === key)) {
                     response.setHeader(
                         RequestResponseHeaders.requestContextHeader, 
-                        `${correlationHeader},${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId},${RequestResponseHeaders.requestContextSourceRoleNameKey}=${client.context.tags[client.context.keys.cloudRole]}`);
+                        `${correlationHeader},${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
                 }
             } else {
                 response.setHeader(
                     RequestResponseHeaders.requestContextHeader, 
-                    `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId},${RequestResponseHeaders.requestContextSourceRoleNameKey}=${client.context.tags[client.context.keys.cloudRole]}`);
+                    `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
             }
         }
     }

--- a/Library/RequestResponseHeaders.ts
+++ b/Library/RequestResponseHeaders.ts
@@ -18,18 +18,6 @@ export = {
     requestContextTargetKey: "appId",
 
     /**
-     * Source-RoleName key in the request context header that is added by an application 
-     * while making http requests and retrieved by the other application when processing incoming requests.
-     */
-    requestContextSourceRoleNameKey: "roleName",
-
-    /**
-     * Target-RoleName key in the request context header that is added to the response 
-     * and retrieved by the calling application when processing incoming responses.
-     */
-    requestContextTargetRoleNameKey: "roleName",
-
-    /**
      * Request-Id header
      */
     requestIdHeader: "request-id",

--- a/Tests/Library/Client.tests.ts
+++ b/Tests/Library/Client.tests.ts
@@ -379,8 +379,7 @@ describe("Library/TelemetryClient", () => {
 
                 // Simulate an incoming request that has a different source correlationId header.
                 let testCorrelationId = 'cid-v1:Application-Id-98765-4321A';
-                let testRoleName = "Backend";
-                request.headers[RequestResponseHeaders.requestContextHeader] = `${RequestResponseHeaders.requestContextSourceKey}=${testCorrelationId},${RequestResponseHeaders.requestContextSourceRoleNameKey}=${testRoleName}`;
+                request.headers[RequestResponseHeaders.requestContextHeader] = `${RequestResponseHeaders.requestContextSourceKey}=${testCorrelationId}`;
 
                 client.trackNodeHttpRequest({ request: <any>request, response: <any>response, properties: properties });
 
@@ -392,11 +391,11 @@ describe("Library/TelemetryClient", () => {
                 response.emitFinish();
                 assert.ok(trackStub.calledOnce);
                 var requestTelemetry = <Contracts.RequestTelemetry>trackStub.firstCall.args[0];
-                assert.equal(requestTelemetry.source, testCorrelationId + " | roleName:" + testRoleName);
+                assert.equal(requestTelemetry.source, testCorrelationId);
 
                 // The client's correlationId should have been added as the response target correlationId header.
                 assert.equal(response.headers[RequestResponseHeaders.requestContextHeader],
-                    `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId},${RequestResponseHeaders.requestContextSourceRoleNameKey}=${client.context.tags[client.context.keys.cloudRole]}`);
+                    `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
             });
 
             it('should NOT use source and target correlationId headers when url is on the excluded list', () => {
@@ -564,16 +563,15 @@ describe("Library/TelemetryClient", () => {
 
                 // The client's correlationId should have been added as the request source correlationId header.
                 assert.equal(request.headers[RequestResponseHeaders.requestContextHeader],
-                    `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId},${RequestResponseHeaders.requestContextSourceRoleNameKey}=${client.context.tags[client.context.keys.cloudRole]}`);
+                    `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
 
                 // response event was not emitted yet
                 assert.ok(trackStub.notCalled);
 
                 // Simulate a response from another service that includes a target correlationId header.
                 const targetCorrelationId = "cid-v1:Application-Key-98765-4321A";
-                const targetRoleName = "Backend";
                 response.headers[RequestResponseHeaders.requestContextHeader] =
-                    `${RequestResponseHeaders.requestContextTargetKey}=${targetCorrelationId},${RequestResponseHeaders.requestContextTargetRoleNameKey}=${targetRoleName},`;
+                    `${RequestResponseHeaders.requestContextTargetKey}=${targetCorrelationId}`;
 
                 // emit response event
                 clock.tick(10);
@@ -581,7 +579,7 @@ describe("Library/TelemetryClient", () => {
                 assert.ok(trackStub.calledOnce);
                 var dependencyTelemetry = <Contracts.DependencyTelemetry>trackStub.firstCall.args[0];
 
-                assert.equal(dependencyTelemetry.target, "bing.com | " + targetCorrelationId + " | roleName:" + targetRoleName);
+                assert.equal(dependencyTelemetry.target, "bing.com | " + targetCorrelationId);
                 assert.equal(dependencyTelemetry.dependencyTypeName, "Http (tracked component)");
             });
 


### PR DESCRIPTION
Role name in correlation headers breaks UI compatibility and was ignored by other SDKs (or in some cases caused other SDKs to fail to correlate).