### PR TITLE
livemetrics: add lastSendSucceeded to prevent permanent retries

### DIFF
--- a/AutoCollection/Performance.ts
+++ b/AutoCollection/Performance.ts
@@ -247,7 +247,7 @@ class AutoCollectPerformance {
         var intervalFailedRequests = (requests.totalFailedRequestCount - lastRequests.totalFailedRequestCount) || 0;
         var elapsedMs = requests.time - lastRequests.time;
         var elapsedSeconds = elapsedMs / 1000;
-        var averageRequestExecutionTime = AutoCollectPerformance._intervalRequestExecutionTime / intervalRequests;
+        var averageRequestExecutionTime = (AutoCollectPerformance._intervalRequestExecutionTime / intervalRequests) || 0; // default to 0 in case no requests in this interval
         AutoCollectPerformance._intervalRequestExecutionTime = 0; // reset
 
         if (elapsedMs > 0) {
@@ -285,7 +285,7 @@ class AutoCollectPerformance {
             var intervalFailedDependencies = (dependencies.totalFailedDependencyCount - lastDependencies.totalFailedDependencyCount) || 0;
             var elapsedMs = dependencies.time - lastDependencies.time;
             var elapsedSeconds = elapsedMs / 1000;
-            var averageDependencyExecutionTime = AutoCollectPerformance._intervalDependencyExecutionTime / intervalDependencies;
+            var averageDependencyExecutionTime = (AutoCollectPerformance._intervalDependencyExecutionTime / intervalDependencies) || 0;
             AutoCollectPerformance._intervalDependencyExecutionTime = 0; // reset
 
             if (elapsedMs > 0) {

--- a/Library/QuickPulseSender.ts
+++ b/Library/QuickPulseSender.ts
@@ -20,17 +20,17 @@ class QuickPulseSender {
         this._config = config;
     }
 
-    public ping(envelope: Contracts.EnvelopeQuickPulse, done: (shouldPOST: boolean) => void): void {
+    public ping(envelope: Contracts.EnvelopeQuickPulse, done: (shouldPOST: boolean, res?: http.IncomingMessage) => void): void {
         this._submitData(envelope, done, "ping");
     }
 
-    public post(envelope: Contracts.EnvelopeQuickPulse, done: (shouldPOST: boolean, res: http.IncomingMessage) => void): void {
+    public post(envelope: Contracts.EnvelopeQuickPulse, done: (shouldPOST: boolean, res?: http.IncomingMessage) => void): void {
 
         // Important: When POSTing data, envelope must be an array
         this._submitData([envelope], done, "post");
     }
 
-    private _submitData(envelope: Contracts.EnvelopeQuickPulse | Contracts.EnvelopeQuickPulse[], done: (shouldPOST: boolean, res: http.IncomingMessage) => void, postOrPing: "post" | "ping"): void {
+    private _submitData(envelope: Contracts.EnvelopeQuickPulse | Contracts.EnvelopeQuickPulse[], done: (shouldPOST: boolean, res?: http.IncomingMessage) => void, postOrPing: "post" | "ping"): void {
         const payload = JSON.stringify(envelope);
         var options = {
             [AutoCollectHttpDependencies.disableCollectionRequestOption]: true,
@@ -52,7 +52,8 @@ class QuickPulseSender {
         req.on("error", (error: Error) => {
             // Unable to contact qps endpoint.
             // Do nothing for now.
-            Logging.warn("Unable to contact qps endpoint", error);
+            Logging.warn("Unable to contact qps endpoint, dropping this Live Metrics packet", error);
+            done(false); // Stop POSTing QPS data
         });
 
         req.write(payload);

--- a/Tests/Library/QuickPulseStateManager.tests.ts
+++ b/Tests/Library/QuickPulseStateManager.tests.ts
@@ -18,7 +18,7 @@ describe("Library/QuickPulseStateManager", () => {
             assert.equal(qps.config.instrumentationKey, "ikey");
             assert.ok(qps.context);
             assert.equal(qps["_isEnabled"], false);
-            assert.equal(QuickPulseClient["_isCollectingData"], false);
+            assert.equal(qps["_isCollectingData"], false);
             assert.ok(qps["_sender"]);
             assert.ok(Object.keys(qps["_metrics"]).length === 0);
             assert.ok(qps["_documents"].length === 0);
@@ -105,7 +105,7 @@ describe("Library/QuickPulseStateManager", () => {
             assert.ok(pingStub.notCalled);
             assert.ok(postStub.notCalled);
 
-            QuickPulseClient["_isCollectingData"] = true;
+            qps["_isCollectingData"] = true;
             qps.enable(true)
 
             assert.ok(postStub.calledOnce);


### PR DESCRIPTION
- Fixes issue where if live metrics service or a customer's app loses connectivity for more than 20 seconds, sending live metrics wouldn't work unless app is restarted.