### PR TITLE
Add HTTP Request Timeout

### DIFF
--- a/Library/AzureVirtualMachine.ts
+++ b/Library/AzureVirtualMachine.ts
@@ -19,6 +19,7 @@ export interface IVirtualMachineInfo {
 }
 
 export class AzureVirtualMachine {
+    public static HTTP_TIMEOUT: number = 2500; // 2.5 seconds
 
     private static TAG = "AzureVirtualMachine";
 
@@ -31,7 +32,6 @@ export class AzureVirtualMachine {
             headers: {
                 "Metadata": "True"
             },
-            timeout: 2500, // DNS resolution is taking long time in MacOS environments
         };
 
         const req = Util.makeRequest(config, metadataRequestUrl, requestOptions, (res) => {
@@ -60,7 +60,7 @@ export class AzureVirtualMachine {
             }
         }, false, false);
         if (req) {
-            req.on("timeout", () => {
+            req.setTimeout(AzureVirtualMachine.HTTP_TIMEOUT, () => {
                 req.abort();
             });
             req.on("error", (error: Error) => {

--- a/Library/CorrelationIdManager.ts
+++ b/Library/CorrelationIdManager.ts
@@ -7,7 +7,7 @@ class CorrelationIdManager {
     private static _handle: NodeJS.Timer;
     public static correlationIdPrefix = "cid-v1:";
     public static w3cEnabled = true;
-    public static HTTP_TIMEOUT: number = 20000; // 20 seconds
+    public static HTTP_TIMEOUT: number = 2500; // 2.5 seconds
 
     // To avoid extraneous HTTP requests, we maintain a queue of callbacks waiting on a particular appId lookup,
     // as well as a cache of completed lookups so future requests can be resolved immediately.

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -285,6 +285,13 @@ class Sender {
 
                 var req = Util.makeRequest(this._config, endpointUrl, options, requestCallback);
 
+                // Needed as of Node.js v13 default timeouts on HTTP requests are no longer default.
+                // Timeout should trigger the request on error function to run.
+                req.setTimeout(20000, () => {
+                    console.log("Triggered 20 second timeout!")
+                    req.destroy({name: "Timeout", message: "Telemetry request timed out."});
+                });
+
                 req.on("error", (error: Error) => {
                     if (this._isStatsbeatSender && !this._statsbeatHasReachedIngestionAtLeastOnce) {
                         this._statsbeatFailedToIngest();

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -29,6 +29,7 @@ class Sender {
     public static CLEANUP_TIMEOUT = 60 * 60 * 1000; // 1 hour
     public static FILE_RETEMPTION_PERIOD = 7 * 24 * 60 * 60 * 1000; // 7 days
     public static TEMPDIR_PREFIX: string = "appInsights-node";
+    public static HTTP_TIMEOUT: number = 20000; // 20 seconds
 
     private _config: Config;
     private _isStatsbeatSender: boolean;
@@ -287,9 +288,8 @@ class Sender {
 
                 // Needed as of Node.js v13 default timeouts on HTTP requests are no longer default.
                 // Timeout should trigger the request on error function to run.
-                req.setTimeout(20000, () => {
-                    console.log("Triggered 20 second timeout!")
-                    req.destroy({name: "Timeout", message: "Telemetry request timed out."});
+                req.setTimeout(Sender.HTTP_TIMEOUT, () => {
+                    req.destroy(new Error("Timeout sending telemetry"));
                 });
 
                 req.on("error", (error: Error) => {

--- a/Tests/EndToEnd.tests.ts
+++ b/Tests/EndToEnd.tests.ts
@@ -108,6 +108,14 @@ class fakeRequest {
 
     }
 
+    public setTimeout(value: number, callback: () => void) {
+
+    }
+
+    public abort() {
+        
+    }
+
     public fail(): void {
         this.callbacks["error"] ? this.callbacks["error"]() : null;
     }

--- a/Tests/Library/AzureVirtualMachine.tests.ts
+++ b/Tests/Library/AzureVirtualMachine.tests.ts
@@ -1,0 +1,46 @@
+import assert = require("assert");
+import sinon = require("sinon");
+import nock = require("nock");
+import AppInsights = require("../../applicationinsights");
+import { AzureVirtualMachine } from "../../Library/AzureVirtualMachine";
+import Vm = require("../../Library/AzureVirtualMachine");
+import Constants = require("../../Declarations/Constants");
+
+describe("Library/AzureVirtualMachine", () => {
+    var sandbox: sinon.SinonSandbox;
+    let interceptor: nock.Interceptor;
+    let nockScope: nock.Scope;
+
+    before(() => {
+        interceptor = nock(Constants.DEFAULT_BREEZE_ENDPOINT)
+            .post("/v2.1/track", (body: string) => {
+                return true;
+            });
+    });
+
+    beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+    });
+
+    after(() => {
+        nock.cleanAll();
+    });
+
+    describe("#getAzureComputeMetadata", () => {
+        afterEach(() => {
+            AzureVirtualMachine.HTTP_TIMEOUT = 2500;
+        });
+
+        it("should timeout effectively when calling getAzureComputeMetadata", () => {
+            const client = new AppInsights.TelemetryClient("key");
+            nockScope = interceptor.delay(300).reply(200);
+            AzureVirtualMachine.HTTP_TIMEOUT = 200;
+
+            let onErrorSpy = sandbox.spy(AzureVirtualMachine, "getAzureComputeMetadata");
+            Vm.AzureVirtualMachine.getAzureComputeMetadata(client.config, () => {
+                console.log("AZURE VIRTUAL MACHINE CALLBACK");
+                assert.ok(onErrorSpy.calledOnce);
+            });
+        });
+    });
+});

--- a/Tests/Library/AzureVirtualMachine.tests.ts
+++ b/Tests/Library/AzureVirtualMachine.tests.ts
@@ -38,7 +38,6 @@ describe("Library/AzureVirtualMachine", () => {
 
             let onErrorSpy = sandbox.spy(AzureVirtualMachine, "getAzureComputeMetadata");
             Vm.AzureVirtualMachine.getAzureComputeMetadata(client.config, () => {
-                console.log("AZURE VIRTUAL MACHINE CALLBACK");
                 assert.ok(onErrorSpy.calledOnce);
             });
         });

--- a/Tests/Library/CorrelationIdManager.tests.ts
+++ b/Tests/Library/CorrelationIdManager.tests.ts
@@ -1,0 +1,46 @@
+import assert = require("assert");
+import sinon = require("sinon");
+import nock = require("nock");
+import AppInsights = require("../../applicationinsights");
+import Constants = require("../../Declarations/Constants");
+import CorrelationIdManager = require("../../Library/CorrelationIdManager");
+
+describe("Library/CorrelationIdManager", () => {
+    var sandbox: sinon.SinonSandbox;
+    let interceptor: nock.Interceptor;
+    let nockScope: nock.Scope;
+
+    before(() => {
+        interceptor = nock(Constants.DEFAULT_BREEZE_ENDPOINT)
+            .post("/v2.1/track", (body: string) => {
+                return true;
+            });
+    });
+
+    beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+    });
+
+    after(() => {
+        nock.cleanAll();
+    });
+
+    describe("#queryCorrelationId", () => {
+        afterEach(() => {
+            CorrelationIdManager.HTTP_TIMEOUT = 2500;
+        });
+
+        it("should timeout effectively when calling queryCorrelationId", () => {
+            const client = new AppInsights.TelemetryClient("key");
+            nockScope = interceptor.delay(300).reply(200);
+            CorrelationIdManager.HTTP_TIMEOUT = 200;
+
+            let onErrorSpy = sandbox.spy(CorrelationIdManager, "queryCorrelationId");
+            CorrelationIdManager.queryCorrelationId(client.config, () => {
+                assert.ok(onErrorSpy.calledOnce);
+                let error = onErrorSpy.args[0][0] as Error;
+                assert.equal(error.message, "telemetry request timed out");
+            });
+        });
+    });
+});

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -138,6 +138,29 @@ describe("Library/Sender", () => {
                 done();
             });
         });
+
+        it("should timeout if the server does not provide a response within 20 seconds", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestTimeout";
+
+            var breezeResponse: Contracts.BreezeResponse = {
+                itemsAccepted: 1,
+                itemsReceived: 1,
+                errors: []
+            };
+
+            nockScope = interceptor.delay(400).reply(200, breezeResponse);
+
+            sender.send([envelope], () => {})
+            .then((response) => {
+                console.log("Response: ", response);
+                done();
+            })
+            .catch((error) => {
+                console.log("Error: ", error);
+                done();
+            });
+        }).timeout(20000);
     });
 
     describe("#setOfflineMode(value, resendInterval)", () => {

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -155,12 +155,13 @@ describe("Library/Sender", () => {
 
             Sender.HTTP_TIMEOUT = 100;
             nockScope = interceptor.delay(300).reply(200, breezeResponse);
+            let onErrorSpy = sandbox.spy(sender, "_onErrorHelper");
 
-            // Attempted using sender.spy() here - had to make _onError() a public method and was still seeing issues with calling it from within the test case.
-            // What I've noticed is that when an assert would evaluate to true using the callbackResponse the console.log of the callbackResponse prints out the breezeResponse.
-            sender.send([envelope], (callbackResponse) => {
-                console.log('callback response', callbackResponse);
-                assert.ok(callbackResponse.includes("Timeout sending telemetry"));
+            sender.send([envelope], () => {
+                assert.ok(onErrorSpy.called);
+                let error = onErrorSpy.args[0][0] as Error;
+                assert.equal(error.message, "telemetry request timed out");
+                done();
             });
         });
     });


### PR DESCRIPTION
Fixes #958 by adding a default HTTP request timeout of 20 seconds. Includes associated unit test.