### PR TITLE
Negative preaggregated metrics fix

### DIFF
--- a/AutoCollection/PreAggregatedMetrics.ts
+++ b/AutoCollection/PreAggregatedMetrics.ts
@@ -23,8 +23,6 @@ class AutoCollectPreAggregatedMetrics {
     private _handle: NodeJS.Timer;
     private _isEnabled: boolean;
     private _isInitialized: boolean;
-    private _lastIntervalRequestExecutionTime: number = 0; // the sum of durations which took place during from app start until last interval
-    private _lastIntervalDependencyExecutionTime: number = 0;
 
     private static _dependencyCountersCollection: Array<AggregatedMetricCounter>;
     private static _requestCountersCollection: Array<AggregatedMetricCounter>;
@@ -172,8 +170,8 @@ class AutoCollectPreAggregatedMetrics {
             currentCounter.time = +new Date;
             var intervalRequests = (currentCounter.totalCount - currentCounter.lastTotalCount) || 0;
             var elapsedMs = currentCounter.time - currentCounter.lastTime;
-            var averageRequestExecutionTime = ((currentCounter.intervalExecutionTime - this._lastIntervalRequestExecutionTime) / intervalRequests) || 0;
-            this._lastIntervalRequestExecutionTime = currentCounter.intervalExecutionTime; // reset
+            var averageRequestExecutionTime = ((currentCounter.intervalExecutionTime - currentCounter.lastIntervalExecutionTime) / intervalRequests) || 0;
+            currentCounter.lastIntervalExecutionTime = currentCounter.intervalExecutionTime; // reset
             if (elapsedMs > 0) {
                 if (intervalRequests > 0) {
                     this._trackPreAggregatedMetric({
@@ -198,8 +196,8 @@ class AutoCollectPreAggregatedMetrics {
             currentCounter.time = +new Date;
             var intervalDependencies = (currentCounter.totalCount - currentCounter.lastTotalCount) || 0;
             var elapsedMs = currentCounter.time - currentCounter.lastTime;
-            var averageDependencyExecutionTime = ((currentCounter.intervalExecutionTime - this._lastIntervalDependencyExecutionTime) / intervalDependencies) || 0;
-            this._lastIntervalDependencyExecutionTime = currentCounter.intervalExecutionTime; // reset
+            var averageDependencyExecutionTime = ((currentCounter.intervalExecutionTime - currentCounter.lastIntervalExecutionTime) / intervalDependencies) || 0;
+            currentCounter.lastIntervalExecutionTime = currentCounter.intervalExecutionTime; // reset
             if (elapsedMs > 0) {
                 if (intervalDependencies > 0) {
                     this._trackPreAggregatedMetric({

--- a/Declarations/Metrics/AggregatedMetricCounters.ts
+++ b/Declarations/Metrics/AggregatedMetricCounters.ts
@@ -12,6 +12,8 @@ export class AggregatedMetricCounter {
 
     public intervalExecutionTime: number;
 
+    public lastIntervalExecutionTime: number;
+
     public dimensions: MetricBaseDimensions;
 
     constructor(dimensions: MetricBaseDimensions) {
@@ -20,6 +22,7 @@ export class AggregatedMetricCounter {
         this.lastTotalCount = 0;
         this.intervalExecutionTime = 0;
         this.lastTime = +new Date;
+        this.lastIntervalExecutionTime = 0;
     }
 }
 

--- a/Tests/AutoCollection/PreAggregatedMetrics.tests.ts
+++ b/Tests/AutoCollection/PreAggregatedMetrics.tests.ts
@@ -47,10 +47,7 @@ describe("AutoCollection/PreAggregatedMetrics", () => {
                 autoCollect2["_trackRequestMetrics"]();
                 AutoCollectPreAggregatedMetrics.countRequest(5000, {});
 
-                const prev1 = autoCollect1["_lastIntervalRequestExecutionTime"];
-                const prev2 = autoCollect2["_lastIntervalRequestExecutionTime"];
-                assert.deepEqual(prev1, prev2);
-                assert.deepEqual(prev1, 1000 + 2000);
+                assert.deepEqual(AutoCollectPreAggregatedMetrics["_requestCountersCollection"][0]["lastIntervalExecutionTime"], 1000 + 2000);
 
                 // Add to end of event loop
                 setTimeout(() => {
@@ -75,6 +72,4 @@ describe("AutoCollection/PreAggregatedMetrics", () => {
             }, 100);
         });
     });
-
-
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
       }
     },
     "@azure/core-http": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.5.tgz",
-      "integrity": "sha512-SjjjqaO9emyn+XM0Qyzt5RsgddOIpGAfhWH6+d8X6/HbhFrtvXLJIz85EMoIO+T4rX3ISStik9MD5LMW9IZg4A==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.6.tgz",
+      "integrity": "sha512-odtH7UMKtekc5YQ86xg9GlVHNXR6pq2JgJ5FBo7/jbOjNGdBqcrIVrZx2bevXVJz/uUTSx6vUf62gzTXTfqYSQ==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-asynciterator-polyfill": "^1.0.0",
@@ -42,7 +42,7 @@
         "node-fetch": "^2.6.0",
         "process": "^0.11.10",
         "tough-cookie": "^4.0.0",
-        "tslib": "^2.0.0",
+        "tslib": "^2.2.0",
         "tunnel": "^0.0.6",
         "uuid": "^8.3.0",
         "xml2js": "^0.4.19"
@@ -1667,9 +1667,9 @@
       }
     },
     "tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "tunnel": {
       "version": "0.0.6",


### PR DESCRIPTION
Last interval execution time need to be part of specific pre aggregated counter instead of global one to avoid miscalculations generating negative numbers

Fixes #776