### PR TITLE
Use request.protocol when available in automatic dependency collection

### DIFF
--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -163,7 +163,7 @@ class HttpDependencyParser extends RequestParser {
         }
 
         // Mix in default values used by http.request and others
-        options.protocol = options.protocol || ((<any>request).agent && (<any>request).agent.protocol) || undefined;
+        options.protocol = options.protocol || ((<any>request).agent && (<any>request).agent.protocol) || ((<any>request).protocol) || undefined;
         options.hostname = options.hostname || 'localhost';
 
         return url.format(options);

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -31,7 +31,7 @@ class AutoCollectHttpRequests {
         this._client = client;
     }
 
-    public enable(isEnabled:boolean) {
+    public enable(isEnabled: boolean) {
         this._isEnabled = isEnabled;
 
         // Autocorrelation requires automatic monitoring of incoming server requests
@@ -43,7 +43,7 @@ class AutoCollectHttpRequests {
         }
     }
 
-    public useAutoCorrelation(isEnabled:boolean, forceClsHooked?:boolean) {
+    public useAutoCorrelation(isEnabled: boolean, forceClsHooked?: boolean) {
         if (isEnabled && !this._isAutoCorrelating) {
             CorrelationContextManager.enable(forceClsHooked);
         } else if (!isEnabled && this._isAutoCorrelating) {
@@ -60,7 +60,7 @@ class AutoCollectHttpRequests {
         return this._isAutoCorrelating;
     }
 
-    private _generateCorrelationContext(requestParser:HttpRequestParser): CorrelationContext {
+    private _generateCorrelationContext(requestParser: HttpRequestParser): CorrelationContext {
         if (!this._isAutoCorrelating) {
             return;
         }
@@ -85,7 +85,7 @@ class AutoCollectHttpRequests {
             if (typeof onRequest !== 'function') {
                 throw new Error('onRequest handler must be a function');
             }
-            return (request:http.ServerRequest, response:http.ServerResponse) => {
+            return (request: http.ServerRequest, response: http.ServerResponse) => {
                 CorrelationContextManager.wrapEmitter(request);
                 CorrelationContextManager.wrapEmitter(response);
                 const shouldCollect: boolean = request && !(<any>request)[AutoCollectHttpRequests.alreadyAutoCollectedFlag];
@@ -103,7 +103,7 @@ class AutoCollectHttpRequests {
                             (<any>request)[AutoCollectHttpRequests.alreadyAutoCollectedFlag] = true;
 
                             // Auto collect request
-                            AutoCollectHttpRequests.trackRequest(this._client, {request: request, response: response}, requestParser);
+                            AutoCollectHttpRequests.trackRequest(this._client, { request: request, response: response }, requestParser);
                         }
 
                         if (typeof onRequest === "function") {
@@ -146,12 +146,23 @@ class AutoCollectHttpRequests {
             server.on = server.addListener;
         }
 
-        const originalHttpServer = http.createServer;
-        http.createServer = (onRequest) => {
+        const originalHttpServer: any = http.createServer;
+
+        // options parameter was added in Node.js v9.6.0, v8.12.0
+        // function createServer(requestListener?: RequestListener): Server;
+        // function createServer(options: ServerOptions, requestListener?: RequestListener): Server;
+        http.createServer = (param1?: Object, param2?: Function) => {
             // todo: get a pointer to the server so the IP address can be read from server.address
-            const server: http.Server = originalHttpServer(wrapOnRequestHandler(onRequest));
-            wrapServerEventHandler(server);
-            return server;
+            if (param2 && typeof param2 === 'function') {
+                const server: http.Server = originalHttpServer(param1, wrapOnRequestHandler(param2));
+                wrapServerEventHandler(server);
+                return server;
+            }
+            else {
+                const server: http.Server = originalHttpServer(wrapOnRequestHandler(param1));
+                wrapServerEventHandler(server);
+                return server;
+            }
         }
 
         const originalHttpsServer = https.createServer;
@@ -191,7 +202,7 @@ class AutoCollectHttpRequests {
     /**
      * Tracks a request by listening to the response 'finish' event
      */
-    public static trackRequest(client: TelemetryClient, telemetry: Contracts.NodeHttpRequestTelemetry, _requestParser?:HttpRequestParser) {
+    public static trackRequest(client: TelemetryClient, telemetry: Contracts.NodeHttpRequestTelemetry, _requestParser?: HttpRequestParser) {
         if (!telemetry.request || !telemetry.response || !client) {
             Logging.info("AutoCollectHttpRequests.trackRequest was called with invalid parameters: ", !telemetry.request, !telemetry.response, !client);
             return;
@@ -222,7 +233,7 @@ class AutoCollectHttpRequests {
 
         // track a failed request if an error is emitted
         if (telemetry.request.on) {
-            telemetry.request.on("error", (error:any) => {
+            telemetry.request.on("error", (error: any) => {
                 AutoCollectHttpRequests.endRequest(client, requestParser, telemetry, null, error);
             });
         }
@@ -231,7 +242,7 @@ class AutoCollectHttpRequests {
     /**
      * Add the target correlationId to the response headers, if not already provided.
      */
-    private static addResponseCorrelationIdHeader(client: TelemetryClient, response:http.ServerResponse) {
+    private static addResponseCorrelationIdHeader(client: TelemetryClient, response: http.ServerResponse) {
         if (client.config && client.config.correlationId &&
             response.getHeader && response.setHeader && !(<any>response).headersSent) {
             const correlationHeader = <any>response.getHeader(RequestResponseHeaders.requestContextHeader);
@@ -268,11 +279,11 @@ class AutoCollectHttpRequests {
     }
 
     public dispose() {
-         AutoCollectHttpRequests.INSTANCE = null;
-         this.enable(false);
-         this._isInitialized = false;
-         CorrelationContextManager.disable();
-         this._isAutoCorrelating = false;
+        AutoCollectHttpRequests.INSTANCE = null;
+        this.enable(false);
+        this._isInitialized = false;
+        CorrelationContextManager.disable();
+        this._isAutoCorrelating = false;
     }
 }
 

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -31,7 +31,7 @@ class AutoCollectHttpRequests {
         this._client = client;
     }
 
-    public enable(isEnabled: boolean) {
+    public enable(isEnabled:boolean) {
         this._isEnabled = isEnabled;
 
         // Autocorrelation requires automatic monitoring of incoming server requests
@@ -43,7 +43,7 @@ class AutoCollectHttpRequests {
         }
     }
 
-    public useAutoCorrelation(isEnabled: boolean, forceClsHooked?: boolean) {
+    public useAutoCorrelation(isEnabled:boolean, forceClsHooked?:boolean) {
         if (isEnabled && !this._isAutoCorrelating) {
             CorrelationContextManager.enable(forceClsHooked);
         } else if (!isEnabled && this._isAutoCorrelating) {
@@ -60,7 +60,7 @@ class AutoCollectHttpRequests {
         return this._isAutoCorrelating;
     }
 
-    private _generateCorrelationContext(requestParser: HttpRequestParser): CorrelationContext {
+    private _generateCorrelationContext(requestParser:HttpRequestParser): CorrelationContext {
         if (!this._isAutoCorrelating) {
             return;
         }
@@ -85,7 +85,7 @@ class AutoCollectHttpRequests {
             if (typeof onRequest !== 'function') {
                 throw new Error('onRequest handler must be a function');
             }
-            return (request: http.ServerRequest, response: http.ServerResponse) => {
+            return (request:http.ServerRequest, response:http.ServerResponse) => {
                 CorrelationContextManager.wrapEmitter(request);
                 CorrelationContextManager.wrapEmitter(response);
                 const shouldCollect: boolean = request && !(<any>request)[AutoCollectHttpRequests.alreadyAutoCollectedFlag];
@@ -103,7 +103,7 @@ class AutoCollectHttpRequests {
                             (<any>request)[AutoCollectHttpRequests.alreadyAutoCollectedFlag] = true;
 
                             // Auto collect request
-                            AutoCollectHttpRequests.trackRequest(this._client, { request: request, response: response }, requestParser);
+                            AutoCollectHttpRequests.trackRequest(this._client, {request: request, response: response}, requestParser);
                         }
 
                         if (typeof onRequest === "function") {
@@ -146,23 +146,12 @@ class AutoCollectHttpRequests {
             server.on = server.addListener;
         }
 
-        const originalHttpServer: any = http.createServer;
-
-        // options parameter was added in Node.js v9.6.0, v8.12.0
-        // function createServer(requestListener?: RequestListener): Server;
-        // function createServer(options: ServerOptions, requestListener?: RequestListener): Server;
-        http.createServer = (param1?: Object, param2?: Function) => {
+        const originalHttpServer = http.createServer;
+        http.createServer = (onRequest) => {
             // todo: get a pointer to the server so the IP address can be read from server.address
-            if (param2 && typeof param2 === 'function') {
-                const server: http.Server = originalHttpServer(param1, wrapOnRequestHandler(param2));
-                wrapServerEventHandler(server);
-                return server;
-            }
-            else {
-                const server: http.Server = originalHttpServer(wrapOnRequestHandler(param1));
-                wrapServerEventHandler(server);
-                return server;
-            }
+            const server: http.Server = originalHttpServer(wrapOnRequestHandler(onRequest));
+            wrapServerEventHandler(server);
+            return server;
         }
 
         const originalHttpsServer = https.createServer;
@@ -202,7 +191,7 @@ class AutoCollectHttpRequests {
     /**
      * Tracks a request by listening to the response 'finish' event
      */
-    public static trackRequest(client: TelemetryClient, telemetry: Contracts.NodeHttpRequestTelemetry, _requestParser?: HttpRequestParser) {
+    public static trackRequest(client: TelemetryClient, telemetry: Contracts.NodeHttpRequestTelemetry, _requestParser?:HttpRequestParser) {
         if (!telemetry.request || !telemetry.response || !client) {
             Logging.info("AutoCollectHttpRequests.trackRequest was called with invalid parameters: ", !telemetry.request, !telemetry.response, !client);
             return;
@@ -233,7 +222,7 @@ class AutoCollectHttpRequests {
 
         // track a failed request if an error is emitted
         if (telemetry.request.on) {
-            telemetry.request.on("error", (error: any) => {
+            telemetry.request.on("error", (error:any) => {
                 AutoCollectHttpRequests.endRequest(client, requestParser, telemetry, null, error);
             });
         }
@@ -242,7 +231,7 @@ class AutoCollectHttpRequests {
     /**
      * Add the target correlationId to the response headers, if not already provided.
      */
-    private static addResponseCorrelationIdHeader(client: TelemetryClient, response: http.ServerResponse) {
+    private static addResponseCorrelationIdHeader(client: TelemetryClient, response:http.ServerResponse) {
         if (client.config && client.config.correlationId &&
             response.getHeader && response.setHeader && !(<any>response).headersSent) {
             const correlationHeader = <any>response.getHeader(RequestResponseHeaders.requestContextHeader);
@@ -279,11 +268,11 @@ class AutoCollectHttpRequests {
     }
 
     public dispose() {
-        AutoCollectHttpRequests.INSTANCE = null;
-        this.enable(false);
-        this._isInitialized = false;
-        CorrelationContextManager.disable();
-        this._isAutoCorrelating = false;
+         AutoCollectHttpRequests.INSTANCE = null;
+         this.enable(false);
+         this._isInitialized = false;
+         CorrelationContextManager.disable();
+         this._isAutoCorrelating = false;
     }
 }
 

--- a/Tests/AutoCollection/HttpDependencyParser.tests.ts
+++ b/Tests/AutoCollection/HttpDependencyParser.tests.ts
@@ -44,7 +44,7 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.data, "http://bing.com:123/search");
             assert.equal(dependencyTelemetry.target, "bing.com:123 | abcdefg");
         });
-        
+
         it("should return correct data for a URL without a protocol (https)", () => {
             (<any>request)["method"] = "GET";
             let parser = new HttpDependencyParser("a.bing.com:443/search", request);
@@ -59,7 +59,7 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.data, "https://a.bing.com:443/search");
             assert.equal(dependencyTelemetry.target, "a.bing.com:443");
         });
-        
+
         it("should return correct data for a URL without a protocol (http)", () => {
             (<any>request)["method"] = "GET";
             let parser = new HttpDependencyParser("a.bing.com:123/search", request);
@@ -99,8 +99,8 @@ describe("AutoCollection/HttpDependencyParser", () => {
             response.statusCode = 200;
             parser.onResponse(response);
 
-            const dependencyTelemetry1 = parser.getDependencyTelemetry({time: new Date(111111)});
-            const dependencyTelemetry2 = parser.getDependencyTelemetry({time: new Date(222222)});
+            const dependencyTelemetry1 = parser.getDependencyTelemetry({ time: new Date(111111) });
+            const dependencyTelemetry2 = parser.getDependencyTelemetry({ time: new Date(222222) });
             assert.deepEqual(dependencyTelemetry1.time, new Date(111111));
             assert.deepEqual(dependencyTelemetry2.time, new Date(222222));
             assert.notDeepEqual(dependencyTelemetry1, dependencyTelemetry2);
@@ -138,6 +138,29 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.success, true);
             assert.equal(dependencyTelemetry.name, "POST /search");
             assert.equal(dependencyTelemetry.data, "http://bing.com:8000/search?q=test");
+            assert.equal(dependencyTelemetry.target, "bing.com:8000");
+        });
+
+        it("should return correct data for URL with protocol in request", () => {
+            let testRequest: http.ClientRequest = <any>{
+                agent: { protocol: undefined },
+                method: "GET",
+                protocol: "https:"
+            };
+            let requestOptions = {
+                host: "bing.com",
+                port: 8000,
+                path: "/search?q=test",
+            };
+
+            let parser = new HttpDependencyParser(requestOptions, testRequest);
+            response.statusCode = 200;
+            parser.onResponse(response);
+            let dependencyTelemetry = parser.getDependencyTelemetry();
+            assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_HTTP);
+            assert.equal(dependencyTelemetry.success, true);
+            assert.equal(dependencyTelemetry.name, "GET /search");
+            assert.equal(dependencyTelemetry.data, "https://bing.com:8000/search?q=test");
             assert.equal(dependencyTelemetry.target, "bing.com:8000");
         });
 


### PR DESCRIPTION
Fixes #719 