### PR TITLE
Fix exception caused by autocollector exception handlers

### DIFF
--- a/AutoCollection/Exceptions.ts
+++ b/AutoCollection/Exceptions.ts
@@ -12,7 +12,7 @@ class AutoCollectExceptions {
     public static get UNCAUGHT_EXCEPTION_HANDLER_NAME(): string { return "uncaughtException"; }
     public static get UNHANDLED_REJECTION_HANDLER_NAME(): string { return "unhandledRejection"; }
 
-    private static _FALLBACK_ERROR_MESSAGE = "No error was provided. Application Insights generated this error stack for you.";
+    private static _FALLBACK_ERROR_MESSAGE = "A promise was rejected without providing an error. Application Insights generated this error stack for you.";
     private _exceptionListenerHandle: (reThrow: boolean, error: Error) => void;
     private _rejectionListenerHandle: (reThrow: boolean, error: Error) => void;
     private _client: TelemetryClient;

--- a/Tests/js/endToEnd.js
+++ b/Tests/js/endToEnd.js
@@ -53,4 +53,17 @@ describe('module', function () {
             });
         });
     });
+
+    describe('rejected promises', () => {
+        it('should not crash on rejected promises containing no callstack', () => {
+            var appInsights = require('../../');
+            appInsights.setup("ikey").start();
+            assert.ok(appInsights.defaultClient);
+            assert.doesNotThrow(() => {
+                Promise.reject();
+            });
+            appInsights.defaultClient.flush();
+            appInsights.dispose();
+        });
+    });
 });

--- a/Tests/js/endToEnd.js
+++ b/Tests/js/endToEnd.js
@@ -54,12 +54,12 @@ describe('module', function () {
         });
     });
 
-    describe('rejected promises', () => {
-        it('should not crash on rejected promises containing no callstack', () => {
+    describe('rejected promises', function () {
+        it('should not crash on rejected promises containing no callstack', function () {
             var appInsights = require('../../');
             appInsights.setup("ikey").start();
             assert.ok(appInsights.defaultClient);
-            assert.doesNotThrow(() => {
+            assert.doesNotThrow(function () {
                 Promise.reject();
             });
             appInsights.defaultClient.flush();

--- a/Tests/js/endToEnd.js
+++ b/Tests/js/endToEnd.js
@@ -57,10 +57,12 @@ describe('module', function () {
     describe('rejected promises', function () {
         it('should not crash on rejected promises containing no callstack', function () {
             var appInsights = require('../../');
-            appInsights.setup("ikey").start();
+            appInsights.setup('ikey').start();
             assert.ok(appInsights.defaultClient);
             assert.doesNotThrow(function () {
-                Promise.reject();
+                if (typeof Promise !== 'undefined') {
+                    Promise.reject();
+                }
             });
             appInsights.defaultClient.flush();
             appInsights.dispose();


### PR DESCRIPTION
Fixes #489 
- Adds a fallback error which is created when no error is passed to the unhandled error handlers, e.g via `Promise.reject()`