### PR TITLE
chore: add new loader entry points

### DIFF
--- a/Bootstrap/Oryx.ts
+++ b/Bootstrap/Oryx.ts
@@ -1,3 +1,4 @@
 import appInsightsLoader = require('./Default');
 appInsightsLoader.setUsagePrefix("alr_"); // App Services Linux Attach
 appInsightsLoader.setupAndStart();
+export = appInsightsLoader;

--- a/Bootstrap/Oryx.ts
+++ b/Bootstrap/Oryx.ts
@@ -1,4 +1,5 @@
+import * as types from "../applicationinsights";
 import appInsightsLoader = require('./Default');
 appInsightsLoader.setUsagePrefix("alr_"); // App Services Linux Attach
-appInsightsLoader.setupAndStart();
-export = appInsightsLoader;
+var appInsights = appInsightsLoader.setupAndStart();
+export = appInsights;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "applicationinsights",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "applicationinsights",
   "license": "MIT",
   "bugs": "https://github.com/Microsoft/ApplicationInsights-node.js/issues",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Microsoft Application Insights module for Node.js",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         ]
     },
     "include": [
+        "Bootstrap/*.ts",
         "*.ts",
         "AutoCollection/diagnostic-channel/*.ts",
         "Tests/**/*.ts"


### PR DESCRIPTION
`1.7.1` ... `1.7.2`
- Compile new agent entry points, (e.g. `Oryx.ts`)