### PR TITLE
Use x-forwarded-proto header if available

### DIFF
--- a/AutoCollection/HttpRequestParser.ts
+++ b/AutoCollection/HttpRequestParser.ts
@@ -172,13 +172,14 @@ class HttpRequestParser extends RequestParser {
         var pathName = requestUrl.pathname;
         var search = requestUrl.search;
 
+        var protocol = (encrypted || request.headers["x-forwarded-proto"] == "https") ? "https" : "http";
+
         var absoluteUrl = url.format({
-            protocol: encrypted ? "https" : "http",
+            protocol: protocol,
             host: request.headers.host,
             pathname: pathName,
             search: search
         });
-
         return absoluteUrl;
     }
 

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -1,5 +1,6 @@
 import http = require("http");
 import https = require("https");
+import url = require("url");
 
 import Contracts = require("../Declarations/Contracts");
 import TelemetryClient = require("../Library/TelemetryClient");

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -1,6 +1,5 @@
 import http = require("http");
 import https = require("https");
-import url = require("url");
 
 import Contracts = require("../Declarations/Contracts");
 import TelemetryClient = require("../Library/TelemetryClient");


### PR DESCRIPTION
When running in Azure App Service, URL show as Http instead of Https, adding header handling to get more accurate URL