### PR TITLE
Fix issue with exception telemetry not being generated for Bunyan errors

### DIFF
--- a/Tests/AutoCollection/bunyan.tests.ts
+++ b/Tests/AutoCollection/bunyan.tests.ts
@@ -23,9 +23,11 @@ describe("diagnostic-channel/bunyan", () => {
             result: "test log",
             level: 50 // Error should still log as MessageData
         };
-        const dummyError = new Error("test error");
+
+        const dummyError = { stack: "Test error" };
+        const bunyanJson = JSON.stringify({ err: dummyError });
         const errorEvent: bunyan.IBunyanData = {
-            result: dummyError as any,
+            result: bunyanJson,
             level: 10, // Verbose should still log as ExceptionData
         };
 


### PR DESCRIPTION
Auto instrumentation only generate exception when message is an error object, if logger.error is called it will generate trace if string is passed.

Fixes #786