### PR TITLE
chore: bump versions to 1.5.0

### DIFF
--- a/Tests/Library/Context.tests.ts
+++ b/Tests/Library/Context.tests.ts
@@ -40,7 +40,7 @@ describe("Library/Context", () => {
         it("should set internalSdkVersion to 'node:<version>'", () => {
             var context = new Context();
             // todo: make this less fragile (will need updating on each minor version change)
-            assert.equal(context.tags[context.keys.internalSdkVersion].substring(0, 9), "node:1.4.");
+            assert.equal(context.tags[context.keys.internalSdkVersion].substring(0, 9), "node:1.5.");
         });
 
         it("should correctly set device context", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "applicationinsights",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "applicationinsights",
   "license": "MIT",
   "bugs": "https://github.com/Microsoft/ApplicationInsights-node.js/issues",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Microsoft Application Insights module for Node.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`1.4.2`...`1.5.0`: minor version bump due to new feature: connection string parsing #538 