### PR TITLE
add support for URL dependency parsing

### DIFF
--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -16,7 +16,7 @@ import CorrelationIdManager = require("../Library/CorrelationIdManager");
 class HttpDependencyParser extends RequestParser {
     private correlationId: string;
 
-    constructor(requestOptions: URL | string | http.RequestOptions | https.RequestOptions, request: http.ClientRequest) {
+    constructor(requestOptions: object | string | http.RequestOptions | https.RequestOptions, request: http.ClientRequest) {
         super();
         if (request && (<any>request).method && requestOptions) {
             // The ClientRequest.method property isn't documented, but is always there.
@@ -114,7 +114,7 @@ class HttpDependencyParser extends RequestParser {
     private static _getUrlFromRequestOptions(options: any, request: http.ClientRequest) {
         if (typeof options === 'string') {
             options = url.parse(options);
-        } else if (options instanceof URL) {
+        } else if (options && typeof (url as any).URL === 'function' && options instanceof (url as any).URL) {
             return url.format(options);
         } else {
             // Avoid modifying the original options object.

--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -16,7 +16,7 @@ import CorrelationIdManager = require("../Library/CorrelationIdManager");
 class HttpDependencyParser extends RequestParser {
     private correlationId: string;
 
-    constructor(requestOptions: string | http.RequestOptions | https.RequestOptions, request: http.ClientRequest) {
+    constructor(requestOptions: URL | string | http.RequestOptions | https.RequestOptions, request: http.ClientRequest) {
         super();
         if (request && (<any>request).method && requestOptions) {
             // The ClientRequest.method property isn't documented, but is always there.
@@ -114,6 +114,8 @@ class HttpDependencyParser extends RequestParser {
     private static _getUrlFromRequestOptions(options: any, request: http.ClientRequest) {
         if (typeof options === 'string') {
             options = url.parse(options);
+        } else if (options instanceof URL) {
+            return url.format(options);
         } else {
             // Avoid modifying the original options object.
             let originalOptions = options;

--- a/Tests/AutoCollection/HttpDependencyParser.tests.ts
+++ b/Tests/AutoCollection/HttpDependencyParser.tests.ts
@@ -29,20 +29,22 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.target, "bing.com");
         });
 
-        it("should return correct data for a URL instance", () => {
-            (<any>request)["method"] = "GET";
-            let parser = new HttpDependencyParser(new URL("http://bing.com/search"), request);
+        if (parseInt(process.versions.node.split(".")[0]) >= 10) {
+            it("should return correct data for a URL instance", () => {
+                (<any>request)["method"] = "GET";
+                let parser = new HttpDependencyParser(new URL("http://bing.com/search"), request);
 
-            response.statusCode = 200;
-            parser.onResponse(response);
+                response.statusCode = 200;
+                parser.onResponse(response);
 
-            let dependencyTelemetry = parser.getDependencyTelemetry();
-            assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_HTTP);
-            assert.equal(dependencyTelemetry.success, true);
-            assert.equal(dependencyTelemetry.name, "GET /search");
-            assert.equal(dependencyTelemetry.data, "http://bing.com/search");
-            assert.equal(dependencyTelemetry.target, "bing.com");
-        })
+                let dependencyTelemetry = parser.getDependencyTelemetry();
+                assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_HTTP);
+                assert.equal(dependencyTelemetry.success, true);
+                assert.equal(dependencyTelemetry.name, "GET /search");
+                assert.equal(dependencyTelemetry.data, "http://bing.com/search");
+                assert.equal(dependencyTelemetry.target, "bing.com");
+            });
+        }
 
         it("should propagate a custom timestamp", () => {
             (<any>request)["method"] = "GET";

--- a/Tests/AutoCollection/HttpDependencyParser.tests.ts
+++ b/Tests/AutoCollection/HttpDependencyParser.tests.ts
@@ -29,6 +29,21 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.target, "bing.com");
         });
 
+        it("should return correct data for a URL instance", () => {
+            (<any>request)["method"] = "GET";
+            let parser = new HttpDependencyParser(new URL("http://bing.com/search"), request);
+
+            response.statusCode = 200;
+            parser.onResponse(response);
+
+            let dependencyTelemetry = parser.getDependencyTelemetry();
+            assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_HTTP);
+            assert.equal(dependencyTelemetry.success, true);
+            assert.equal(dependencyTelemetry.name, "GET /search");
+            assert.equal(dependencyTelemetry.data, "http://bing.com/search");
+            assert.equal(dependencyTelemetry.target, "bing.com");
+        })
+
         it("should propagate a custom timestamp", () => {
             (<any>request)["method"] = "GET";
             let parser = new HttpDependencyParser("http://bing.com/search", request);
@@ -38,9 +53,9 @@ describe("AutoCollection/HttpDependencyParser", () => {
 
             const dependencyTelemetry1 = parser.getDependencyTelemetry({time: new Date(111111)});
             const dependencyTelemetry2 = parser.getDependencyTelemetry({time: new Date(222222)});
-            assert.deepEqual(dependencyTelemetry1.time, new Date(111111)); 
-            assert.deepEqual(dependencyTelemetry2.time, new Date(222222)); 
-            assert.notDeepEqual(dependencyTelemetry1, dependencyTelemetry2); 
+            assert.deepEqual(dependencyTelemetry1.time, new Date(111111));
+            assert.deepEqual(dependencyTelemetry2.time, new Date(222222));
+            assert.notDeepEqual(dependencyTelemetry1, dependencyTelemetry2);
         });
 
         it("should return correct data for a posted URL with query string", () => {

--- a/Tests/applicationInsights.tests.ts
+++ b/Tests/applicationInsights.tests.ts
@@ -105,7 +105,7 @@ describe("ApplicationInsights", () => {
 
         it("should enable AI tracing mode by default", () => {
             AppInsights.setup("key").start();
-            assert.equal(CorrelationIdManager.w3cEnabled, false);
+            assert.equal(CorrelationIdManager.w3cEnabled, true);
         });
 
         it("should be able to enable W3C tracing mode via enum", () => {

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -343,6 +343,7 @@ export class Configuration {
  * Disposes the default client and all the auto collectors so they can be reinitialized with different configuration
 */
 export function dispose() {
+    CorrelationIdManager.w3cEnabled = true; // reset to default
     defaultClient = null;
     _isStarted = false;
     if (_console) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/cls-hooked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.0.tgz",
-      "integrity": "sha512-H2ov/zMqgs7b66dkfufx3SXMnYFn6u9IOMEY7JZYWXJhE/WVZogedXsQIgM/504DyvtbNNXMiofaRr1E0+3yZA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.1.tgz",
+      "integrity": "sha512-nMjNjQAk9vAYnDEXRUxGSACarjPDRKVaZ8xrwKzRy1BmzG5tN3JUkuvdVwE8P2GBkSRokxVw+QUpuvFzvOsKpA==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "backcompattest": "npm run build && npm pack && node --use_strict ./Tests/BackCompatibility/RunBackCompatTests.js"
   },
   "devDependencies": {
-    "@types/cls-hooked": "^4.3.0",
+    "@types/cls-hooked": "^4.3.1",
     "@types/mocha": "2.2.48",
     "@types/node": "4.2.4",
     "@types/sinon": "2.1.2",


### PR DESCRIPTION
`got(https://example.com)` sends requests through to the `http` module with an instance of a `URL` class. Previously, the parsing here would not pick up the class prototype methods, so it looks like an empty object and defaults to a `localhost` dependency.

https://nodejs.org/api/https.html#https_https_get_url_options_callback