### PR TITLE
fix: cut a name for trackDependency if a sql is too big

### DIFF
--- a/AutoCollection/diagnostic-channel/postgres.sub.ts
+++ b/AutoCollection/diagnostic-channel/postgres.sub.ts
@@ -13,10 +13,11 @@ export const subscriber = (event: IStandardEvent<pg.IPostgresData>) => {
         const sql = (q.preparable && q.preparable.text) || q.plan || q.text || "unknown query";
         const success = !event.data.error;
         const conn = `${event.data.database.host}:${event.data.database.port}`;
+        const name = sql.length > 1024 ? sql.slice(0, 1021) + '...' : sql;
         client.trackDependency({
             target: conn,
             data: sql,
-            name: sql,
+            name,
             duration: event.data.duration,
             success: success,
             resultCode: success ? "0" : "1",

--- a/AutoCollection/diagnostic-channel/postgres.sub.ts
+++ b/AutoCollection/diagnostic-channel/postgres.sub.ts
@@ -13,11 +13,10 @@ export const subscriber = (event: IStandardEvent<pg.IPostgresData>) => {
         const sql = (q.preparable && q.preparable.text) || q.plan || q.text || "unknown query";
         const success = !event.data.error;
         const conn = `${event.data.database.host}:${event.data.database.port}`;
-        const name = sql.length > 1024 ? sql.slice(0, 1021) + '...' : sql;
         client.trackDependency({
             target: conn,
             data: sql,
-            name,
+            name: sql,
             duration: event.data.duration,
             success: success,
             resultCode: success ? "0" : "1",

--- a/Library/EnvelopeFactory.ts
+++ b/Library/EnvelopeFactory.ts
@@ -115,7 +115,7 @@ class EnvelopeFactory {
 
     private static createDependencyData(telemetry: Contracts.DependencyTelemetry & Contracts.Identified): Contracts.Data<Contracts.RemoteDependencyData> {
         var remoteDependency = new Contracts.RemoteDependencyData();
-        remoteDependency.name = telemetry.name;
+        remoteDependency.name = telemetry.name.length > 1024 ? telemetry.name.slice(0, 1021) + '...' : telemetry.name;
         remoteDependency.data = telemetry.data;
         remoteDependency.target = telemetry.target;
         remoteDependency.duration = Util.msToTimeSpan(telemetry.duration);


### PR DESCRIPTION
I have found that if a SQL to Postgres DB is big we won't be able to see this dependency in Application Insights. I guess this happens because a name property that sends to the trackDependency function must be limited to 1024 symbols.

In my tests, I had limited a name property then info about Postgres dependency was saved to Application Insights.