### PR TITLE
qps: never change ping state on errors

### DIFF
--- a/Library/QuickPulseSender.ts
+++ b/Library/QuickPulseSender.ts
@@ -65,12 +65,12 @@ class QuickPulseSender {
             if (this._consecutiveErrors % QuickPulseSender.MAX_QPS_FAILURES_BEFORE_WARN === 0) {
                 notice = `Live Metrics endpoint could not be reached ${this._consecutiveErrors} consecutive times. Most recent error:`;
                 Logging.warn(QuickPulseSender.TAG, notice, error);
-                done(false); // Stop POSTing QPS data
             } else {
                 // Potentially transient error, do not change the ping/post state yet.
                 Logging.info(QuickPulseSender.TAG, notice, error);
-                done();
             }
+
+            done();
         });
 
         req.write(payload);

--- a/Library/QuickPulseStateManager.ts
+++ b/Library/QuickPulseStateManager.ts
@@ -152,21 +152,28 @@ class QuickPulseStateManager {
         this._sender.post(envelope, this._quickPulseDone.bind(this));
     }
 
-    private _quickPulseDone(shouldPOST: boolean, res?: http.IncomingMessage): void {
-        if (this._isCollectingData !== shouldPOST) {
-            Logging.info("Live Metrics sending data", shouldPOST);
-            this.enableCollectors(shouldPOST);
-        }
-        this._isCollectingData = shouldPOST;
+    /**
+     * Change the current QPS send state. (shouldPOST == undefined) --> error, but do not change the state yet.
+     */
+    private _quickPulseDone(shouldPOST?: boolean, res?: http.IncomingMessage): void {
+        if (shouldPOST != undefined) {
+            if (this._isCollectingData !== shouldPOST) {
+                Logging.info("Live Metrics sending data", shouldPOST);
+                this.enableCollectors(shouldPOST);
+            }
+            this._isCollectingData = shouldPOST;
 
-        if (res && res.statusCode < 300 && res.statusCode >= 200) {
-            this._lastSuccessTime = Date.now();
-            this._lastSendSucceeded = true;
+            if (res && res.statusCode < 300 && res.statusCode >= 200) {
+                this._lastSuccessTime = Date.now();
+                this._lastSendSucceeded = true;
+            } else {
+                this._lastSendSucceeded = false;
+            }
         } else {
+            // Received an error, keep the state as is
             this._lastSendSucceeded = false;
         }
     }
-
 }
 
 export = QuickPulseStateManager;


### PR DESCRIPTION
Adds a third scenario to the `done` callback for QPS transmissions. 

To follow the live metrics error handling pattern of other SDKs, this PR instead stays in POSTing mode indefinitely. The ping/post state can only change by a successful QPS response. The SDK will instead rely on the existing setTimeout fallback logic (if only errors, wait 60 seconds before sending again) for extended erroring scenarios.