### PR TITLE
[Codeless] change format of diag logger output

### DIFF
--- a/Bootstrap/DiagnosticLogger.ts
+++ b/Bootstrap/DiagnosticLogger.ts
@@ -13,8 +13,16 @@ export class DiagnosticLogger {
         message: null,
         level: null,
         time: null,
-        logger: "nodejs.applicationinsights",
-        properties: {}
+        logger: "applicationinsights.extension.diagnostics",
+        properties: {
+            language: "nodejs",
+            operation: "Startup",
+            siteName: process.env.WEBSITE_SITE_NAME,
+            ikey: process.env.APPINSIGHTS_INSTRUMENTATIONKEY,
+            extensionVersion: process.env.ApplicationInsightsAgent_EXTENSION_VERSION,
+            sdkVersion: "1.8.6",
+            subscriptionId: process.env.WEBSITE_OWNER_NAME ? process.env.WEBSITE_OWNER_NAME.split("+")[0] : null,
+        }
     }
 
     constructor(private _writer: DataModel.AgentLogger = console) {}
@@ -28,7 +36,7 @@ export class DiagnosticLogger {
                 ...DiagnosticLogger.DefaultEnvelope,
                 message,
                 level: DataModel.SeverityLevel.INFO,
-                time: new Date().toUTCString()
+                time: new Date().toISOString(),
             };
             this._writer.log(diagnosticMessage);
         } else {

--- a/Bootstrap/FileWriter.ts
+++ b/Bootstrap/FileWriter.ts
@@ -48,7 +48,7 @@ export class FileWriter implements DataModel.AgentLogger {
     public log(message: any) {
         if (this._ready) {
             let data = typeof message === "object"
-                ? JSON.stringify(message, null, 2)
+                ? JSON.stringify(message)
                 : message.toString();
 
             // Check if existing file needs to be renamed

--- a/Tests/Bootstrap/DiagnosticLogger.spec.ts
+++ b/Tests/Bootstrap/DiagnosticLogger.spec.ts
@@ -1,11 +1,55 @@
 import assert = require("assert");
+import sinon = require("sinon");
+import { AgentLogger } from "../../Bootstrap/DataModel";
 import { DiagnosticLogger } from "../../Bootstrap/DiagnosticLogger";
+import { NoopLogger } from "../../Bootstrap/NoopLogger";
+import * as DataModel from "../../Bootstrap/DataModel";
+
+class TestWriter implements AgentLogger {
+    prev: any;
+
+    log(message?: any, ...optional: any[]): void {
+        this.prev = message;
+    }
+
+    error(message?: any, ...optional: any[]): void {
+        this.log(message, ...optional);
+    }
+}
 
 describe("DiagnosticLogger", () => {
+    const logger = new DiagnosticLogger(new NoopLogger());
+    const stub = sinon.stub(logger["_writer"], "log");
+    const version = require("../../../package.json").version;
+
+    afterEach(() => {
+        stub.reset();
+    })
+
     describe("#DiagnosticLogger.DefaultEnvelope", () => {
         it("should have the correct version string", () => {
-            const version = require("../../../package.json").version;
             assert.equal(DiagnosticLogger.DefaultEnvelope.properties.sdkVersion, version);
         });
+    });
+
+    describe("#DiagnosticLogger.logMessage", () => {
+        it("should log all required fields", () => {
+            logger.logMessage("Some message");
+            assert.deepEqual(stub.args[0][0], {
+                level: DataModel.SeverityLevel.INFO,
+                message: "Some message",
+                logger: "applicationinsights.extension.diagnostics",
+                time: new Date().toISOString(),
+                properties: {
+                    language: "nodejs",
+                    operation: "Startup",
+                    siteName: undefined,
+                    ikey: undefined,
+                    extensionVersion: undefined,
+                    sdkVersion: version,
+                    subscriptionId: null,
+                }
+            } as DataModel.DiagnosticLog)
+        })
     });
 });

--- a/Tests/Bootstrap/DiagnosticLogger.spec.ts
+++ b/Tests/Bootstrap/DiagnosticLogger.spec.ts
@@ -1,0 +1,11 @@
+import assert = require("assert");
+import { DiagnosticLogger } from "../../Bootstrap/DiagnosticLogger";
+
+describe("DiagnosticLogger", () => {
+    describe("#DiagnosticLogger.DefaultEnvelope", () => {
+        it("should have the correct version string", () => {
+            const version = require("../../../package.json").version;
+            assert.equal(DiagnosticLogger.DefaultEnvelope.properties.sdkVersion, version);
+        });
+    });
+});


### PR DESCRIPTION
Changes required to get attach-time telemetry to work end-to-end
- Adds required `properties` values for PaaS environments
- Changes JSON output to be stringified to a single line instead of using standard 2-space indentation format
- Writes `date` using correct ISO string format