### PR TITLE
feat(diag): add mongo enhanced query collection

### DIFF
--- a/Library/Config.ts
+++ b/Library/Config.ts
@@ -46,6 +46,11 @@ class Config {
     public httpAgent: http.Agent;
     /** An https.Agent to use for SDK HTTPS traffic (Optional, Default undefined) */
     public httpsAgent: https.Agent;
+    /** (Off by default) If true, when depdency telemetry is autocollected, more information about it
+     *  will be collected. E.g. what filters were used for a "find" MongoDB query. PII/secrets
+     *  are not scrubbed. This functionality is experimental and is subject to change across releases.
+     **/
+    public enhancedDependencyCollection = false;
 
     private endpointBase: string = "https://dc.services.visualstudio.com";
     private setCorrelationId: (v: string) => void;

--- a/Tests/AutoCollection/mongo.tests.ts
+++ b/Tests/AutoCollection/mongo.tests.ts
@@ -1,0 +1,82 @@
+import assert = require("assert");
+import sinon = require("sinon");
+import AppInsights = require("../../applicationinsights");
+import { channel, IStandardEvent } from "diagnostic-channel";
+import { enable, dispose as disable } from "../../AutoCollection/diagnostic-channel/mongodb.sub";
+import { mongodb } from "diagnostic-channel-publishers";
+
+describe("diagnostic-channel/mongodb", () => {
+    afterEach(() => {
+        AppInsights.dispose();
+        disable();
+    });
+
+    it("should send enhanced autocollection telemetry if enhancedDependencyCollection === true", () => {
+        AppInsights.setup("key");
+        AppInsights.start();
+
+        const trackDependencyStub = sinon.stub(AppInsights.defaultClient, "trackDependency");
+
+        disable();
+        enable(true, AppInsights.defaultClient);
+
+        const mongoEvent: mongodb.IMongoData = {
+            startedData: {
+                command: {
+                    find: {
+                        filter: {},
+                        find: "some database"
+                    },
+                    insert: {
+                        foo: "bar"
+                    }
+                }
+            },
+            event: {
+                commandName: "find"
+            },
+            succeeded: true
+        }
+        AppInsights.defaultClient.config.enhancedDependencyCollection = true;
+        channel.publish("mongodb", mongoEvent);
+
+        assert.ok(trackDependencyStub.calledOnce);
+        assert.deepEqual(trackDependencyStub.args[0][0].data, JSON.stringify(mongoEvent.startedData.command.find))
+
+        trackDependencyStub.restore();
+    });
+
+    it("should not send enhanced autocollection telemetry by default", () => {
+        AppInsights.setup("key");
+        AppInsights.start();
+
+        const trackDependencyStub = sinon.stub(AppInsights.defaultClient, "trackDependency");
+
+        disable();
+        enable(true, AppInsights.defaultClient);
+
+        const mongoEvent: mongodb.IMongoData = {
+            startedData: {
+                command: {
+                    find: {
+                        filter: {},
+                        find: "some database"
+                    },
+                    insert: {
+                        foo: "bar"
+                    }
+                }
+            },
+            event: {
+                commandName: "find"
+            },
+            succeeded: true
+        }
+        channel.publish("mongodb", mongoEvent);
+
+        assert.ok(trackDependencyStub.calledOnce);
+        assert.deepEqual(trackDependencyStub.args[0][0].data, mongoEvent.event.commandName)
+
+        trackDependencyStub.restore();
+    });
+});


### PR DESCRIPTION
Adds experimental (opt-in) configuration option on `Config` to opt into sending more detailed query information for autocollected dependencies. Currently only mongodb queries will work. Support for other libraries will be added in separate PRs (and future releases).

This feature is intended to be experimental in that the format of the data or the actual data could change in future releases. Other libraries will also be supported, which would cause more telemetry volume to be sent if this feature is enabled.