### PR TITLE
add env variable to disable dep correlation

### DIFF
--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -10,6 +10,7 @@ import RequestResponseHeaders = require("../Library/RequestResponseHeaders");
 import HttpRequestParser = require("./HttpRequestParser");
 import { CorrelationContextManager, CorrelationContext, PrivateCustomProperties } from "./CorrelationContextManager";
 import AutoCollectPerformance = require("./Performance");
+import Config = require("../Library/Config");
 
 class AutoCollectHttpRequests {
 
@@ -44,7 +45,7 @@ class AutoCollectHttpRequests {
     }
 
     public useAutoCorrelation(isEnabled:boolean, forceClsHooked?:boolean) {
-        if (isEnabled && !this._isAutoCorrelating) {
+        if (isEnabled && !this._isAutoCorrelating && !process.env[Config.ENV_disableDependencyCorrelation]) {
             CorrelationContextManager.enable(forceClsHooked);
         } else if (!isEnabled && this._isAutoCorrelating) {
             CorrelationContextManager.disable();

--- a/Library/Config.ts
+++ b/Library/Config.ts
@@ -12,6 +12,9 @@ class Config {
     public static legacy_ENV_iKey = "APPINSIGHTS_INSTRUMENTATION_KEY";
     public static ENV_profileQueryEndpoint = "APPINSIGHTS_PROFILE_QUERY_ENDPOINT";
 
+    // Disable dependency correlation
+    public static ENV_disableDependencyCorrelation = "APPINSIGHTS_DISABLE_DEPENDENCY_CORRELATION";
+
     public static ENV_http_proxy = "http_proxy";
     public static ENV_https_proxy = "https_proxy";
 


### PR DESCRIPTION
Currently `useAutoCorrelation()` does the check for the new environment variable. Am wondering if it should be moved to `CorrelationContextManager.enable()` instead, or the 2 places that call `useAutoCorrelation()` in `applicationinsights.ts` instead.