### PR TITLE
feat: add In-Proc-Agent

### DIFF
--- a/Bootstrap/Default.ts
+++ b/Bootstrap/Default.ts
@@ -55,7 +55,6 @@ export function setUsagePrefix(prefix: string) {
  * @param setupString connection string or instrumentation key
  */
 export function setupAndStart(setupString = _setupString): typeof types | null {
-    console.log("Trying to setup Application Insights", setupString, _extensionEnabled);
     if (!_extensionEnabled && sdkAlreadyExists() === false) {
         return null;
     }

--- a/Bootstrap/Default.ts
+++ b/Bootstrap/Default.ts
@@ -14,6 +14,26 @@ export interface AgentLogger {
     error(message?: any, ...optional: any[]): void;
 }
 
+function sdkAlreadyExists(): boolean {
+    try {
+        // appInstance should either resolve to user SDK or crash. If it resolves to attach SDK, user probably modified their NODE_PATH
+        const appInstance = require.resolve("applicationinsights"); // assumes that the cwd is near user's package.json
+        const attachInstance = require.resolve("../applicationinsights");
+        if (appInstance !== attachInstance) {
+            _logger.log(
+                "applicationinsights module is already installed in this application; not re-attaching. Installed SDK location:",
+                appInstance
+            );
+            return true;
+        }
+        // User probably modified their NODE_PATH to resolve to this instance. Attach appinsights
+        return false;
+    } catch (e) {
+        // crashed while trying to resolve "applicationinsights", so SDK does not exist. Attach appinsights
+        return false;
+    }
+}
+
 /**
  * Sets the attach-time logger
  * @param logger logger which implements the `AgentLogger` interface
@@ -35,7 +55,7 @@ export function setUsagePrefix(prefix: string) {
  * @param setupString connection string or instrumentation key
  */
 export function setupAndStart(setupString = _setupString): typeof types | null {
-    if (!_extensionEnabled) {
+    if (!_extensionEnabled && sdkAlreadyExists() === false) {
         return null;
     }
     if (!setupString) {

--- a/Bootstrap/Default.ts
+++ b/Bootstrap/Default.ts
@@ -80,6 +80,7 @@ export function setupAndStart(setupString = _setupString): typeof types | null {
         _appInsights.setup(setupString).setSendLiveMetrics(true);
         _appInsights.defaultClient.addTelemetryProcessor(prefixInternalSdkVersion);
         _appInsights.start();
+        _logger.log("Application Insights was started with setupString", setupString, _extensionEnabled);
     } catch (e) {
         _logger.error("Error setting up Application Insights", e);
     }

--- a/Bootstrap/Default.ts
+++ b/Bootstrap/Default.ts
@@ -1,0 +1,67 @@
+import * as types from "../applicationinsights";
+
+// Private configuration vars
+let _appInsights: typeof types | null;
+let _logger: AgentLogger = console;
+let _prefix = "ad_"; // App Services, Default
+
+// Env var local constants
+const _setupString = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING || process.env.APPINSIGHTS_INSTRUMENTATION_KEY;
+const _extensionEnabled = process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION && process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION !== "disabled";
+
+export interface AgentLogger {
+    log(message?: any, ...optional: any[]): void;
+    error(message?: any, ...optional: any[]): void;
+}
+
+/**
+ * Sets the attach-time logger
+ * @param logger logger which implements the `AgentLogger` interface
+ */
+export function setLogger(logger: AgentLogger) {
+    return _logger = logger;
+}
+
+/**
+ * Sets the string which is prefixed to the exsting sdkVersion, e.g. `ad_`, `alr_`
+ * @param prefix string prefix, including underscore. Defaults to `ad_`
+ */
+export function setUsagePrefix(prefix: string) {
+    _prefix = prefix;
+}
+
+/**
+ * Try to setup and start this app insights instance, if attach is enabled.
+ * @param setupString connection string or instrumentation key
+ */
+export function setupAndStart(setupString = _setupString): typeof types | null {
+    if (!_extensionEnabled) {
+        return null;
+    }
+    if (!setupString) {
+        _logger.error(
+            "Application Insights wanted to be started, but no Connection String was provided",
+            setupString
+        );
+        return null;
+    }
+
+    try {
+        _appInsights = require("../applicationinsights");
+        const prefixInternalSdkVersion = function (envelope: types.Contracts.Envelope, _contextObjects: Object) {
+            try {
+                var appInsightsSDKVersion = _appInsights.defaultClient.context.keys.internalSdkVersion;
+                envelope.tags[appInsightsSDKVersion] = _prefix + envelope.tags[appInsightsSDKVersion];
+            } catch (e) {
+                _logger.error("Error prefixing SDK version", e);
+            }
+            return true;
+        }
+        _appInsights.setup(setupString).setSendLiveMetrics(true);
+        _appInsights.defaultClient.addTelemetryProcessor(prefixInternalSdkVersion);
+        _appInsights.start();
+    } catch (e) {
+        _logger.error("Error setting up Application Insights", e);
+    }
+    return _appInsights;
+}

--- a/Bootstrap/Default.ts
+++ b/Bootstrap/Default.ts
@@ -55,6 +55,7 @@ export function setUsagePrefix(prefix: string) {
  * @param setupString connection string or instrumentation key
  */
 export function setupAndStart(setupString = _setupString): typeof types | null {
+    console.log("Trying to setup Application Insights", setupString, _extensionEnabled);
     if (!_extensionEnabled && sdkAlreadyExists() === false) {
         return null;
     }

--- a/Bootstrap/Default.ts
+++ b/Bootstrap/Default.ts
@@ -60,7 +60,7 @@ export function setupAndStart(setupString = _setupString): typeof types | null {
     }
     if (!setupString) {
         _logger.error(
-            "Application Insights wanted to be started, but no Connection String was provided",
+            "Application Insights wanted to be started, but no Connection String or Instrumentation Key was provided",
             setupString
         );
         return null;

--- a/Bootstrap/Oryx.ts
+++ b/Bootstrap/Oryx.ts
@@ -1,0 +1,3 @@
+import appInsightsLoader = require('./Default');
+appInsightsLoader.setUsagePrefix("alr_"); // App Services Linux Attach
+appInsightsLoader.setupAndStart();

--- a/Tests/Bootstrap/Default.spec.ts
+++ b/Tests/Bootstrap/Default.spec.ts
@@ -1,0 +1,104 @@
+import assert = require("assert");
+import sinon = require("sinon");
+import * as types from "../../Bootstrap/Default";
+
+const appInsights = require("../../applicationinsights");
+
+class LoggerSpy implements types.AgentLogger {
+    public logCount = 0
+    public errorCount = 0;
+
+    public log() {
+        this.logCount++;
+    }
+    public error() {
+        this.errorCount++;
+    }
+}
+
+describe("#setupAndStart()", () => {
+    const startSpy = sinon.spy(appInsights, "start");
+
+    before(() => {
+        startSpy.reset();
+    });
+
+    afterEach(() => {
+        startSpy.reset();
+        delete require.cache[require.resolve("../../Bootstrap/Default")];
+    });
+
+    after(() => {
+        startSpy.restore();
+    });
+
+    it("should setup and start the SDK", () => {
+        // Setup env vars before requiring loader
+        const logger = new LoggerSpy();
+        const origEnv = process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION;
+        process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION = "~2";
+
+        // Test
+        const Default = require("../../Bootstrap/Default") as typeof types;
+        Default.setLogger(logger);
+        const instance = Default.setupAndStart("abc");
+        assert.deepEqual(instance, appInsights);
+
+        // Cleanup
+        instance.dispose();
+        process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION = origEnv;
+
+        // start was called once
+        assert.equal(startSpy.callCount, 1);
+
+        // No logging was done
+        assert.equal(logger.logCount, 0);
+        assert.equal(logger.errorCount, 0);
+    });
+
+    it("should not setup and start the SDK if it has been disabled", () => {
+        // Setup
+        const logger = new LoggerSpy();
+        const origEnv = process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION;
+        process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION = "disabled";
+
+        // Test
+        const Default = require("../../Bootstrap/Default") as typeof types;
+        Default.setLogger(logger);
+        const instance = Default.setupAndStart("abc");
+        assert.equal(instance, null);
+
+        // Cleanup
+        process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION = origEnv;
+
+        // start was never called
+        assert.equal(startSpy.callCount, 0);
+
+        // No logging was done
+        assert.equal(logger.logCount, 0);
+        assert.equal(logger.errorCount, 0, "Do not log if attach is disabled");
+    });
+
+    it("should not setup and start the SDK if no setupString is provided", () => {
+        // Setup
+        const logger = new LoggerSpy();
+        const origEnv = process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION;
+        process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION = "~2";
+
+        // Test
+        const Default = require("../../Bootstrap/Default") as typeof types;
+        Default.setLogger(logger);
+        const instance = Default.setupAndStart();
+        assert.equal(instance, null);
+
+        // Cleanup
+        process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION = origEnv;
+
+        // start was never called
+        assert.equal(startSpy.callCount, 0);
+
+        // No logging was done
+        assert.equal(logger.logCount, 0);
+        assert.equal(logger.errorCount, 1, "Should log if attach is attempted");
+    });
+});

--- a/Tests/Bootstrap/Default.spec.ts
+++ b/Tests/Bootstrap/Default.spec.ts
@@ -10,11 +10,9 @@ class LoggerSpy implements types.AgentLogger {
 
     public log() {
         this.logCount++;
-        console.log(arguments);
     }
     public error() {
         this.errorCount++;
-        console.error(arguments);
     }
 }
 
@@ -85,7 +83,11 @@ describe("#setupAndStart()", () => {
         // Setup
         const logger = new LoggerSpy();
         const origEnv = process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION;
+        const origIkey = process.env.APPINSIGHTS_INSTRUMENTATION_KEY;
+        const origCs = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
         process.env.APPLICATIONINSIGHTS_EXTENSION_VERSION = "~2";
+        delete process.env.APPINSIGHTS_INSTRUMENTATION_KEY;
+        delete process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
 
         // Test
         const Default = require("../../Bootstrap/Default") as typeof types;
@@ -102,5 +104,8 @@ describe("#setupAndStart()", () => {
         // No logging was done
         assert.equal(logger.logCount, 0);
         assert.equal(logger.errorCount, 1, "Should log if attach is attempted");
+
+        process.env.APPINSIGHTS_INSTRUMENTATION_KEY = origIkey;
+        process.env.APPLICATIONINSIGHTS_CONNECTION_STRING = origCs;
     });
 });

--- a/Tests/Bootstrap/Default.spec.ts
+++ b/Tests/Bootstrap/Default.spec.ts
@@ -10,9 +10,11 @@ class LoggerSpy implements types.AgentLogger {
 
     public log() {
         this.logCount++;
+        console.log(arguments);
     }
     public error() {
         this.errorCount++;
+        console.error(arguments);
     }
 }
 
@@ -52,7 +54,7 @@ describe("#setupAndStart()", () => {
         assert.equal(startSpy.callCount, 1);
 
         // No logging was done
-        assert.equal(logger.logCount, 0);
+        assert.equal(logger.logCount, 1);
         assert.equal(logger.errorCount, 0);
     });
 

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -317,11 +317,11 @@ export class Configuration {
             _performanceLiveMetrics = new AutoCollectPerformance(liveMetricsClient as any, 1000, true);
             liveMetricsClient.addCollector(_performanceLiveMetrics);
             defaultClient.quickPulseClient = liveMetricsClient; // Need this so we can forward all manual tracks to live metrics via PerformanceMetricsTelemetryProcessor
-            _isSendingLiveMetrics = enable;
         } else {
             // qps client already exists; enable/disable it
             liveMetricsClient.enable(enable);
         }
+        _isSendingLiveMetrics = enable;
 
         return Configuration;
     }
@@ -350,5 +350,9 @@ export function dispose() {
     }
     if(_clientRequests) {
         _clientRequests.dispose();
+    }
+    if(liveMetricsClient) {
+        liveMetricsClient.enable(false);
+        _isSendingLiveMetrics = false;
     }
 }

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -354,5 +354,6 @@ export function dispose() {
     if(liveMetricsClient) {
         liveMetricsClient.enable(false);
         _isSendingLiveMetrics = false;
+        liveMetricsClient = undefined;
     }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",
     "test": "npm run test:ts && npm run test:js",
+    "test:debug": "mocha ./out/Tests --inspect-brk --recursive --no-exit",
     "test:ts": "mocha ./out/Tests --recursive --no-exit",
     "test:js": "mocha ./Tests/js --recursive --no-exit",
     "functionaltest": "npm run build && npm pack && node --use_strict ./Tests/FunctionalTests/RunFunctionalTests.js",


### PR DESCRIPTION
- Adds in-proc-agent for node.js SDK which can be directly imported by compute platforms.
  - `Default.ts`: Base IPA which other compute speciffic platforms will start from
  - `Oryx.ts`: Sets `alr_` prefix and sets up app insights via `Default.ts`