### PR TITLE
#732: Fix: Validate envelope after telemetry processors

### DIFF
--- a/Library/TelemetryClient.ts
+++ b/Library/TelemetryClient.ts
@@ -13,6 +13,7 @@ import Logging = require("./Logging");
 import FlushOptions = require("./FlushOptions");
 import EnvelopeFactory = require("./EnvelopeFactory");
 import QuickPulseStateManager = require("./QuickPulseStateManager");
+import {Tags} from "../Declarations/Contracts";
 
 /**
  * Application Insights telemetry client provides interface to track telemetry items, register telemetry initializers and
@@ -214,6 +215,15 @@ class TelemetryClient {
             } catch (error) {
                 accepted = true;
                 Logging.warn("One of telemetry processors failed, telemetry item will be sent.", error, envelope);
+            }
+        }
+
+        // Sanitize tags and properties after running telemetry processors
+        if (accepted) {
+            envelope.tags = Util.validateStringMap(envelope.data.baseData.properties) as Tags & Tags[];
+
+            if (envelope.data.baseData.properties) {
+                envelope.data.baseData.properties = Util.validateStringMap(envelope.data.baseData.properties);
             }
         }
 

--- a/Library/TelemetryClient.ts
+++ b/Library/TelemetryClient.ts
@@ -220,9 +220,10 @@ class TelemetryClient {
 
         // Sanitize tags and properties after running telemetry processors
         if (accepted) {
-            envelope.tags = Util.validateStringMap(envelope.data.baseData.properties) as Tags & Tags[];
-
-            if (envelope.data.baseData.properties) {
+            if (envelope && envelope.tags) {
+                envelope.tags = Util.validateStringMap(envelope.tags) as Tags & Tags[];
+            }
+            if (envelope && envelope.data && envelope.data.baseData && envelope.data.baseData.properties) {
                 envelope.data.baseData.properties = Util.validateStringMap(envelope.data.baseData.properties);
             }
         }


### PR DESCRIPTION
Fixes #732 

When setting non-string values in telemetry processors the logging is hidden unless you use `.setInternalLogging()` and lower your `maxBatchSize` and `maxBatchIntervalMs` appropriately.

This code only runs when telemetry processors are present. (https://github.com/microsoft/ApplicationInsights-node.js/blob/c56f1933755c22999272f2299d37624426ddc125/Library/TelemetryClient.ts#L198)

I have tested this and it works to correct issues that occur when non-string values are added in telemetry processors. This makes the behavior consistent with adding custom properties at other points in the event lifetime.