### PR TITLE
[Draft]Add Stale Issue/PR Handling GitHub Workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,23 @@
+name: 'Lock Threads'
+
+# Will search once a day at 0:00 for closed issues and pull requests that have not had any activity in the past year.
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          process-only: 'issues'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: 'Stale issue handler'
+# Will search once a day at 7:00 for stale issues/PRs (those that have no had updates in 30 days).
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.0.0
+        id: stale
+        with:
+          stale-issue-message: 'This Issue will be closed in 30 days. Please remove the "Stale" label or comment to avoid closure with no action.'
+          stale-pr-message: 'This PR will be closed in 30 days. Please remove the "Stale" label or comment to avoid closure with no action.'
+          operations-per-run: 200
+          days-before-stale: 300
+          days-before-close: 30
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          close-issue-label: 'closed'
+          close-pr-label: 'closed'
+          exempt-issue-labels: 'bug,enhancement,documentation,waiting,keep'
+          exempt-all-milestones: true
+          exempt-all-assignees: true
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
Adds GitHub workflows that manage automatically locking stale threads as well as stale issues and PRs.