### PR TITLE
change(winston/console): send exception if error provided to logger

### DIFF
--- a/AutoCollection/diagnostic-channel/bunyan.sub.ts
+++ b/AutoCollection/diagnostic-channel/bunyan.sub.ts
@@ -23,7 +23,7 @@ const subscriber = (event: IStandardEvent<bunyan.IBunyanData>) => {
     const message = event.data.result as Error | string;
     clients.forEach((client) => {
         const AIlevel = bunyanToAILevelMap[event.data.level];
-        if ((message) instanceof Error) {
+        if (message instanceof Error) {
             client.trackException({ exception: (message) });
         } else {
             client.trackTrace({message: message, severity: AIlevel});
@@ -43,4 +43,9 @@ export function enable(enabled: boolean, client: TelemetryClient) {
             channel.unsubscribe("bunyan", subscriber);
         }
     }
+}
+
+export function dispose() {
+    channel.unsubscribe("bunyan", subscriber);
+    clients = [];
 }

--- a/AutoCollection/diagnostic-channel/bunyan.sub.ts
+++ b/AutoCollection/diagnostic-channel/bunyan.sub.ts
@@ -20,9 +20,14 @@ const bunyanToAILevelMap: {[key: number] : number} = {
 };
 
 const subscriber = (event: IStandardEvent<bunyan.IBunyanData>) => {
+    const message = event.data.result as Error | string;
     clients.forEach((client) => {
         const AIlevel = bunyanToAILevelMap[event.data.level];
-        client.trackTrace({message: event.data.result, severity: AIlevel});
+        if ((message) instanceof Error) {
+            client.trackException({ exception: (message) });
+        } else {
+            client.trackTrace({message: message, severity: AIlevel});
+        }
     });
 };
 

--- a/AutoCollection/diagnostic-channel/console.sub.ts
+++ b/AutoCollection/diagnostic-channel/console.sub.ts
@@ -37,3 +37,8 @@ export function enable(enabled: boolean, client: TelemetryClient) {
         }
     }
 }
+
+export function dispose() {
+    channel.unsubscribe("console", subscriber);
+    clients = [];
+}

--- a/AutoCollection/diagnostic-channel/console.sub.ts
+++ b/AutoCollection/diagnostic-channel/console.sub.ts
@@ -10,13 +10,17 @@ import {console as consolePub} from "diagnostic-channel-publishers";
 let clients: TelemetryClient[] = [];
 
 const subscriber = (event: IStandardEvent<consolePub.IConsoleData>) => {
+    let message = event.data.message as Error | string;
     clients.forEach((client) => {
-        // Message can have a trailing newline
-        let message = event.data.message;
-        if (message.lastIndexOf("\n") == message.length - 1) {
-            message = message.substring(0, message.length - 1);
+        if (message instanceof Error) {
+            client.trackException({ exception: message});
+        } else {
+            // Message can have a trailing newline
+            if (message.lastIndexOf("\n") == message.length - 1) {
+                message = message.substring(0, message.length - 1);
+            }
+            client.trackTrace({message: message, severity: (event.data.stderr ? SeverityLevel.Warning : SeverityLevel.Information)});
         }
-        client.trackTrace({message: message, severity: (event.data.stderr ? SeverityLevel.Warning : SeverityLevel.Information)});
     });
 };
 

--- a/AutoCollection/diagnostic-channel/initialization.ts
+++ b/AutoCollection/diagnostic-channel/initialization.ts
@@ -25,7 +25,7 @@ if (IsInitialized) {
     };
     for (const mod in modules) {
         if (unpatchedModules.indexOf(mod) === -1) {
-           modules[mod].enable();
+            modules[mod].enable();
         }
     }
 }

--- a/Tests/AutoCollection/Console.tests.ts
+++ b/Tests/AutoCollection/Console.tests.ts
@@ -4,6 +4,10 @@ import Console = require("../../AutoCollection/Console")
 
 import AppInsights = require("../../applicationinsights");
 
+import { channel, IStandardEvent } from "diagnostic-channel";
+import { enable, dispose as disable } from "../../AutoCollection/diagnostic-channel/console.sub";
+import { console } from "diagnostic-channel-publishers";
+
 describe("AutoCollection/Console", () => {
     afterEach(() => {
         AppInsights.dispose();
@@ -20,6 +24,44 @@ describe("AutoCollection/Console", () => {
             AppInsights.dispose();
             assert.equal(enableConsoleRequestsSpy.callCount, 2, "enable(false) should be called once as part of console autocollection shutdown");
             assert.equal(enableConsoleRequestsSpy.getCall(1).args[0], false);
+        });
+    });
+
+    describe("#log and #error()", () => {
+        it("should call trackException for errors and trackTrace for logs", () => {
+            var appInsights = AppInsights.setup("key");
+            appInsights.start();
+
+            const trackExceptionStub = sinon.stub(AppInsights.defaultClient, "trackException");
+            const trackTraceStub = sinon.stub(AppInsights.defaultClient, "trackTrace");
+
+            disable();
+            enable(true, AppInsights.defaultClient);
+            const logEvent: console.IConsoleData = {
+                message: "test log",
+                stderr: true // should log as MessageData regardless of this setting
+            };
+            const dummyError = new Error("test error");
+            const errorEvent: console.IConsoleData = {
+                message: dummyError as any,
+                stderr: false, // log() should still log as ExceptionData
+            };
+
+            channel.publish("console", logEvent);
+            assert.ok(trackExceptionStub.notCalled);
+            assert.ok(trackTraceStub.calledOnce);
+            assert.deepEqual(trackTraceStub.args[0][0].message, "test log");
+            trackExceptionStub.reset();
+            trackTraceStub.reset();
+
+            channel.publish("console", errorEvent);
+            assert.ok(trackExceptionStub.calledOnce);
+            assert.ok(trackTraceStub.notCalled);
+            assert.deepEqual(trackExceptionStub.args[0][0].exception, dummyError);
+
+            disable();
+            trackExceptionStub.restore();
+            trackTraceStub.restore();
         });
     });
 });

--- a/Tests/AutoCollection/bunyan.tests.ts
+++ b/Tests/AutoCollection/bunyan.tests.ts
@@ -2,10 +2,10 @@ import assert = require("assert");
 import sinon = require("sinon");
 import AppInsights = require("../../applicationinsights");
 import { channel, IStandardEvent } from "diagnostic-channel";
-import { enable, dispose as disable } from "../../AutoCollection/diagnostic-channel/winston.sub";
-import { winston } from "diagnostic-channel-publishers";
+import { enable, dispose as disable } from "../../AutoCollection/diagnostic-channel/bunyan.sub";
+import { bunyan } from "diagnostic-channel-publishers";
 
-describe("diagnostic-channel/winston", () => {
+describe("diagnostic-channel/bunyan", () => {
     afterEach(() => {
         AppInsights.dispose();
         disable();
@@ -19,28 +19,24 @@ describe("diagnostic-channel/winston", () => {
 
         disable();
         enable(true, AppInsights.defaultClient);
-        const logEvent: winston.IWinstonData = {
-            message: "test log",
-            meta: {},
-            level: "foo",
-            levelKind: "npm"
+        const logEvent: bunyan.IBunyanData = {
+            result: "test log",
+            level: 50 // Error should still log as MessageData
         };
         const dummyError = new Error("test error");
-        const errorEvent: winston.IWinstonData = {
-            message: dummyError as any,
-            meta: {},
-            level: "foo",
-            levelKind: "npm"
+        const errorEvent: bunyan.IBunyanData = {
+            result: dummyError as any,
+            level: 10, // Verbose should still log as ExceptionData
         };
 
-        channel.publish("winston", logEvent);
+        channel.publish("bunyan", logEvent);
         assert.ok(trackExceptionStub.notCalled);
         assert.ok(trackTraceStub.calledOnce);
         assert.deepEqual(trackTraceStub.args[0][0].message, "test log");
         trackExceptionStub.reset();
         trackTraceStub.reset();
 
-        channel.publish("winston", errorEvent);
+        channel.publish("bunyan", errorEvent);
         assert.ok(trackExceptionStub.calledOnce);
         assert.ok(trackTraceStub.notCalled);
         assert.deepEqual(trackExceptionStub.args[0][0].exception, dummyError);

--- a/Tests/AutoCollection/winston.tests.ts
+++ b/Tests/AutoCollection/winston.tests.ts
@@ -1,0 +1,50 @@
+import assert = require("assert");
+import sinon = require("sinon");
+import AppInsights = require("../../applicationinsights");
+import { channel, IStandardEvent } from "diagnostic-channel";
+import { enable, dispose as disable } from "../../AutoCollection/diagnostic-channel/winston.sub";
+import { winston } from "diagnostic-channel-publishers";
+
+describe("diagnostic-channel/winston", () => {
+    afterEach(() => {
+        AppInsights.dispose();
+    });
+    it("should call trackException for errors, trackTrace for logs", () => {
+        AppInsights.setup("key").setAutoCollectConsole(true);
+        AppInsights.start();
+
+        const trackExceptionStub = sinon.stub(AppInsights.defaultClient, "trackException");
+        const trackTraceStub = sinon.stub(AppInsights.defaultClient, "trackTrace");
+
+        disable();
+        enable(true, AppInsights.defaultClient);
+        const logEvent: winston.IWinstonData = {
+            message: "test log",
+            meta: {},
+            level: "foo",
+            levelKind: "npm"
+        };
+        const dummyError = new Error("test error");
+        const errorEvent: winston.IWinstonData = {
+            message: dummyError as any,
+            meta: {},
+            level: "foo",
+            levelKind: "npm"
+        };
+
+        channel.publish("winston", logEvent);
+        assert.ok(trackExceptionStub.notCalled);
+        assert.ok(trackTraceStub.calledOnce);
+        assert.deepEqual(trackTraceStub.args[0][0].message, "test log");
+        trackExceptionStub.reset();
+        trackTraceStub.reset();
+
+        channel.publish("winston", errorEvent);
+        assert.ok(trackExceptionStub.calledOnce);
+        assert.ok(trackTraceStub.notCalled);
+        assert.deepEqual(trackExceptionStub.args[0][0].exception, dummyError);
+
+        trackExceptionStub.restore();
+        trackTraceStub.restore();
+    });
+});


### PR DESCRIPTION
For scenarios where `winston.error` is used to log an `Error`, we will now call `trackException` instead of sending log data with `trackTrace`. A similar change is made to all other supported loggers (`console` and `bunyan`) An example:
```js
try {
  ...
} catch (e) {
  winston.error(e); // this will now send 'e' as exception telemetry instead of log telemetry
}
```
This PR also fixes the unit test reliability of `Performance.tests.ts`