### PR TITLE
parse nonstring request-context header

### DIFF
--- a/AutoCollection/HttpDependencies.ts
+++ b/AutoCollection/HttpDependencies.ts
@@ -122,31 +122,33 @@ class AutoCollectHttpDependencies {
         // methods exist before invoking them.
         if (Util.canIncludeCorrelationHeader(client, requestParser.getUrl()) && telemetry.request.getHeader && telemetry.request.setHeader) {
             if (client.config && client.config.correlationId) {
-                const correlationHeader = telemetry.request.getHeader(RequestResponseHeaders.requestContextHeader);
-                if (correlationHeader) {
-                    const components = correlationHeader.split(",");
-                    const key = `${RequestResponseHeaders.requestContextSourceKey}=`;
-                    if (!components.some((value) => value.substring(0,key.length) === key)) {
-                        telemetry.request.setHeader(
-                            RequestResponseHeaders.requestContextHeader,
-                            `${correlationHeader},${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
-                    }
+                // getHeader returns "any" type in newer versions of node. In basic scenarios, this will be <string | string[] | number>, but could be modified to anything else via middleware
+                const correlationHeader = <any>telemetry.request.getHeader(RequestResponseHeaders.requestContextHeader)
+                if (typeof correlationHeader === "string") {
+                    AutoCollectHttpDependencies.addRequestCorrelationIdHeaderFromString(client, telemetry, correlationHeader)
+                } else if (correlationHeader instanceof Array) { // string[]
+                    const headers = correlationHeader.join(",");
+                    AutoCollectHttpDependencies.addRequestCorrelationIdHeaderFromString(client, telemetry, headers)
+                } else if (correlationHeader && typeof (correlationHeader as any).toString === "function") {
+                    // best effort attempt: requires well-defined toString
+                    const header = (correlationHeader as any).toString();
+                    AutoCollectHttpDependencies.addRequestCorrelationIdHeaderFromString(client, telemetry, header);
                 } else {
                     telemetry.request.setHeader(
                         RequestResponseHeaders.requestContextHeader,
                         `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
                 }
-            }
 
-            if (currentContext && currentContext.operation) {
-                telemetry.request.setHeader(RequestResponseHeaders.requestIdHeader, uniqueRequestId);
-                // Also set legacy headers
-                telemetry.request.setHeader(RequestResponseHeaders.parentIdHeader, currentContext.operation.id);
-                telemetry.request.setHeader(RequestResponseHeaders.rootIdHeader, uniqueRequestId);
+                if (currentContext && currentContext.operation) {
+                    telemetry.request.setHeader(RequestResponseHeaders.requestIdHeader, uniqueRequestId);
+                    // Also set legacy headers
+                    telemetry.request.setHeader(RequestResponseHeaders.parentIdHeader, currentContext.operation.id);
+                    telemetry.request.setHeader(RequestResponseHeaders.rootIdHeader, uniqueRequestId);
 
-                const correlationContextHeader = (<PrivateCustomProperties>currentContext.customProperties).serializeToHeader();
-                if (correlationContextHeader) {
-                    telemetry.request.setHeader(RequestResponseHeaders.correlationContextHeader, correlationContextHeader);
+                    const correlationContextHeader = (<PrivateCustomProperties>currentContext.customProperties).serializeToHeader();
+                    if (correlationContextHeader) {
+                        telemetry.request.setHeader(RequestResponseHeaders.correlationContextHeader, correlationContextHeader);
+                    }
                 }
             }
         }
@@ -184,6 +186,18 @@ class AutoCollectHttpDependencies {
         AutoCollectHttpDependencies.INSTANCE = null;
         this.enable(false);
         this._isInitialized = false;
+    }
+
+    private static addRequestCorrelationIdHeaderFromString(client: TelemetryClient, telemetry: Contracts.NodeHttpDependencyTelemetry, correlationHeader: string) {
+        const components = correlationHeader.split(",");
+        const key = `${RequestResponseHeaders.requestContextSourceKey}=`;
+        const found = components.some(value => value.substring(0,key.length) === key);
+
+        if (!found) {
+            telemetry.request.setHeader(
+                RequestResponseHeaders.requestContextHeader,
+                `${correlationHeader},${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
+        }
     }
 }
 

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -255,6 +255,7 @@ class Util {
         }
     }
 
+
     /**
      * Generate request
      *
@@ -331,5 +332,44 @@ class Util {
         }
 
     };
+
+    /**
+     * Parse standard <string | string[] | number> request-context header
+     */
+    public static safeIncludeCorrelationHeader(client: TelemetryClient, request: http.ClientRequest | http.ServerResponse, correlationHeader: any) {
+        let header: string; // attempt to cast correlationHeader to string
+        if (typeof correlationHeader === "string") {
+            header = correlationHeader;
+        } else if (correlationHeader instanceof Array) { // string[]
+            header = correlationHeader.join(",");
+        } else if (correlationHeader && typeof (correlationHeader as any).toString === "function") {
+            // best effort attempt: requires well-defined toString
+            try {
+                header = (correlationHeader as any).toString();
+            } catch (err) {
+                Logging.warn("Outgoing request-context header could not be read. Correlation of requests may be lost.", err, correlationHeader);
+            }
+        }
+
+        if (header) {
+            Util.addCorrelationIdHeaderFromString(client, request, header);
+        } else {
+            request.setHeader(
+                RequestResponseHeaders.requestContextHeader,
+                `${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
+        }
+    }
+
+    private static addCorrelationIdHeaderFromString(client: TelemetryClient, response: http.ClientRequest | http.ServerResponse, correlationHeader: string) {
+        const components = correlationHeader.split(",");
+        const key = `${RequestResponseHeaders.requestContextSourceKey}=`;
+        const found = components.some(value => value.substring(0,key.length) === key);
+
+        if (!found) {
+            response.setHeader(
+                RequestResponseHeaders.requestContextHeader,
+                `${correlationHeader},${RequestResponseHeaders.requestContextSourceKey}=${client.config.correlationId}`);
+        }
+    }
 }
 export = Util;

--- a/Tests/AutoCollection/HttpDependencies.tests.ts
+++ b/Tests/AutoCollection/HttpDependencies.tests.ts
@@ -22,4 +22,46 @@ describe("AutoCollection/HttpDependencies", () => {
             assert.equal(enableHttpDependenciesSpy.getCall(1).args[0], false);
         });
     });
+    describe("#trackRequest", () => {
+        var telemetry = {
+            options: {},
+            request: {
+                headers: <{[key: string]: any} >{},
+                getHeader: function (name: string) { return this.headers[name] },
+                setHeader: function (name: string, value: any) { this.headers[name] = value },
+                clearHeaders: function() { this.headers = {} }
+            }
+        }
+
+        afterEach(() => {
+            AppInsights.dispose();
+            telemetry.request.clearHeaders();
+        });
+        it("should accept string request-context", () => {
+            var appInsights = AppInsights.setup("key").setAutoCollectDependencies(true);
+            AppInsights.defaultClient.config.correlationId = "abcdefg";
+            appInsights.start();
+
+            telemetry.request.setHeader("request-context", "appId=cid-v1:aaaaed48-297a-4ea2-af46-0a5a5d26aaaa");
+            assert.doesNotThrow(() => HttpDependencies.trackRequest(AppInsights.defaultClient, telemetry as any));
+        });
+
+        it ("should accept nonstring request-context", () => {
+            var appInsights = AppInsights.setup("key").setAutoCollectDependencies(true);
+            AppInsights.defaultClient.config.correlationId = "abcdefg";
+            appInsights.start();
+
+            telemetry.request.setHeader("request-context", ["appId=cid-v1:aaaaed48-297a-4ea2-af46-0a5a5d26aaaa"]);
+            assert.doesNotThrow(() => HttpDependencies.trackRequest(AppInsights.defaultClient, telemetry as any));
+            assert.deepEqual(telemetry.request.getHeader("request-context"), ["appId=cid-v1:aaaaed48-297a-4ea2-af46-0a5a5d26aaaa"], "does not modify valid appId header")
+
+            telemetry.request.setHeader("request-context", 123);
+            assert.doesNotThrow(() => HttpDependencies.trackRequest(AppInsights.defaultClient, telemetry as any));
+            assert.ok(telemetry.request.getHeader("request-context").indexOf("abcdefg") !== -1)
+
+            telemetry.request.setHeader("request-context", {foo: 'bar'});
+            assert.doesNotThrow(() => HttpDependencies.trackRequest(AppInsights.defaultClient, telemetry as any));
+            assert.ok(telemetry.request.getHeader("request-context").indexOf("abcdefg") !== -1)
+        });
+    });
 });


### PR DESCRIPTION
Fixes #512 

`getHeader` returns a type of `any` instead of `string`. Only occurrence of this in the SDK is with `request-context` parsing. This PR attempts to parse `request-context` header for `<string | string[] | number>`, else it fallsback to `toString`. Current node typings dev dependency of this SDK has the type as returning a string, so it may be useful to upgrade to a more recent typings version for SDK development.