### PR TITLE
add useAsyncHooks arg to CorrelationContextManager

### DIFF
--- a/AutoCollection/CorrelationContextManager.ts
+++ b/AutoCollection/CorrelationContextManager.ts
@@ -43,6 +43,7 @@ export interface CorrelationContext {
 export class CorrelationContextManager {
     private static enabled: boolean = false;
     private static hasEverEnabled: boolean = false;
+    private static forceClsHooked: boolean = undefined; // true: use cls-hooked, false: use cls, undefined: choose based on node version
     private static session: cls.Namespace;
     private static cls: typeof cls;
     private static CONTEXT_NAME = "ApplicationInsights-Context"
@@ -123,7 +124,7 @@ export class CorrelationContextManager {
     /**
      *  Enables the CorrelationContextManager.
      */
-    public static enable() {
+    public static enable(forceClsHooked?: boolean) {
         if (this.enabled) {
             return;
         }
@@ -132,12 +133,12 @@ export class CorrelationContextManager {
             this.enabled = false;
             return;
         }
-
         if (!CorrelationContextManager.hasEverEnabled) {
+            this.forceClsHooked = forceClsHooked;
             this.hasEverEnabled = true;
 
             if (typeof this.cls === "undefined") {
-                if (CorrelationContextManager.isClsHookedCompatible()) {
+                if (CorrelationContextManager.forceClsHooked === true || (CorrelationContextManager.forceClsHooked === undefined && CorrelationContextManager.isClsHookedCompatible())) {
                     this.cls = require('cls-hooked');
                 } else {
                     this.cls = require('continuation-local-storage');

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -282,6 +282,8 @@ class AutoCollectHttpRequests {
          AutoCollectHttpRequests.INSTANCE = null;
          this.enable(false);
          this._isInitialized = false;
+         CorrelationContextManager.disable();
+         this._isAutoCorrelating = false;
     }
 }
 

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -43,9 +43,9 @@ class AutoCollectHttpRequests {
         }
     }
 
-    public useAutoCorrelation(isEnabled:boolean) {
+    public useAutoCorrelation(isEnabled:boolean, forceClsHooked?:boolean) {
         if (isEnabled && !this._isAutoCorrelating) {
-            CorrelationContextManager.enable();
+            CorrelationContextManager.enable(forceClsHooked);
         } else if (!isEnabled && this._isAutoCorrelating) {
             CorrelationContextManager.disable();
         }

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -35,22 +35,22 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
 
             it("should use cls-hooked if force flag is set to true", () => {
                 CorrelationContextManager.enable(true);
-                assert.deepEqual(require('cls-hooked'), (CorrelationContextManager as any).cls, 'cls-hooked is loaded');
-                assert.notDeepEqual(require('continuation-local-storage'), (CorrelationContextManager as any).cls);
+                assert.deepEqual((CorrelationContextManager as any).cls, require('cls-hooked'), 'cls-hooked is loaded');
+                assert.notDeepEqual((CorrelationContextManager as any).cls, require('continuation-local-storage'));
             });
             it("should use continuation-local-storage if force flag is set to false", () => {
                 CorrelationContextManager.enable(false);
-                assert.deepEqual(require('continuation-local-storage'), (CorrelationContextManager as any).cls, 'cls is loaded');
-                assert.notDeepEqual(require('cls-hooked'), (CorrelationContextManager as any).cls);
+                assert.deepEqual((CorrelationContextManager as any).cls, require('continuation-local-storage'), 'cls is loaded');
+                assert.notDeepEqual((CorrelationContextManager as any).cls, require('cls-hooked'));
             });
             it("should pick correct version of cls based on node version", () => {
                 CorrelationContextManager.enable();
                 if (CorrelationContextManager.isClsHookedCompatible()) {
-                    assert.deepEqual(require('cls-hooked'), (CorrelationContextManager as any).cls, 'cls-hooked is loaded');
-                    assert.notDeepEqual(require('continuation-local-storage'), (CorrelationContextManager as any).cls);
+                    assert.deepEqual((CorrelationContextManager as any).cls, require('cls-hooked'), 'cls-hooked is loaded');
+                    assert.notDeepEqual((CorrelationContextManager as any).cls, require('continuation-local-storage'));
                 } else {
-                    assert.deepEqual(require('continuation-local-storage'), (CorrelationContextManager as any).cls, 'cls is loaded');
-                    assert.notDeepEqual(require('cls-hooked'), (CorrelationContextManager as any).cls);
+                    assert.deepEqual((CorrelationContextManager as any).cls, require('continuation-local-storage'), 'cls is loaded');
+                    assert.notDeepEqual((CorrelationContextManager as any).cls, require('cls-hooked'));
                 }
             });
         });

--- a/Tests/AutoCollection/CorrelationContextManager.tests.ts
+++ b/Tests/AutoCollection/CorrelationContextManager.tests.ts
@@ -26,6 +26,34 @@ if (CorrelationContextManager.isNodeVersionCompatible()) {
             },
             customProperties
         };
+        describe("#enable", () => {
+            afterEach(() => {
+                (CorrelationContextManager as any).hasEverEnabled = false;
+                (CorrelationContextManager as any).cls = undefined;
+                CorrelationContextManager.disable();
+            });
+
+            it("should use cls-hooked if force flag is set to true", () => {
+                CorrelationContextManager.enable(true);
+                assert.deepEqual(require('cls-hooked'), (CorrelationContextManager as any).cls, 'cls-hooked is loaded');
+                assert.notDeepEqual(require('continuation-local-storage'), (CorrelationContextManager as any).cls);
+            });
+            it("should use continuation-local-storage if force flag is set to false", () => {
+                CorrelationContextManager.enable(false);
+                assert.deepEqual(require('continuation-local-storage'), (CorrelationContextManager as any).cls, 'cls is loaded');
+                assert.notDeepEqual(require('cls-hooked'), (CorrelationContextManager as any).cls);
+            });
+            it("should pick correct version of cls based on node version", () => {
+                CorrelationContextManager.enable();
+                if (CorrelationContextManager.isClsHookedCompatible()) {
+                    assert.deepEqual(require('cls-hooked'), (CorrelationContextManager as any).cls, 'cls-hooked is loaded');
+                    assert.notDeepEqual(require('continuation-local-storage'), (CorrelationContextManager as any).cls);
+                } else {
+                    assert.deepEqual(require('continuation-local-storage'), (CorrelationContextManager as any).cls, 'cls is loaded');
+                    assert.notDeepEqual(require('cls-hooked'), (CorrelationContextManager as any).cls);
+                }
+            });
+        });
 
         describe("#getCurrentContext()", () => {
             afterEach(() => {

--- a/Tests/applicationInsights.tests.ts
+++ b/Tests/applicationInsights.tests.ts
@@ -141,7 +141,7 @@ describe("ApplicationInsights", () => {
         var AppInsights = require("../applicationinsights");
         var Contracts = require("../Declarations/Contracts");
         var CCM = require("../AutoCollection/CorrelationContextManager").CorrelationContextManager;
-        var origGCC = CCM.getCurrentContext;        
+        var origGCC = CCM.getCurrentContext;
 
         beforeEach(() => {
             CCM.getCurrentContext = () => 'context';
@@ -149,11 +149,27 @@ describe("ApplicationInsights", () => {
 
         afterEach(() => {
             CCM.getCurrentContext = origGCC;
+            CCM.hasEverEnabled = false;
+            CCM.disable();
         });
 
         it("should provide a context if correlating", () => {
             AppInsights.setup("key")
             .setAutoDependencyCorrelation(true)
+            .start();
+            assert.equal(AppInsights.getCorrelationContext(), 'context');
+        });
+
+        it("should provide a cls-hooked context if force flag set", () => {
+            AppInsights.setup("key")
+            .setAutoDependencyCorrelation(true, true)
+            .start();
+            assert.equal(AppInsights.getCorrelationContext(), 'context');
+        });
+
+        it("should provide a continuation-local-storage context if force flag set", () => {
+            AppInsights.setup("key")
+            .setAutoDependencyCorrelation(true, false)
             .start();
             assert.equal(AppInsights.getCorrelationContext(), 'context');
         });

--- a/Tests/applicationInsights.tests.ts
+++ b/Tests/applicationInsights.tests.ts
@@ -150,7 +150,9 @@ describe("ApplicationInsights", () => {
         afterEach(() => {
             CCM.getCurrentContext = origGCC;
             CCM.hasEverEnabled = false;
+            CCM.cls = undefined;
             CCM.disable();
+            AppInsights.dispose();
         });
 
         it("should provide a context if correlating", () => {
@@ -160,18 +162,24 @@ describe("ApplicationInsights", () => {
             assert.equal(AppInsights.getCorrelationContext(), 'context');
         });
 
-        it("should provide a cls-hooked context if force flag set", () => {
+        it("should provide a cls-hooked context if force flag set to true", () => {
             AppInsights.setup("key")
             .setAutoDependencyCorrelation(true, true)
             .start();
             assert.equal(AppInsights.getCorrelationContext(), 'context');
+            if (CCM.isNodeVersionCompatible()) {
+                assert.equal(CCM.cls, require('cls-hooked'));
+            }
         });
 
-        it("should provide a continuation-local-storage context if force flag set", () => {
+        it("should provide a continuation-local-storage context if force flag set to false", () => {
             AppInsights.setup("key")
             .setAutoDependencyCorrelation(true, false)
             .start();
             assert.equal(AppInsights.getCorrelationContext(), 'context');
+            if (CCM.isNodeVersionCompatible()) {
+                assert.equal(CCM.cls, require('continuation-local-storage'));
+            }
         });
 
         it("should not provide a context if not correlating", () => {

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -206,13 +206,14 @@ export class Configuration {
     /**
      * Sets the state of automatic dependency correlation (enabled by default)
      * @param value if true dependencies will be correlated with requests
+     * @param useAsyncHooks if true, forces use of experimental async_hooks module to provide correlation. If false, instead uses async-listener. If left blank, the best option is chosen for you based on your version on NodeJS.
      * @returns {Configuration} this class
      */
-    public static setAutoDependencyCorrelation(value: boolean, forceClsHooked?: boolean) {
+    public static setAutoDependencyCorrelation(value: boolean, useAsyncHooks?: boolean) {
         _isCorrelating = value;
-        _forceClsHooked = forceClsHooked;
+        _forceClsHooked = useAsyncHooks;
         if (_isStarted) {
-            _serverRequests.useAutoCorrelation(value, forceClsHooked);
+            _serverRequests.useAutoCorrelation(value, useAsyncHooks);
         }
 
         return Configuration;

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -23,7 +23,7 @@ let _isRequests = true;
 let _isDependencies = true;
 let _isDiskRetry = true;
 let _isCorrelating = true;
-let _forceClsHooked;
+let _forceClsHooked: boolean;
 
 let _diskRetryInterval: number = undefined;
 let _diskRetryMaxBytes: number = undefined;
@@ -83,7 +83,7 @@ export function start() {
         _console.enable(_isConsole, _isConsoleLog);
         _exceptions.enable(_isExceptions);
         _performance.enable(_isPerformance);
-        _serverRequests.useAutoCorrelation(_isCorrelating);
+        _serverRequests.useAutoCorrelation(_isCorrelating, _forceClsHooked);
         _serverRequests.enable(_isRequests);
         _clientRequests.enable(_isDependencies);
     } else {
@@ -212,7 +212,7 @@ export class Configuration {
         _isCorrelating = value;
         _forceClsHooked = forceClsHooked;
         if (_isStarted) {
-            _serverRequests.useAutoCorrelation(value);
+            _serverRequests.useAutoCorrelation(value, forceClsHooked);
         }
 
         return Configuration;

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -206,7 +206,7 @@ export class Configuration {
     /**
      * Sets the state of automatic dependency correlation (enabled by default)
      * @param value if true dependencies will be correlated with requests
-     * @param useAsyncHooks if true, forces use of experimental async_hooks module to provide correlation. If false, instead uses async-listener. If left blank, the best option is chosen for you based on your version on NodeJS.
+     * @param useAsyncHooks if true, forces use of experimental async_hooks module to provide correlation. If false, instead uses only patching-based techniques. If left blank, the best option is chosen for you based on your version of NodeJS.
      * @returns {Configuration} this class
      */
     public static setAutoDependencyCorrelation(value: boolean, useAsyncHooks?: boolean) {

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -23,6 +23,7 @@ let _isRequests = true;
 let _isDependencies = true;
 let _isDiskRetry = true;
 let _isCorrelating = true;
+let _forceClsHooked;
 
 let _diskRetryInterval: number = undefined;
 let _diskRetryMaxBytes: number = undefined;
@@ -44,7 +45,7 @@ export let defaultClient: TelemetryClient;
 /**
  * Initializes the default client. Should be called after setting
  * configuration options.
- * 
+ *
  * @param instrumentationKey the instrumentation key to use. Optional, if
  * this is not specified, the value will be read from the environment
  * variable APPINSIGHTS_INSTRUMENTATIONKEY.
@@ -72,7 +73,7 @@ export function setup(instrumentationKey?: string) {
 
 /**
  * Starts automatic collection of telemetry. Prior to calling start no
- * telemetry will be *automatically* collected, though manual collection 
+ * telemetry will be *automatically* collected, though manual collection
  * is enabled.
  * @returns {ApplicationInsights} this class
  */
@@ -96,12 +97,12 @@ export function start() {
  * Returns an object that is shared across all code handling a given request.
  * This can be used similarly to thread-local storage in other languages.
  * Properties set on this object will be available to telemetry processors.
- * 
+ *
  * Do not store sensitive information here.
  * Custom properties set on this object can be exposed in a future SDK
  * release via outgoing HTTP headers.
  * This is to allow for correlating data cross-component.
- * 
+ *
  * This method will return null if automatic dependency correlation is disabled.
  * @returns A plain object for request storage or null if automatic dependency correlation is disabled.
  */
@@ -207,8 +208,9 @@ export class Configuration {
      * @param value if true dependencies will be correlated with requests
      * @returns {Configuration} this class
      */
-    public static setAutoDependencyCorrelation(value: boolean) {
+    public static setAutoDependencyCorrelation(value: boolean, forceClsHooked?: boolean) {
         _isCorrelating = value;
+        _forceClsHooked = forceClsHooked;
         if (_isStarted) {
             _serverRequests.useAutoCorrelation(value);
         }

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -206,7 +206,7 @@ export class Configuration {
     /**
      * Sets the state of automatic dependency correlation (enabled by default)
      * @param value if true dependencies will be correlated with requests
-     * @param useAsyncHooks if true, forces use of experimental async_hooks module to provide correlation. If false, instead uses only patching-based techniques. If left blank, the best option is chosen for you based on your version of NodeJS.
+     * @param useAsyncHooks if true, forces use of experimental async_hooks module to provide correlation. If false, instead uses only patching-based techniques. If left blank, the best option is chosen for you based on your version of Node.js.
      * @returns {Configuration} this class
      */
     public static setAutoDependencyCorrelation(value: boolean, useAsyncHooks?: boolean) {


### PR DESCRIPTION
https://github.com/Microsoft/ApplicationInsights-node.js/compare/markwolff/add-force-cls?expand=1#diff-1452dad132989865d44d978755072970L210

- `true`: use `cls-hooked`
- `false`: use `continuation-local-storage`
- `undefined`: select library based on `node` version