### PR TITLE
Update all Senders to use https.globalAgent instead of tlsRestrictedAgent

### DIFF
--- a/Library/QuickPulseSender.ts
+++ b/Library/QuickPulseSender.ts
@@ -2,6 +2,7 @@ import https = require("https");
 import Config = require("./Config");
 import AutoCollectHttpDependencies = require("../AutoCollection/HttpDependencies");
 import Logging = require("./Logging");
+import Util = require("./Util");
 
 // Types
 import * as http from "http";
@@ -49,6 +50,13 @@ class QuickPulseSender {
                 'Content-Length': Buffer.byteLength(payload)
             }
         };
+
+        // HTTPS only
+        if (this._config.httpsAgent) {
+            (<any>options).agent = this._config.httpsAgent;
+        } else {
+            (<any>options).agent = https.globalAgent || Util.tlsRestrictedAgent;
+        }
 
         const req = https.request(options, (res: http.IncomingMessage) => {
             const shouldPOSTData = res.headers[QuickPulseConfig.subscribed] === "true";

--- a/Library/QuickPulseSender.ts
+++ b/Library/QuickPulseSender.ts
@@ -55,7 +55,7 @@ class QuickPulseSender {
         if (this._config.httpsAgent) {
             (<any>options).agent = this._config.httpsAgent;
         } else {
-            (<any>options).agent = https.globalAgent || Util.tlsRestrictedAgent;
+            (<any>options).agent = Util.tlsRestrictedAgent;
         }
 
         const req = https.request(options, (res: http.IncomingMessage) => {

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -223,7 +223,7 @@ class Sender {
         if (Sender.ACL_IDENTITY) {
             return callback(null, Sender.ACL_IDENTITY);
         }
-        var psProc = child_process.spawn(Sender.POWERSHELL_PATH, 
+        var psProc = child_process.spawn(Sender.POWERSHELL_PATH,
             ["-Command", "[System.Security.Principal.WindowsIdentity]::GetCurrent().Name"], <any>{
                 windowsHide: true,
                 stdio: ['ignore', 'pipe', 'pipe'] // Needed to prevent hanging on Win 7
@@ -245,7 +245,7 @@ class Sender {
         }
         // Some very old versions of Node (< 0.11) don't have this
         if (child_process.spawnSync) {
-            var psProc = child_process.spawnSync(Sender.POWERSHELL_PATH, 
+            var psProc = child_process.spawnSync(Sender.POWERSHELL_PATH,
                 ["-Command", "[System.Security.Principal.WindowsIdentity]::GetCurrent().Name"], <any>{
                     windowsHide: true,
                     stdio: ['ignore', 'pipe', 'pipe'] // Needed to prevent hanging on Win 7

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -326,7 +326,8 @@ class Util {
             options.agent = config.httpAgent;
         } else if (isHttps) {
             // HTTPS without a passed in agent. Use one that enforces our TLS rules
-            options.agent = Util.tlsRestrictedAgent;
+            // @todo: globalAgent is always defined (node0.5.9+), is tlsRestrictedAgent still required?
+            options.agent = https.globalAgent || Util.tlsRestrictedAgent;
         }
 
         if (isHttps) {

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -326,8 +326,7 @@ class Util {
             options.agent = config.httpAgent;
         } else if (isHttps) {
             // HTTPS without a passed in agent. Use one that enforces our TLS rules
-            // @todo: globalAgent is always defined (node0.5.9+), is tlsRestrictedAgent still required?
-            options.agent = https.globalAgent || Util.tlsRestrictedAgent;
+            options.agent = Util.tlsRestrictedAgent;
         }
 
         if (isHttps) {


### PR DESCRIPTION
Updates #615 

Update `Sender` and `QuickPulseSender` to use `https.globalAgent`. This agent is always defined, so `Util.tlsRestrictedAgent` may no longer be necessary.