### PR TITLE
fix stackframe regex on scoped packages

### DIFF
--- a/Library/EnvelopeFactory.ts
+++ b/Library/EnvelopeFactory.ts
@@ -356,7 +356,7 @@ class _StackFrame {
 
     // regex to match stack frames from ie/chrome/ff
     // methodName=$2, fileName=$4, lineNo=$5, column=$6
-    public static regex = /^([\s]+at)?(.*?)(\@|\s\(|\s)([^\(\n]+):([0-9]+):([0-9]+)(\)?)$/;
+    public static regex = /^(\s+at)?(.*?)(\@|\s\(|\s)([^\(\n]+):(\d+):(\d+)(\)?)$/;
     public static baseSize = 58; //'{"method":"","level":,"assembly":"","fileName":"","line":}'.length
     public sizeInBytes = 0;
     public level: number;

--- a/Library/EnvelopeFactory.ts
+++ b/Library/EnvelopeFactory.ts
@@ -356,7 +356,7 @@ class _StackFrame {
 
     // regex to match stack frames from ie/chrome/ff
     // methodName=$2, fileName=$4, lineNo=$5, column=$6
-    public static regex = /^([\s]+at)?(.*?)(\@|\s\(|\s)([^\(\@\n]+):([0-9]+):([0-9]+)(\)?)$/;
+    public static regex = /^([\s]+at)?(.*?)(\@|\s\(|\s)([^\(\n]+):([0-9]+):([0-9]+)(\)?)$/;
     public static baseSize = 58; //'{"method":"","level":,"assembly":"","fileName":"","line":}'.length
     public sizeInBytes = 0;
     public level: number;

--- a/Tests/Library/EnvelopeFactoryTests.ts
+++ b/Tests/Library/EnvelopeFactoryTests.ts
@@ -107,6 +107,42 @@ describe("Library/EnvelopeFactory", () => {
 
             assert.deepEqual(actual, expected);
         });
+        
+        it("fills stack when provided a scoped package", () => {
+            simpleError.stack = "  at Context.foo (C:/@foo/bar/example.js:123:45)\n" + simpleError.stack;
+            
+            var envelope = EnvelopeFactory.createEnvelope(<Contracts.ExceptionTelemetry>{ exception: simpleError }, Contracts.TelemetryType.Exception);
+            var exceptionData = <Contracts.Data<Contracts.ExceptionData>>envelope.data;
+
+            var actual = exceptionData.baseData.exceptions[0].parsedStack[0];
+
+            assert.deepEqual(actual, {
+                fileName: "C:/@foo/bar/example.js",
+                line: 123,
+                level: 0,
+                sizeInBytes: 141,
+                assembly: "at Context.foo (C:/@foo/bar/example.js:123:45)",
+                method: "Context.foo"
+            });
+        });
+        
+        it("fills stack when provided a scoped package", () => {
+            simpleError.stack = "  at C:/@foo/bar/example.js:123:45\n" + simpleError.stack;
+            
+            var envelope = EnvelopeFactory.createEnvelope(<Contracts.ExceptionTelemetry>{ exception: simpleError }, Contracts.TelemetryType.Exception);
+            var exceptionData = <Contracts.Data<Contracts.ExceptionData>>envelope.data;
+
+            var actual = exceptionData.baseData.exceptions[0].parsedStack[0];
+
+            assert.deepEqual(actual, {
+                fileName: "C:/@foo/bar/example.js",
+                line: 123,
+                level: 0,
+                sizeInBytes: 127,
+                assembly: "at C:/@foo/bar/example.js:123:45",
+                method: "<no_method>"
+            });
+        });
 
         it("fills 'severityLevel' with Error when not specified", () => {
             var envelope = EnvelopeFactory.createEnvelope(<Contracts.ExceptionTelemetry>{ exception: simpleError }, Contracts.TelemetryType.Exception);


### PR DESCRIPTION
Updates regex to support stackframes from scoped packages, e.g. `@microsoft/applicationinsights-web`

Fixes #695 