### PR TITLE
Update to use WHATWG URL API instead of url.parse()

### DIFF
--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -123,7 +123,7 @@ class HttpDependencyParser extends RequestParser {
                     options = new url.URL("http://" + options);
                 }
             }
-        } else if (options && typeof url.URL === 'function' && options instanceof URL) {
+        } else if (options && typeof url.URL === 'function' && options instanceof url.URL) {
             return url.format(options);
         } else {
             // Avoid modifying the original options object.

--- a/Library/Config.ts
+++ b/Library/Config.ts
@@ -104,7 +104,7 @@ class Config {
         this._quickPulseHost = csCode.liveendpoint || csEnv.liveendpoint || process.env[Config.ENV_quickPulseHost] || Constants.DEFAULT_LIVEMETRICS_HOST;
         // Parse quickPulseHost if it starts with http(s)://
         if (this._quickPulseHost.match(/^https?:\/\//)) {
-            this._quickPulseHost = url.parse(this._quickPulseHost).host;
+            this._quickPulseHost = new url.URL(this._quickPulseHost).host;
         }
     }
 

--- a/Library/TelemetryClient.ts
+++ b/Library/TelemetryClient.ts
@@ -118,7 +118,14 @@ class TelemetryClient {
             // url.parse().host returns null for non-urls,
             // making this essentially a no-op in those cases
             // If this logic is moved, update jsdoc in DependencyTelemetry.target
-            telemetry.target = url.parse(telemetry.data).host;
+            // url.parse() is deprecated, update to use WHATWG URL API instead
+            try {
+                telemetry.target = new url.URL(telemetry.data).host;
+            } catch (error) {
+                // set target as null to be compliant with previous behavior
+                telemetry.target = null;
+                Logging.warn("The URL object is failed to create.", error);
+            }
         }
         this.track(telemetry, Contracts.TelemetryType.Dependency);
     }

--- a/Library/Util.ts
+++ b/Library/Util.ts
@@ -245,7 +245,7 @@ class Util {
 
         for (let i = 0; i < excludedDomains.length; i++) {
             let regex = new RegExp(excludedDomains[i].replace(/\./g, "\.").replace(/\*/g, ".*"));
-            if (regex.test(url.parse(requestUrl).hostname)) {
+            if (regex.test(new url.URL(requestUrl).hostname)) {
                 return false;
             }
         }
@@ -287,7 +287,7 @@ class Util {
             requestUrl = 'https:' + requestUrl;
         }
 
-        var requestUrlParsed = url.parse(requestUrl);
+        var requestUrlParsed = new url.URL(requestUrl);
         var options = {
             ...requestOptions,
             host: requestUrlParsed.hostname,
@@ -308,7 +308,7 @@ class Util {
             if (proxyUrl.indexOf('//') === 0) {
                 proxyUrl = 'http:' + proxyUrl;
             }
-            var proxyUrlParsed = url.parse(proxyUrl);
+            var proxyUrlParsed = new url.URL(proxyUrl);
 
             // https is not supported at the moment
             if (proxyUrlParsed.protocol === 'https:') {

--- a/Tests/AutoCollection/HttpDependencyParser.tests.ts
+++ b/Tests/AutoCollection/HttpDependencyParser.tests.ts
@@ -56,8 +56,8 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_HTTP);
             assert.equal(dependencyTelemetry.success, true);
             assert.equal(dependencyTelemetry.name, "GET /search");
-            assert.equal(dependencyTelemetry.data, "https://a.bing.com:443/search");
-            assert.equal(dependencyTelemetry.target, "a.bing.com:443");
+            assert.equal(dependencyTelemetry.data, "https://a.bing.com/search");
+            assert.equal(dependencyTelemetry.target, "a.bing.com");
         });
 
         it("should return correct data for a URL without a protocol (http)", () => {

--- a/Tests/Library/Util.tests.ts
+++ b/Tests/Library/Util.tests.ts
@@ -295,7 +295,7 @@ describe("Library/Util", () => {
     describe("#makeRequest()", () => {
         const proxyUrl = "http://10.0.0.1:3128";
         const proxyUrlHttps = "https://10.0.0.1:3128";
-        const proxyUrlParsed = url.parse(proxyUrl);
+        const proxyUrlParsed = new url.URL(proxyUrl);
         const options = {
             method: "GET",
             headers: <{ [key: string]: string }>{
@@ -305,7 +305,7 @@ describe("Library/Util", () => {
 
         describe("for http request", () => {
             const requestUrl = "http://abc.def.bing.com";
-            const requestUrlParsed = url.parse(requestUrl);
+            const requestUrlParsed = new url.URL(requestUrl);
 
             beforeEach(() => {
                 if (process.env.hasOwnProperty('https_proxy')) {
@@ -384,7 +384,7 @@ describe("Library/Util", () => {
 
         describe("for https request", () => {
             const requestUrl = "https://abc.def.bing.com";
-            const requestUrlParsed = url.parse(requestUrl);
+            const requestUrlParsed = new url.URL(requestUrl);
 
             beforeEach(() => {
                 if (process.env.hasOwnProperty('https_proxy')) {


### PR DESCRIPTION
This PR includes: 
- Update to WHATWG URL API instead of `url.parse()` method.
- Addresses #432 
- URL API is stable on Node 8: https://nodejs.org/docs/latest-v8.x/api/url.html#url_url

Details: 
- [url.parse](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) is deprecated
- The [WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api) is recommended

Note: 
`new URL(input[, base])` : [details](https://nodejs.org/api/url.html#url_new_url_input_base)
- When creating a new URL object, if the first parameter `input `is relative, then `base `is required. If `input `is absolute, the `base `is ignored.
- A `TypeError `will be thrown if the `input `or `base `are not valid URLs. 