### PR TITLE
only log extended duration QPS errors

### DIFF
--- a/Library/QuickPulseSender.ts
+++ b/Library/QuickPulseSender.ts
@@ -60,15 +60,10 @@ class QuickPulseSender {
             // Do nothing for now.
             this._consecutiveErrors++;
 
-            // Log every error, but instead warn when X number of consecutive errors occur
-            let shouldWarn = false;
-            let notice = `Live Metrics endpoint could not be reached ${this._consecutiveErrors} consecutive times. This packet will not appear in Live Metrics. Most recent error:`;
-
+            // LOG every error, but WARN instead when X number of consecutive errors occur
+            let notice = `Transient error connecting to the Live Metrics endpoint. This packet will not appear in your Live Metrics Stream. Error:`;
             if (this._consecutiveErrors % QuickPulseSender.MAX_QPS_FAILURES_BEFORE_WARN === 0) {
-                shouldWarn = !Logging.enableDebug;
-            }
-
-            if (shouldWarn) {
+                notice = `Live Metrics endpoint could not be reached ${this._consecutiveErrors} consecutive times. Most recent error:`;
                 Logging.warn(QuickPulseSender.TAG, notice, error);
             } else {
                 Logging.info(QuickPulseSender.TAG, notice, error);

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ separately from clients created with `new appInsights.TelemetryClient()`.
 | ------------------------------- |------------------------------------------------------------------------------------------------------------|
 | instrumentationKey              | An identifier for your Application Insights resource                                                       |
 | endpointUrl                     | The ingestion endpoint to send telemetry payloads to                                                       |
+| quickPulseHost                  | The Live Metrics Stream host to send live metrics telemetry to                                             |
 | proxyHttpUrl                    | A proxy server for SDK HTTP traffic (Optional, Default pulled from `http_proxy` environment variable)      |
 | proxyHttpsUrl                   | A proxy server for SDK HTTPS traffic (Optional, Default pulled from `https_proxy` environment variable)    |
 | httpAgent                       | An http.Agent to use for SDK HTTP traffic (Optional, Default undefined)                                    |


### PR DESCRIPTION
- If verbose debugging is enabled, log QPS errors only when POSTing
- If verbose debugging is disabled, log QPS errors only if they persist for an extended amount of time
as per discussion in #510 