### PR TITLE
RDD: Correctly parse urls without protocols

### DIFF
--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -114,7 +114,18 @@ class HttpDependencyParser extends RequestParser {
      */
     private static _getUrlFromRequestOptions(options: any, request: http.ClientRequest) {
         if (typeof options === 'string') {
-            options = url.parse(options);
+            if (options.indexOf("http://") === 0 || options.indexOf("https://") === 0) {
+                // protocol exists, parse normally
+                options = url.parse(options);
+            } else {
+                // protocol not found, insert http/https where appropriate
+                const parsed = url.parse(options);
+                if (parsed.host === "443") {
+                    options = url.parse("https://" + options);
+                } else {
+                    options = url.parse("http://" + options)
+                }
+            }
         } else if (options && typeof (url as any).URL === 'function' && options instanceof (url as any).URL) {
             return url.format(options);
         } else {

--- a/Tests/AutoCollection/HttpDependencyParser.tests.ts
+++ b/Tests/AutoCollection/HttpDependencyParser.tests.ts
@@ -44,6 +44,36 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.data, "http://bing.com:123/search");
             assert.equal(dependencyTelemetry.target, "bing.com:123 | abcdefg");
         });
+        
+        it("should return correct data for a URL without a protocol (https)", () => {
+            (<any>request)["method"] = "GET";
+            let parser = new HttpDependencyParser("a.bing.com:443/search", request);
+
+            response.statusCode = 200;
+            parser.onResponse(response);
+
+            let dependencyTelemetry = parser.getDependencyTelemetry();
+            assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_HTTP);
+            assert.equal(dependencyTelemetry.success, true);
+            assert.equal(dependencyTelemetry.name, "GET /search");
+            assert.equal(dependencyTelemetry.data, "https://a.bing.com:443/search");
+            assert.equal(dependencyTelemetry.target, "a.bing.com:443");
+        });
+        
+        it("should return correct data for a URL without a protocol (http)", () => {
+            (<any>request)["method"] = "GET";
+            let parser = new HttpDependencyParser("a.bing.com:123/search", request);
+
+            response.statusCode = 200;
+            parser.onResponse(response);
+
+            let dependencyTelemetry = parser.getDependencyTelemetry();
+            assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_HTTP);
+            assert.equal(dependencyTelemetry.success, true);
+            assert.equal(dependencyTelemetry.name, "GET /search");
+            assert.equal(dependencyTelemetry.data, "http://a.bing.com:123/search");
+            assert.equal(dependencyTelemetry.target, "a.bing.com:123");
+        });
 
         if (parseInt(process.versions.node.split(".")[0]) >= 10) {
             it("should return correct data for a URL instance", () => {


### PR DESCRIPTION
Fix issue where dependency URLs without protocol prefixes are incorrectly parsed

Fixes #689
