### PR TITLE
Add 500 Retry Codes

### DIFF
--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -358,7 +358,9 @@ class Sender {
             statusCode === 408 || // Timeout
             statusCode === 429 || // Too many requests
             statusCode === 500 || // Server Error
-            statusCode === 503 // Server Unavailable
+            statusCode === 502 || // Bad Gateway
+            statusCode === 503 || // Server Unavailable
+            statusCode === 504 // Gateway Timeout
         );
     }
 

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -101,10 +101,58 @@ describe("Library/Sender", () => {
             });
         });
 
-        it("should put telemetry in disk when retryable code is returned", (done) => {
+        it("should put telemetry in disk when retryable 408 code is returned", (done) => {
             var envelope = new Contracts.Envelope();
             envelope.name = "TestRetryable";
             nockScope = interceptor.reply(408, null);
+            var storeStub = sandbox.stub(sender, "_storeToDisk");
+            sender.send([envelope], (responseText) => {
+                assert.ok(storeStub.calledOnce);
+                assert.equal(storeStub.firstCall.args[0][0].name, "TestRetryable");
+                done();
+            });
+        });
+
+        it("should put telemetry in disk when retryable 500 code is returned", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestRetryable";
+            nockScope = interceptor.reply(500, null);
+            var storeStub = sandbox.stub(sender, "_storeToDisk");
+            sender.send([envelope], (responseText) => {
+                assert.ok(storeStub.calledOnce);
+                assert.equal(storeStub.firstCall.args[0][0].name, "TestRetryable");
+                done();
+            });
+        });
+
+        it("should put telemetry in disk when retryable 502 code is returned", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestRetryable";
+            nockScope = interceptor.reply(502, null);
+            var storeStub = sandbox.stub(sender, "_storeToDisk");
+            sender.send([envelope], (responseText) => {
+                assert.ok(storeStub.calledOnce);
+                assert.equal(storeStub.firstCall.args[0][0].name, "TestRetryable");
+                done();
+            });
+        });
+
+        it("should put telemetry in disk when retryable 503 code is returned", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestRetryable";
+            nockScope = interceptor.reply(503, null);
+            var storeStub = sandbox.stub(sender, "_storeToDisk");
+            sender.send([envelope], (responseText) => {
+                assert.ok(storeStub.calledOnce);
+                assert.equal(storeStub.firstCall.args[0][0].name, "TestRetryable");
+                done();
+            });
+        });
+
+        it("should put telemetry in disk when retryable 504 code is returned", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestRetryable";
+            nockScope = interceptor.reply(504, null);
             var storeStub = sandbox.stub(sender, "_storeToDisk");
             sender.send([envelope], (responseText) => {
                 assert.ok(storeStub.calledOnce);


### PR DESCRIPTION
<h2>Related Specification</h2>
https://github.com/microsoft/Telemetry-Collection-Spec/blob/main/ApplicationInsights/sdk_behavior_breeze.md#500---internal-server-error

<h2>What this PR Addresses</h2>
Indicates 502, 503, and 504 status codes as allowing retry per the above specification.

<h3>Related Details</h3>
This PR will be accompanied by a related one in the Azure JS SDK.