### PR TITLE
Fix exceptions auto collector promise handling

### DIFF
--- a/AutoCollection/Exceptions.ts
+++ b/AutoCollection/Exceptions.ts
@@ -46,7 +46,7 @@ class AutoCollectExceptions {
             if (!this._exceptionListenerHandle) {
                 // For scenarios like Promise.reject(), an error won't be passed to the handle. Create a placeholder
                 // error for these scenarios.
-                var handle = (reThrow: boolean, name?: string, error: Error = new Error(AutoCollectExceptions._FALLBACK_ERROR_MESSAGE)) => {
+                var handle = (reThrow: boolean, name: string, error: Error = new Error(AutoCollectExceptions._FALLBACK_ERROR_MESSAGE)) => {
                     this._client.trackException({ exception: error });
                     this._client.flush({ isAppCrashing: true });
                     // only rethrow when we are the only listener
@@ -58,11 +58,11 @@ class AutoCollectExceptions {
 
                 if (AutoCollectExceptions._canUseUncaughtExceptionMonitor) {
                     // Node.js >= 13.7.0, use uncaughtExceptionMonitor. It handles both promises and exceptions
-                    this._exceptionListenerHandle = handle.bind(this, false); // never rethrows
+                    this._exceptionListenerHandle = handle.bind(this, false, undefined); // never rethrows
                     process.on(AutoCollectExceptions.UNCAUGHT_EXCEPTION_MONITOR_HANDLER_NAME, this._exceptionListenerHandle);
                 } else {
                     this._exceptionListenerHandle = handle.bind(this, true, AutoCollectExceptions.UNCAUGHT_EXCEPTION_HANDLER_NAME);
-                    this._rejectionListenerHandle = handle.bind(this, false); // never rethrows
+                    this._rejectionListenerHandle = handle.bind(this, false, undefined); // never rethrows
                     process.on(AutoCollectExceptions.UNCAUGHT_EXCEPTION_HANDLER_NAME, this._exceptionListenerHandle);
                     process.on(AutoCollectExceptions.UNHANDLED_REJECTION_HANDLER_NAME, this._rejectionListenerHandle);
                 }


### PR DESCRIPTION
All errors thrown from Promises are always send to Application Insights with message `[object Promise]`.

Problem exists because during binding of promise handler only one param is given instead of 2 thats why `error` value land in `name` variable.

Code that can be used to reproduce problem:
```
new Promise<any>(() => {
      throw new Error('test');
});
```