### PR TITLE
rdd: set target port before target correlation id

### DIFF
--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -55,17 +55,18 @@ class HttpDependencyParser extends RequestParser {
         let remoteDependencyType = Contracts.RemoteDependencyDataConstants.TYPE_HTTP;
 
         let remoteDependencyTarget = urlObject.hostname;
-        if (this.correlationId) {
-            remoteDependencyType = Contracts.RemoteDependencyDataConstants.TYPE_AI;
-            if (this.correlationId !== CorrelationIdManager.correlationIdPrefix) {
-                remoteDependencyTarget = urlObject.hostname + " | " + this.correlationId;
-            }
-        } else {
-            remoteDependencyType = Contracts.RemoteDependencyDataConstants.TYPE_HTTP;
-        }
 
         if (urlObject.port) {
             remoteDependencyTarget += ":" + urlObject.port;
+        }
+
+        if (this.correlationId) {
+            remoteDependencyType = Contracts.RemoteDependencyDataConstants.TYPE_AI;
+            if (this.correlationId !== CorrelationIdManager.correlationIdPrefix) {
+                remoteDependencyTarget += " | " + this.correlationId;
+            }
+        } else {
+            remoteDependencyType = Contracts.RemoteDependencyDataConstants.TYPE_HTTP;
         }
 
         var dependencyTelemetry: Contracts.DependencyTelemetry & Contracts.Identified = {

--- a/Tests/AutoCollection/HttpDependencyParser.tests.ts
+++ b/Tests/AutoCollection/HttpDependencyParser.tests.ts
@@ -29,6 +29,22 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.target, "bing.com");
         });
 
+        it("should return correct data for a URL string with correlationId", () => {
+            (<any>request)["method"] = "GET";
+            let parser = new HttpDependencyParser("http://bing.com:123/search", request);
+
+            response.statusCode = 200;
+            parser.onResponse(response);
+
+            parser["correlationId"] = "abcdefg";
+            let dependencyTelemetry = parser.getDependencyTelemetry();
+            assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_AI);
+            assert.equal(dependencyTelemetry.success, true);
+            assert.equal(dependencyTelemetry.name, "GET /search");
+            assert.equal(dependencyTelemetry.data, "http://bing.com:123/search");
+            assert.equal(dependencyTelemetry.target, "bing.com:123 | abcdefg");
+        });
+
         if (parseInt(process.versions.node.split(".")[0]) >= 10) {
             it("should return correct data for a URL instance", () => {
                 (<any>request)["method"] = "GET";


### PR DESCRIPTION
Fixes an issue where `dependency.target` could look something like `example.com | cid-v1:abc:443`. The port component of the string, `:443`, should suffix `example.com`.

`example.com | cid-v1:abc:443` --> `example.com:443 | cid-v1:abc`