### PR TITLE
publishers: Update package version to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -202,9 +202,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.2.tgz",
-      "integrity": "sha512-2hBlg1BtBT+nd04MGGGZinDv5gOTRQOCzdgk+KRQZ20XJ/uepC0B0rwWLQtz6Tk6InXymWqsk1sMC975cPEReA=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
+      "integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
     },
     "diff": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "cls-hooked": "^4.2.2",
     "continuation-local-storage": "^3.2.1",
     "diagnostic-channel": "0.2.0",
-    "diagnostic-channel-publishers": "^0.3.2"
+    "diagnostic-channel-publishers": "^0.3.3"
   }
 }


### PR DESCRIPTION
Update `diagnostic-channel-publishers` to latest version, `0.3.3`. This PR is not actually necessary as a lockfile is not published or used in functional tests, so this version is already being used.