### PR TITLE
fix wrong telemetrytype in qps conversion

### DIFF
--- a/Declarations/Constants.ts
+++ b/Declarations/Constants.ts
@@ -75,20 +75,20 @@ export const QuickPulseType: {[key in Contracts.TelemetryTypeKeys]: QuickPulseTy
     Dependency: "DependencyTelemetryDocument"
 };
 
-export const TelemetryTypeStringToQuickPulseType: {[key in Contracts.TelemetryTypeKeys]: QuickPulseType} = {
-    Event: QuickPulseType.Event,
-    Exception: QuickPulseType.Exception,
-    Trace: QuickPulseType.Trace,
-    Metric: QuickPulseType.Metric,
-    Request: QuickPulseType.Request,
-    Dependency: QuickPulseType.Dependency,
+export const TelemetryTypeStringToQuickPulseType: {[key in Contracts.TelemetryTypeValues]: QuickPulseType} = {
+    EventData: QuickPulseType.Event,
+    ExceptionData: QuickPulseType.Exception,
+    MessageData: QuickPulseType.Trace,
+    MetricData: QuickPulseType.Metric,
+    RequestData: QuickPulseType.Request,
+    RemoteDependencyData: QuickPulseType.Dependency
 };
 
-export const TelemetryTypeStringToQuickPulseDocumentType: {[key in Contracts.TelemetryTypeKeys]: QuickPulseDocumentType} = {
-    Event: QuickPulseDocumentType.Event,
-    Exception: QuickPulseDocumentType.Exception,
-    Trace: QuickPulseDocumentType.Trace,
-    Metric: QuickPulseDocumentType.Metric,
-    Request: QuickPulseDocumentType.Request,
-    Dependency: QuickPulseDocumentType.Dependency,
+export const TelemetryTypeStringToQuickPulseDocumentType: {[key in Contracts.TelemetryTypeValues]: QuickPulseDocumentType} = {
+    EventData: QuickPulseDocumentType.Event,
+    ExceptionData: QuickPulseDocumentType.Exception,
+    MessageData: QuickPulseDocumentType.Trace,
+    MetricData: QuickPulseDocumentType.Metric,
+    RequestData: QuickPulseDocumentType.Request,
+    RemoteDependencyData: QuickPulseDocumentType.Dependency
 };

--- a/Library/QuickPulseEnvelopeFactory.ts
+++ b/Library/QuickPulseEnvelopeFactory.ts
@@ -157,8 +157,8 @@ class QuickPulseEnvelopeFactory {
 
 
         if (envelope.data.baseType) {
-            __type = Constants.TelemetryTypeStringToQuickPulseType[envelope.data.baseType as Contracts.TelemetryTypeKeys];
-            documentType = Constants.TelemetryTypeStringToQuickPulseDocumentType[envelope.data.baseType as Contracts.TelemetryTypeKeys];
+            __type = Constants.TelemetryTypeStringToQuickPulseType[envelope.data.baseType as Contracts.TelemetryTypeValues];
+            documentType = Constants.TelemetryTypeStringToQuickPulseDocumentType[envelope.data.baseType as Contracts.TelemetryTypeValues];
         } else {
             // Remark: This should never be hit because createQuickPulseDocument is only called within
             // valid baseType values

--- a/Tests/Library/QuickPulseEnvelopeFactory.tests.ts
+++ b/Tests/Library/QuickPulseEnvelopeFactory.tests.ts
@@ -1,0 +1,21 @@
+import assert = require("assert");
+import sinon = require("sinon");
+
+import Contracts = require("../../Declarations/Contracts");
+import Constants = require("../../Declarations/Constants");
+
+describe("Library/QuickPulseEnvelopeFactory", () => {
+    describe("QPS Constants", () => {
+        it("should convert TelemetryTypeValues to QuickPulseType", () => {
+            const keys = Object.keys(Contracts.TelemetryTypeString);
+            assert.ok(keys.length > 0);
+            keys.forEach((key: Contracts.TelemetryTypeKeys) => {
+                const value = Contracts.TelemetryTypeString[key];
+                const qpsType = Constants.TelemetryTypeStringToQuickPulseType[value];
+                const qpsDocType = Constants.TelemetryTypeStringToQuickPulseDocumentType[value];
+                assert.equal(qpsType, Constants.QuickPulseType[key]);
+                assert.equal(qpsDocType, Constants.QuickPulseDocumentType[key]);
+            })
+        });
+    });
+});


### PR DESCRIPTION
Wrong typing and key was used in conversion to qps document type string. Resolved and added a test for this.