### PR TITLE
startOperation: Re-export AzFunctions Types, add extra name overload, make HttpRequest nullable

### DIFF
--- a/Library/Functions.ts
+++ b/Library/Functions.ts
@@ -11,7 +11,7 @@ export interface Context {
  * HTTP request object. Provided to your function when using HTTP Bindings.
  */
 export interface HttpRequest {
-    method: string;
+    method: string | null;
     url: string;
     headers: {
         [key: string]: string;

--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -13,7 +13,6 @@ import Tracestate = require("./Library/Tracestate");
 import HttpRequestParser = require("./AutoCollection/HttpRequestParser");
 import { IncomingMessage } from "http";
 import { ISpanContext } from "diagnostic-channel";
-import * as azureFunctionsTypes from "./Library/Functions";
 
 import { AutoCollectNativePerformance, IDisabledExtendedMetrics } from "./AutoCollection/NativePerformance";
 
@@ -21,6 +20,7 @@ import { AutoCollectNativePerformance, IDisabledExtendedMetrics } from "./AutoCo
 // They're exposed using "export import" so that types are passed along as expected
 export import TelemetryClient = require("./Library/NodeClient");
 export import Contracts = require("./Declarations/Contracts");
+export import azureFunctionsTypes = require("./Library/Functions");
 
 export enum DistributedTracingModes {
     /**
@@ -158,6 +158,7 @@ export function getCorrelationContext(): CorrelationContextManager.CorrelationCo
  */
 export function startOperation(context: ISpanContext, name: string): CorrelationContextManager.CorrelationContext | null;
 export function startOperation(context: azureFunctionsTypes.Context, request: azureFunctionsTypes.HttpRequest): CorrelationContextManager.CorrelationContext | null;
+export function startOperation(context: azureFunctionsTypes.Context, name: string): CorrelationContextManager.CorrelationContext | null;
 export function startOperation(context: IncomingMessage | azureFunctionsTypes.HttpRequest, request?: never): CorrelationContextManager.CorrelationContext | null;
 export function startOperation(context: azureFunctionsTypes.Context | (IncomingMessage | azureFunctionsTypes.HttpRequest) | (ISpanContext), request?: azureFunctionsTypes.HttpRequest | string): CorrelationContextManager.CorrelationContext | null {
     return CorrelationContextManager.CorrelationContextManager.startOperation(context, request);


### PR DESCRIPTION
Fixes #681 

- [types] Re-export internally used Azure function types
- [types] Add `(Function.Context, string) => CorrelationContextContext` overload pattern (implementation already supported this, tests already exist!)
- [types] Make Internally used `HttpRequest.method` nullable

/cc @pjblakey