### PR TITLE
diag-publishers: bump to 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -202,9 +202,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.1.tgz",
-      "integrity": "sha512-NpZ7IOVUfea/kAx4+ub4NIYZyRCSymjXM5BZxnThs3ul9gAKqjm7J8QDDQW3Ecuo2XxjNLoWLeKmrPUWKNZaYw=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.2.tgz",
+      "integrity": "sha512-gbt5BVjwTV1wnng0Xi766DVrRxSeGECAX8Qrig7tKCDfXW2SbK7bKY6A3tgGjk5BB50aXgVXIsbtQiYIkt57Mg=="
     },
     "diff": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "cls-hooked": "^4.2.2",
     "continuation-local-storage": "^3.2.1",
     "diagnostic-channel": "0.3.1",
-    "diagnostic-channel-publishers": "0.4.1"
+    "diagnostic-channel-publishers": "0.4.2"
   }
 }


### PR DESCRIPTION
Bump to latest version of `diagnostic-channel-publishers`