### PR TITLE
applicationinsights.ts

### DIFF
--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -362,7 +362,7 @@ export class Configuration {
 
         if (!liveMetricsClient && enable) {
             // No qps client exists. Create one and prepare it to be enabled at .start()
-            liveMetricsClient = new QuickPulseClient(defaultClient.config, null);
+            liveMetricsClient = new QuickPulseClient(defaultClient.config, defaultClient.context);
             _performanceLiveMetrics = new AutoCollectPerformance(liveMetricsClient as any, 1000, true);
             liveMetricsClient.addCollector(_performanceLiveMetrics);
             defaultClient.quickPulseClient = liveMetricsClient; // Need this so we can forward all manual tracks to live metrics via PerformanceMetricsTelemetryProcessor


### PR DESCRIPTION
Fix https://github.com/microsoft/ApplicationInsights-node.js/issues/837

- pass defaultClient.context to QuickPulseClient

While tinkering with the debugger, I noticed that the constructor for `QuickPulseStateManager `  will use default context if one is not provided.
https://github.com/microsoft/ApplicationInsights-node.js/blob/a327c10f53cc4e93699fb5c2b196bc0906b7882d/Library/QuickPulseStateManager.ts#L35-L40

and

null was always passed to `QuickPulseStateManager`, hence the default context will always be used
https://github.com/microsoft/ApplicationInsights-node.js/blob/a327c10f53cc4e93699fb5c2b196bc0906b7882d/applicationinsights.ts#L363-L369

This explains #837 inability to get "Role Name" updated in the portal.