### PR TITLE
ship mapfiles

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,7 +14,7 @@ Tests
 # Don't publish source files that aren't needed in package
 *.ts
 !*.d.ts
-*.js.map
+!*.js.map
 .travis.yml
 .ntvs_analysis.dat
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",
+        "inlineSources": true,
         "sourceMap": true,
         "declaration": true,
         "noImplicitAny": true,


### PR DESCRIPTION
#523
Updates `.npmignore` to not ignore built mapfiles.