### PR TITLE
Fix package.json dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,8 +106,7 @@
     "@opentelemetry/semantic-conventions": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-      "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-      "dev": true
+      "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA=="
     },
     "@opentelemetry/tracing": {
       "version": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "node": ">=8.0.0"
   },
   "devDependencies": {
-    "@opentelemetry/semantic-conventions": "^0.24.0",
     "@types/cls-hooked": "^4.3.3",
     "@types/mocha": "^7.0.2",
     "@types/node": "^8.0.0",
@@ -59,9 +58,18 @@
     "@azure/core-http": "^2.2.0",
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/tracing": "^0.23.0",
+    "@opentelemetry/semantic-conventions": "^0.24.0",
     "cls-hooked": "^4.2.2",
     "continuation-local-storage": "^3.2.1",
     "diagnostic-channel": "1.0.0",
     "diagnostic-channel-publishers": "1.0.3"
+  },
+  "peerDependencies": {
+    "applicationinsights-native-metrics": "*"
+  },
+  "peerDependenciesMeta": {
+    "applicationinsights-native-metrics": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@azure/core-http": "^2.2.0",
     "@opentelemetry/api": "^1.0.3",
+    "@opentelemetry/core": "^0.23.0",
     "@opentelemetry/tracing": "^0.23.0",
     "@opentelemetry/semantic-conventions": "^0.24.0",
     "cls-hooked": "^4.2.2",


### PR DESCRIPTION
When using Yarn v2, packages that are explicitly imported within a package scope need to be marked as either a direct dependency or a peer. This prevents tacit module resolution from creeping into dependencies.

### 1: Move `@opentelemetry/semantic-conventions` to dependencies.
**Justification**: it's directly imported in the following locations:
* https://github.com/microsoft/ApplicationInsights-node.js/blob/ec12907d1d92a68c0c577d1df020c08e0cbc0e0f/AutoCollection/diagnostic-channel/SpanParser.ts#L4
* https://github.com/microsoft/ApplicationInsights-node.js/blob/ec12907d1d92a68c0c577d1df020c08e0cbc0e0f/AutoCollection/diagnostic-channel/Azure/EventHub.ts#L5

### 2: Add `@opentelemetry/core` to dependencies
**Justification** it's directly imported in the following location:
* https://github.com/microsoft/ApplicationInsights-node.js/blob/ec12907d1d92a68c0c577d1df020c08e0cbc0e0f/AutoCollection/diagnostic-channel/Azure/EventHub.ts#L4

### 3: Mark `applicationinsights-native-metrics` as an optional peer dependency.
**Justification**: it's conditionally imported in the following location:

https://github.com/microsoft/ApplicationInsights-node.js/blob/ec12907d1d92a68c0c577d1df020c08e0cbc0e0f/AutoCollection/NativePerformance.ts#L63

This can be resolved on the client-side, but clients have to monkey-patch in proper dependencies: https://github.com/microsoft/community-organization-operations-suite/blob/b04c9fe9bec52aba50f50ac68a90e398ab620a56/.yarnrc.yml#L45-L48
