### PR TITLE
Add retry when redirect is triggered

### DIFF
--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -282,6 +282,7 @@ class Sender {
     private _isRetriable(statusCode: number) {
         return (
             statusCode === 206 || // Retriable
+            statusCode === 308 || // Permanent Redirect
             statusCode === 401 || // Unauthorized
             statusCode === 403 || // Forbidden
             statusCode === 408 || // Timeout

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -168,8 +168,10 @@ describe("Library/Sender", () => {
         it("should change ingestion endpoint when redirect response code is returned (308)", (done) => {
             interceptor.reply(308, {}, { "Location": "testLocation" });
             var testSender = new Sender(new Config("2bb22222-bbbb-1ccc-8ddd-eeeeffff3333"));
+            var storeStub = sandbox.stub(testSender, "_storeToDisk");
             testSender.send([testEnvelope], (responseText) => {
                 assert.equal(testSender["_redirectedHost"], "testLocation");
+                assert.ok(storeStub.calledOnce);
                 done();
             });
         });

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -168,6 +168,7 @@ describe("Library/Sender", () => {
         it("should change ingestion endpoint when redirect response code is returned (308)", (done) => {
             interceptor.reply(308, {}, { "Location": "testLocation" });
             var testSender = new Sender(new Config("2bb22222-bbbb-1ccc-8ddd-eeeeffff3333"));
+            testSender.setDiskRetryMode(true);
             var storeStub = sandbox.stub(testSender, "_storeToDisk");
             testSender.send([testEnvelope], (responseText) => {
                 assert.equal(testSender["_redirectedHost"], "testLocation");


### PR DESCRIPTION
Data is not persisted in Breeze when redirect is returned