### PR TITLE
Prevent Azure SDK OT incompatibility  to trigger errors

### DIFF
--- a/AutoCollection/diagnostic-channel/SpanParser.ts
+++ b/AutoCollection/diagnostic-channel/SpanParser.ts
@@ -14,7 +14,8 @@ function filterSpanAttributes(attributes: SpanAttributes) {
 }
 
 export function spanToTelemetryContract(span: Span): (Contracts.DependencyTelemetry & Contracts.RequestTelemetry) & Contracts.Identified {
-    const id = `|${span.spanContext().traceId}.${span.spanContext().spanId}.`;
+    const spanContext = span.spanContext ? span.spanContext() : (<any>span).context(); // context is available in OT API <v0.19.0
+    const id = `|${spanContext.traceId}.${spanContext.spanId}.`;
     const duration = Math.round(span["_duration"][0] * 1e3 + span["_duration"][1] / 1e6);
     let peerAddress = span.attributes["peer.address"] ? span.attributes["peer.address"].toString() : "";
 

--- a/AutoCollection/diagnostic-channel/azure-coretracing.sub.ts
+++ b/AutoCollection/diagnostic-channel/azure-coretracing.sub.ts
@@ -14,27 +14,29 @@ import { AsyncScopeManager } from "../AsyncHooksScopeManager";
 let clients: TelemetryClient[] = [];
 
 export const subscriber = (event: IStandardEvent<Span>) => {
-    const span = event.data;
-    const telemetry = SpanParser.spanToTelemetryContract(span);
-    const spanContext = span.spanContext();
-    const traceparent = new Traceparent();
-    traceparent.traceId = spanContext.traceId;
-    traceparent.spanId = spanContext.spanId;
-    traceparent.traceFlag = Traceparent.formatOpenTelemetryTraceFlags(spanContext.traceFlags);
-    traceparent.parentId = span.parentSpanId ? `|${spanContext.traceId}.${span.parentSpanId}.` : null;
-
-    AsyncScopeManager.with(span, () => {
-        clients.forEach((client) => {
-            if (span.kind === SpanKind.SERVER) {
-                // Server or Consumer
-                client.trackRequest(telemetry);
-            } else if (span.kind === SpanKind.CLIENT || span.kind === SpanKind.INTERNAL) {
-                // Client or Producer or Internal
-                client.trackDependency(telemetry);
-            }
-            // else - ignore producer/consumer spans for now until it is clear how this sdk should interpret them
+    try {
+        const span = event.data;
+        const telemetry = SpanParser.spanToTelemetryContract(span);
+        const spanContext = span.spanContext ? span.spanContext() : (<any>span).context(); // context is available in OT API <v0.19.0
+        const traceparent = new Traceparent();
+        traceparent.traceId = spanContext.traceId;
+        traceparent.spanId = spanContext.spanId;
+        traceparent.traceFlag = Traceparent.formatOpenTelemetryTraceFlags(spanContext.traceFlags);
+        traceparent.parentId = span.parentSpanId ? `|${spanContext.traceId}.${span.parentSpanId}.` : null;
+        AsyncScopeManager.with(span, () => {
+            clients.forEach((client) => {
+                if (span.kind === SpanKind.SERVER) {
+                    // Server or Consumer
+                    client.trackRequest(telemetry);
+                } else if (span.kind === SpanKind.CLIENT || span.kind === SpanKind.INTERNAL) {
+                    // Client or Producer or Internal
+                    client.trackDependency(telemetry);
+                }
+                // else - ignore producer/consumer spans for now until it is clear how this sdk should interpret them
+            });
         });
-    });
+    }
+    catch (err) { { /** ignore errors */ } }
 };
 
 export function enable(enabled: boolean, client: TelemetryClient) {


### PR DESCRIPTION
OT rename of context method is causing errors when incompatible versions are loaded of OpenTelemetry API in Azure SDKs and this library 
https://github.com/open-telemetry/opentelemetry-js-api/pull/45

