### PR TITLE
fix(AutoCollectHttpRequests): Http requests aren't collect if we call dispose+setup after http.createServer

### DIFF
--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -13,7 +13,7 @@ import AutoCollectPerformance = require("./Performance");
 class AutoCollectHttpRequests {
 
     public static INSTANCE: AutoCollectHttpRequests;
-    public static HANDLER_READY: boolean = false;
+    private static HANDLER_READY: boolean = false;
 
     private static alreadyAutoCollectedFlag = "_appInsightsAutoCollected";
 

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -75,7 +75,7 @@ class AutoCollectHttpRequests {
         );
     }
 
-    private registerRequest(request: http.ServerRequest, response: http.ServerResponse, onRequest: Function) {
+    private _registerRequest(request: http.ServerRequest, response: http.ServerResponse, onRequest: Function) {
         // Set up correlation context
         const requestParser = new HttpRequestParser(request);
         const correlationContext = this._generateCorrelationContext(requestParser);
@@ -120,7 +120,7 @@ class AutoCollectHttpRequests {
                 const shouldCollect: boolean = request && !(<any>request)[AutoCollectHttpRequests.alreadyAutoCollectedFlag];
 
                 if (request && shouldCollect) {
-                    AutoCollectHttpRequests.INSTANCE?.registerRequest(request, response, onRequest)
+                    AutoCollectHttpRequests.INSTANCE?._registerRequest(request, response, onRequest)
                 } else {
                     if (typeof onRequest === "function") {
                         onRequest(request, response);

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -22,6 +22,7 @@ import Util = require("../Library/Util");
 import { JsonConfig } from "../Library/JsonConfig";
 import { FileAccessControl } from "../Library/FileAccessControl";
 import FileSystemHelper = require("../Library/FileSystemHelper");
+import AutoCollectHttpRequests = require("../AutoCollection/HttpRequests");
 
 /**
  * A fake response class that passes by default
@@ -242,6 +243,10 @@ describe("EndToEnd", () => {
                 return fakeHttpSrv;
             });
 
+            // We stub the property indicating if the handler on http(s).createServer is ready so that the handler is
+            // placed on the function http(s).createServer stub
+            sandbox.stub(AutoCollectHttpRequests, 'HANDLER_READY', false);
+
             AppInsights
                 .setup("ikey")
                 .setAutoCollectRequests(true)
@@ -264,6 +269,10 @@ describe("EndToEnd", () => {
                 fakeHttpSrv.setCallback(callback);
                 return fakeHttpSrv;
             });
+
+            // We stub the property indicating if the handler on http(s).createServer is ready so that the handler is
+            // placed on the function http(s).createServer stub
+            sandbox.stub(AutoCollectHttpRequests, 'HANDLER_READY', false);
 
             AppInsights
                 .setup("ikey")


### PR DESCRIPTION
### **- What is the problem?**
Currently, every time an instance of AutoCollectHttpRequests is created, we overwrite the http(s).createServer function to add a handler to track HTTP(S) requests. As a result, if we call the constructor several times we end up with several handlers that can duplicate data.
The second problem is when we initialize the library once with setup() and then create the server with http(s).createServer. Here we track the requests correctly but if, for X reasons, we call dispose() and then setup(), the HTTP requests will not be tracked anymore because the code waits for a call to createServer to add the instance handler (despite the fact that the instance created at the first setup call already had one in place)

### **- How is it corrected?**
As the code allows to have only one instance of AutoCollectHttpRequests at the same time ( stored in the static variable INSTANCE ), it is not necessary to modify the code of http(s).createServer each time the constructor is called. It is necessary to do it only once and in the added handler, we call a method of the instance stored in the static variable to register the request.
Thus, after the call to dispose() the registrations will stop but will resume after the call to setup despite the change of instance.

__ __

_The fix is not optimized. In fact, this kind of handler should not be added when calling a constructor but rather at the very beginning of the library to optimize the chances that the library is well instantiated by the developers. However, after a discussion with @hectorhdzg ( #945 ) it turns out that this part of the code is going to change soon, so I didn't want to dwell on a code that will soon be completely overwritten._