### PR TITLE
Add path to http dependency when host is missing

### DIFF
--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -144,12 +144,26 @@ class HttpDependencyParser extends RequestParser {
             }
         }
 
+        
+
         // Oddly, url.format ignores path and only uses pathname and search,
         // so create them from the path, if path was specified
         if (options.path && options.host) {
             // need to force a protocol to make parameter valid - base url is required when input is a relative url
             try {
                 const parsedQuery = new url.URL(options.path, 'http://' + options.host + options.path);
+                options.pathname = parsedQuery.pathname;
+                options.search = parsedQuery.search;
+            }
+            catch (ex) { }
+        }
+
+        // Sometimes the hostname is provided but not the host
+        // Add in the path when this occurs
+        if (options.path && options.hostname && !options.host) {
+            // need to force a protocol to make parameter valid - base url is required when input is a relative url
+            try {
+                const parsedQuery = new url.URL(options.path, 'http://' + options.hostname + options.path);
                 options.pathname = parsedQuery.pathname;
                 options.search = parsedQuery.search;
             }

--- a/AutoCollection/HttpDependencyParser.ts
+++ b/AutoCollection/HttpDependencyParser.ts
@@ -144,8 +144,6 @@ class HttpDependencyParser extends RequestParser {
             }
         }
 
-        
-
         // Oddly, url.format ignores path and only uses pathname and search,
         // so create them from the path, if path was specified
         if (options.path && options.host) {

--- a/Tests/AutoCollection/HttpDependencyParser.tests.ts
+++ b/Tests/AutoCollection/HttpDependencyParser.tests.ts
@@ -141,6 +141,26 @@ describe("AutoCollection/HttpDependencyParser", () => {
             assert.equal(dependencyTelemetry.target, "bing.com:8000");
         });
 
+        it("should return correct data for a request options object with a hostname but no host", () => {
+            let requestOptions = {
+                hostname: "bing.com",
+                port: 8000,
+                path: "/search?q=test",
+            };
+            (<any>request)["method"] = "POST";
+            let parser = new HttpDependencyParser(requestOptions, request);
+
+            response.statusCode = 200;
+            parser.onResponse(response);
+
+            let dependencyTelemetry = parser.getDependencyTelemetry();
+            assert.equal(dependencyTelemetry.dependencyTypeName, Contracts.RemoteDependencyDataConstants.TYPE_HTTP);
+            assert.equal(dependencyTelemetry.success, true);
+            assert.equal(dependencyTelemetry.name, "POST /search");
+            assert.equal(dependencyTelemetry.data, "http://bing.com:8000/search?q=test");
+            assert.equal(dependencyTelemetry.target, "bing.com:8000");
+        });
+
         it("should return correct data for URL with protocol in request", () => {
             let testRequest: http.ClientRequest = <any>{
                 agent: { protocol: undefined },


### PR DESCRIPTION
Whenever the hostname is populated but the host is missing, use the hostname and add in the path. This fixes the issue where the path is missing from app insights detailed in this issue #886 