### PR TITLE
feat: add diagnostic-channel debug logging

### DIFF
--- a/AutoCollection/diagnostic-channel/initialization.ts
+++ b/AutoCollection/diagnostic-channel/initialization.ts
@@ -5,12 +5,14 @@
 // This is to avoid requiring the actual module if the NO_DIAGNOSTIC_CHANNEL env is present
 import * as DiagChannelPublishers from "diagnostic-channel-publishers";
 import * as DiagChannel from "diagnostic-channel";
+import Logging = require("../../Library/Logging");
 
 export const IsInitialized = !process.env["APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL"];
+const TAG = "DiagnosticChannel";
 
 if (IsInitialized) {
     const publishers: typeof DiagChannelPublishers = require("diagnostic-channel-publishers");
-    const individualOptOuts = process.env["APPLICATION_INSIGHTS_NO_PATCH_MODULES"] || "";
+    const individualOptOuts: string = process.env["APPLICATION_INSIGHTS_NO_PATCH_MODULES"] || "";
     const unpatchedModules = individualOptOuts.split(",");
     const modules: {[key: string] : any} = {
         bunyan: publishers.bunyan,
@@ -26,8 +28,14 @@ if (IsInitialized) {
     for (const mod in modules) {
         if (unpatchedModules.indexOf(mod) === -1) {
             modules[mod].enable();
+            Logging.info(TAG, `Subscribed to ${mod} events`);
         }
     }
+    if (unpatchedModules.length > 0) {
+        Logging.info(TAG, "Some modules will not be patched", unpatchedModules);
+    }
+} else {
+    Logging.info(TAG, "Not subscribing to dependency autocollection because APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL was set");
 }
 
 export function registerContextPreservation(cb: (cb: Function) => Function) {


### PR DESCRIPTION
Add `info` logging for 3rd party module patching
- Log when a module is successfully patched
- Log modules for which patching was opted out of
- Log when patching altogether is opted out of