### PR TITLE
fix: Fix error with puppeteer, agent can be undefined

### DIFF
--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -139,7 +139,7 @@ class HttpDependencyParser extends RequestParser {
         }
 
         // Mix in default values used by http.request and others
-        options.protocol = options.protocol || (<any>request).agent.protocol;
+        options.protocol = options.protocol || ((<any>request).agent && (<any>request).agent.protocol) || undefined;
         options.hostname = options.hostname || 'localhost';
 
         return url.format(options);


### PR DESCRIPTION
Fix the issue #406 

When puppeteer start, the protocol and agent can be undefined.