### PR TITLE
fix(w3c): use correct default trace flag

### DIFF
--- a/Library/Traceparent.ts
+++ b/Library/Traceparent.ts
@@ -7,7 +7,7 @@ import CorrelationIdManager = require("./CorrelationIdManager");
  * https://www.w3.org/TR/trace-context/#traceparent-field
  */
 class Traceparent {
-    private static DEFAULT_TRACE_FLAG = "00";
+    private static DEFAULT_TRACE_FLAG = "01";
     private static DEFAULT_VERSION = "00";
 
     public legacyRootId: string;
@@ -56,7 +56,7 @@ class Traceparent {
 
                 // TraceFlag validation
                 if (!this.traceFlag.match(/^[0-9a-f]{2}$/g)) {
-                    this.traceFlag = Traceparent.DEFAULT_VERSION;
+                    this.traceFlag = Traceparent.DEFAULT_TRACE_FLAG;
                     this.traceId = Util.w3cTraceId();
                 }
 

--- a/Tests/AutoCollection/HttpRequestParser.tests.ts
+++ b/Tests/AutoCollection/HttpRequestParser.tests.ts
@@ -59,11 +59,11 @@ describe("AutoCollection/HttpRequestParser", () => {
             assert.ok(Util.isValidW3CId(requestTags[(<any>HttpRequestParser).keys.operationId]));
             assert.ok(Util.isValidW3CId(helper["requestId"].substr(1, 32)));
             const traceparent = helper["traceparent"];
-            assert.equal(traceparent.version, "00");
+            assert.equal(traceparent.version, Traceparent["DEFAULT_VERSION"]);
             assert.ok(Util.isValidW3CId(traceparent.traceId));
             assert.ok(Traceparent.isValidSpanId(traceparent.spanId));
             assert.notEqual(traceparent.traceId, traceparent.spanId);
-            assert.equal(traceparent.traceFlag, "00");
+            assert.equal(traceparent.traceFlag, Traceparent["DEFAULT_TRACE_FLAG"]);
         });
 
         it("if w3c tracing is enabled and request-id in format of X", () => {
@@ -74,11 +74,11 @@ describe("AutoCollection/HttpRequestParser", () => {
             assert.equal(helper["legacyRootId"], "abc");
             assert.ok(Util.isValidW3CId(requestTags[(<any>HttpRequestParser).keys.operationId]));
             const traceparent = helper["traceparent"];
-            assert.equal(traceparent.version, "00");
+            assert.equal(traceparent.version, Traceparent["DEFAULT_VERSION"]);
             assert.ok(Util.isValidW3CId(traceparent.traceId));
             assert.ok(Traceparent.isValidSpanId(traceparent.spanId));
             assert.notEqual(traceparent.traceId, traceparent.spanId);
-            assert.equal(traceparent.traceFlag, "00");
+            assert.equal(traceparent.traceFlag, Traceparent["DEFAULT_TRACE_FLAG"]);
         });
 
         it("should generate a traceparent if both tracing headers are not present (p4)", () => {
@@ -89,11 +89,11 @@ describe("AutoCollection/HttpRequestParser", () => {
             assert.ok(helper["requestId"].match(backCompatFormat));
             assert.ok(Util.isValidW3CId(requestTags[(<any>HttpRequestParser).keys.operationId]));
             const traceparent = helper["traceparent"];
-            assert.equal(traceparent.version, "00");
+            assert.equal(traceparent.version, Traceparent["DEFAULT_VERSION"]);
             assert.ok(Util.isValidW3CId(traceparent.traceId));
             assert.ok(Traceparent.isValidSpanId(traceparent.spanId));
             assert.notEqual(traceparent.traceId, traceparent.spanId);
-            assert.equal(traceparent.traceFlag, "00");
+            assert.equal(traceparent.traceFlag, Traceparent["DEFAULT_TRACE_FLAG"]);
 
             assert.equal(traceparent.traceId, helper["operationId"]);
             assert.notEqual(traceparent.spanId, helper["operationId"]);

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -355,7 +355,7 @@ describe("EndToEnd", () => {
             }));
             https.request(<any>'https://test.com', (c) => {
                 eventEmitter.emit("response", {});
-                assert.ok((eventEmitter as any).headers.traceparent.match(/^00-[0-z]{32}-[0-z]{16}-00/g), "traceparent header is passed, 00-W3C-W3C-00");
+                assert.ok((eventEmitter as any).headers.traceparent.match(/^00-[0-z]{32}-[0-z]{16}-[0-9a-f]{2}/g), "traceparent header is passed, 00-W3C-W3C-00");
                 assert.ok((eventEmitter as any).headers["request-id"].match(/^\|[0-z]{32}\.[0-z]{16}\./g), "back compat header is also passed, |W3C.W3C." + (eventEmitter as any).headers["request-id"]);
                 CorrelationIdManager.w3cEnabled = false;
                 AppInsights.defaultClient.flush();


### PR DESCRIPTION
Default W3C trace flag should be `"01"`, sampled in. This flag should be modified (in future PR) based on whether or not this trace context is being sampled in or out by this SDK.