### PR TITLE
Add statusCode and exceptionType Fields to Network Statsbeat

### DIFF
--- a/AutoCollection/NetworkStatsbeat.ts
+++ b/AutoCollection/NetworkStatsbeat.ts
@@ -14,13 +14,13 @@ export class NetworkStatsbeat {
 
     public totalSuccesfulRequestCount: number;
 
-    public totalFailedRequestCount: number;
+    public totalFailedRequestCount: { statusCode: number, count: number }[];
 
-    public retryCount: number;
+    public retryCount: { statusCode: number, count: number }[];
 
-    public exceptionCount: number;
+    public exceptionCount: { exceptionType: string, count: number }[];
 
-    public throttleCount: number;
+    public throttleCount: { statusCode: number, count: number }[];
 
     public intervalRequestExecutionTime: number;
 
@@ -31,10 +31,10 @@ export class NetworkStatsbeat {
         this.host = host;
         this.totalRequestCount = 0;
         this.totalSuccesfulRequestCount = 0;
-        this.totalFailedRequestCount = 0;
-        this.retryCount = 0;
-        this.exceptionCount = 0;
-        this.throttleCount = 0;
+        this.totalFailedRequestCount = [];
+        this.retryCount = [];
+        this.exceptionCount = [];
+        this.throttleCount = [];
         this.intervalRequestExecutionTime = 0;
         this.lastIntervalRequestExecutionTime = 0;
         this.lastTime = +new Date;

--- a/AutoCollection/Statsbeat.ts
+++ b/AutoCollection/Statsbeat.ts
@@ -44,8 +44,6 @@ class Statsbeat {
     private _attach: string = Constants.StatsbeatAttach.sdk; // Default is SDK
     private _feature: number = Constants.StatsbeatFeature.NONE;
     private _instrumentation: number = Constants.StatsbeatInstrumentation.NONE;
-    private _exceptionType: string;
-    private _statusCode: number;
 
     constructor(config: Config, context?: Context) {
         this._isInitialized = false;
@@ -298,7 +296,6 @@ class Statsbeat {
                 commonProperties
             );
             if (currentCounter.totalSuccesfulRequestCount > 0) {
-                properties = Object.assign({ ...properties, statusCode: this._statusCode });
                 this._statbeatMetrics.push({
                         name: Constants.StatsbeatCounter.REQUEST_SUCCESS,
                         value: currentCounter.totalSuccesfulRequestCount,

--- a/AutoCollection/Statsbeat.ts
+++ b/AutoCollection/Statsbeat.ts
@@ -126,6 +126,9 @@ class Statsbeat {
         counter.totalRequestCount++;
         counter.intervalRequestExecutionTime += duration;
         if (success === false) {
+            if (!statusCode) {
+                return;
+            }
             let currentStatusCounter = counter.totalFailedRequestCount.find((statusCounter) => statusCode === statusCounter.statusCode);
             if (currentStatusCounter) {
                 currentStatusCounter.count++;

--- a/AutoCollection/Statsbeat.ts
+++ b/AutoCollection/Statsbeat.ts
@@ -140,16 +140,16 @@ class Statsbeat {
         }
     }
 
-    public countException(endpoint: number, host: string, exceptionType: string) {
+    public countException(endpoint: number, host: string, exceptionType: Error) {
         if (!this.isEnabled()) {
             return;
         }
         let counter: Network.NetworkStatsbeat = this._getNetworkStatsbeatCounter(endpoint, host);
-        let currentErrorCounter = counter.exceptionCount.find((exceptionCounter) => exceptionType === exceptionCounter.exceptionType);
+        let currentErrorCounter = counter.exceptionCount.find((exceptionCounter) => exceptionType.name === exceptionCounter.exceptionType);
         if (currentErrorCounter) {
             currentErrorCounter.count++;
         } else {
-            counter.exceptionCount.push({ exceptionType: exceptionType, count: 1 });
+            counter.exceptionCount.push({ exceptionType: exceptionType.name, count: 1 });
         }
     }
 

--- a/AutoCollection/Statsbeat.ts
+++ b/AutoCollection/Statsbeat.ts
@@ -44,7 +44,7 @@ class Statsbeat {
     private _attach: string = Constants.StatsbeatAttach.sdk; // Default is SDK
     private _feature: number = Constants.StatsbeatFeature.NONE;
     private _instrumentation: number = Constants.StatsbeatInstrumentation.NONE;
-    private _exceptionType: string;
+    public _exceptionType: string;
     public _statusCode: number;
 
     constructor(config: Config, context?: Context) {

--- a/AutoCollection/Statsbeat.ts
+++ b/AutoCollection/Statsbeat.ts
@@ -118,7 +118,7 @@ class Statsbeat {
         this._instrumentation &= ~instrumentation;
     }
 
-    public countRequest(endpoint: number, host: string, duration: number, success: boolean, statusCode: number) {
+    public countRequest(endpoint: number, host: string, duration: number, success: boolean, statusCode?: number) {
         if (!this.isEnabled()) {
             return;
         }
@@ -305,6 +305,7 @@ class Statsbeat {
             }
             if (currentCounter.totalFailedRequestCount.length > 0) {
                 currentCounter.totalFailedRequestCount.forEach((currentCounter) => {
+                    properties = Object.assign({ ...properties, "statusCode": currentCounter.statusCode });
                     this._statbeatMetrics.push({
                         name: Constants.StatsbeatCounter.REQUEST_FAILURE,
                         value: currentCounter.count,
@@ -315,6 +316,7 @@ class Statsbeat {
             }
             if (currentCounter.retryCount.length > 0) {
                 currentCounter.retryCount.forEach((currentCounter) => {
+                    properties = Object.assign({ ...properties, "statusCode": currentCounter.statusCode });
                     this._statbeatMetrics.push({
                         name: Constants.StatsbeatCounter.RETRY_COUNT,
                         value: currentCounter.count,
@@ -325,6 +327,7 @@ class Statsbeat {
             }
             if (currentCounter.throttleCount.length > 0) {
                 currentCounter.throttleCount.forEach((currentCounter) => {
+                    properties = Object.assign({ ...properties, "statusCode": currentCounter.statusCode });
                     this._statbeatMetrics.push({
                         name: Constants.StatsbeatCounter.THROTTLE_COUNT,
                         value: currentCounter.count,
@@ -335,6 +338,7 @@ class Statsbeat {
             }
             if (currentCounter.exceptionCount.length > 0) {
                 currentCounter.exceptionCount.forEach((currentCounter) => {
+                    properties = Object.assign({ ...properties, "exceptionType": currentCounter.exceptionType });
                     this._statbeatMetrics.push({
                         name: Constants.StatsbeatCounter.EXCEPTION_COUNT,
                         value: currentCounter.count,

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -207,6 +207,9 @@ class Sender {
                             }
                         }
                         if (this._statsbeat) {
+                            if (res.statusCode) {
+                                this._statsbeat._statusCode = res.statusCode;
+                            }
                             if (res.statusCode == throttleStatusCode || res.statusCode == legacyThrottleStatusCode) { // Throttle
                                 this._statsbeat.countThrottle(Constants.StatsbeatNetworkCategory.Breeze, endpointHost);
                             }
@@ -301,6 +304,7 @@ class Sender {
                     // todo: handle error codes better (group to recoverable/non-recoverable and persist)
                     this._numConsecutiveFailures++;
                     if (this._statsbeat) {
+                        this._statsbeat._exceptionType = error.name;
                         this._statsbeat.countException(Constants.StatsbeatNetworkCategory.Breeze, endpointHost);
                     }
 

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -263,12 +263,12 @@ class Sender {
                                 }
                             }
                             else {
-                                let circularRedirectMessage = "Error sending telemetry because of circular redirects.";
+                                const circularRedirectError: Error = { name: "Circular Redirect", message: "Error sending telemetry because of circular redirects." }
                                 if (this._statsbeat) {
-                                    this._statsbeat.countException(Constants.StatsbeatNetworkCategory.Breeze, endpointHost, circularRedirectMessage);
+                                    this._statsbeat.countException(Constants.StatsbeatNetworkCategory.Breeze, endpointHost, circularRedirectError);
                                 }
                                 if (typeof callback === "function") {
-                                    callback(circularRedirectMessage);
+                                    callback("Error sending telemetry because of circular redirects.");
                                 }
                             }
 
@@ -302,7 +302,7 @@ class Sender {
                     // todo: handle error codes better (group to recoverable/non-recoverable and persist)
                     this._numConsecutiveFailures++;
                     if (this._statsbeat) {
-                        this._statsbeat.countException(Constants.StatsbeatNetworkCategory.Breeze, endpointHost, error.name);
+                        this._statsbeat.countException(Constants.StatsbeatNetworkCategory.Breeze, endpointHost, error);
                     }
 
                     // Only use warn level if retries are disabled or we've had some number of consecutive failures sending data

--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -358,7 +358,9 @@ class Sender {
             statusCode === 408 || // Timeout
             statusCode === 429 || // Too many requests
             statusCode === 500 || // Server Error
-            statusCode === 503 // Server Unavailable
+            statusCode === 502 || // Bad Gateway
+            statusCode === 503 || // Server Unavailable
+            statusCode === 504 // Gateway Timeout
         );
     }
 

--- a/Tests/AutoCollection/Statsbeat.tests.ts
+++ b/Tests/AutoCollection/Statsbeat.tests.ts
@@ -132,7 +132,7 @@ describe("AutoCollection/Statsbeat", () => {
         it("It adds correct network properties to custom metric", (done) => {
             statsBeat.enable(true);
             const sendStub = sandbox.stub(statsBeat, "_sendStatsbeats");
-            statsBeat.countRequest(1, "testEndpointHost", 123, true);
+            statsBeat.countRequest(1, "testEndpointHost", 123, true, 200);
             statsBeat.setCodelessAttach();
             statsBeat.trackShortIntervalStatsbeats().then(() => {
                 assert.ok(sendStub.called, "should call _sendStatsbeats");
@@ -156,8 +156,8 @@ describe("AutoCollection/Statsbeat", () => {
         it("Track duration", (done) => {
             statsBeat.enable(true);
             const sendStub = sandbox.stub(statsBeat, "_sendStatsbeats");
-            statsBeat.countRequest(0, "test", 1000, true);
-            statsBeat.countRequest(0, "test", 500, false);
+            statsBeat.countRequest(0, "test", 1000, true, 200);
+            statsBeat.countRequest(0, "test", 500, false, 408);
             statsBeat.trackShortIntervalStatsbeats().then((error) => {
                 assert.ok(sendStub.called, "should call _sendStatsbeats");
                 assert.equal(statsBeat["_statbeatMetrics"].length, 3);
@@ -171,17 +171,17 @@ describe("AutoCollection/Statsbeat", () => {
         it("Track counts", (done) => {
             statsBeat.enable(true);
             const sendStub = sandbox.stub(statsBeat, "_sendStatsbeats");
-            statsBeat.countRequest(0, "test", 1, true);
-            statsBeat.countRequest(0, "test", 1, true);
-            statsBeat.countRequest(0, "test", 1, true);
-            statsBeat.countRequest(0, "test", 1, true);
-            statsBeat.countRequest(0, "test", 1, false);
-            statsBeat.countRequest(0, "test", 1, false);
-            statsBeat.countRequest(0, "test", 1, false);
-            statsBeat.countRetry(0, "test");
-            statsBeat.countRetry(0, "test");
-            statsBeat.countThrottle(0, "test");
-            statsBeat.countException(0, "test");
+            statsBeat.countRequest(0, "test", 1, true, 200);
+            statsBeat.countRequest(0, "test", 1, true, 200);
+            statsBeat.countRequest(0, "test", 1, true, 200);
+            statsBeat.countRequest(0, "test", 1, true, 200);
+            statsBeat.countRequest(0, "test", 1, false, 200);
+            statsBeat.countRequest(0, "test", 1, false, 200);
+            statsBeat.countRequest(0, "test", 1, false, 200);
+            statsBeat.countRetry(0, "test", 206);
+            statsBeat.countRetry(0, "test", 206);
+            statsBeat.countThrottle(0, "test", 206);
+            statsBeat.countException(0, "test", "Statsbeat Exception");
             statsBeat.trackShortIntervalStatsbeats().then(() => {
                 assert.ok(sendStub.called, "should call _sendStatsbeats");
                 assert.equal(statsBeat["_statbeatMetrics"].length, 6);
@@ -295,9 +295,9 @@ describe("AutoCollection/Statsbeat", () => {
         it("Multiple network categories and endpoints", (done) => {
             statsBeat.enable(true);
             const sendStub = sandbox.stub(statsBeat, "_sendStatsbeats");
-            statsBeat.countRequest(0, "https://breezeFirstEndpoint.something.com", 100, true);
-            statsBeat.countRequest(1, "http://quickpulseEndpoint.something.com", 200, true);
-            statsBeat.countRequest(0, "breezeSecondEndpoint", 400, true);
+            statsBeat.countRequest(0, "https://breezeFirstEndpoint.something.com", 100, true, 200);
+            statsBeat.countRequest(1, "http://quickpulseEndpoint.something.com", 200, true, 200);
+            statsBeat.countRequest(0, "breezeSecondEndpoint", 400, true, 200);
             statsBeat.trackShortIntervalStatsbeats().then(() => {
                 assert.ok(sendStub.called, "should call _sendStatsbeats");
                 let metric: any = statsBeat["_statbeatMetrics"].find(f => f.name === "Request Duration"

--- a/Tests/AutoCollection/Statsbeat.tests.ts
+++ b/Tests/AutoCollection/Statsbeat.tests.ts
@@ -181,7 +181,7 @@ describe("AutoCollection/Statsbeat", () => {
             statsBeat.countRetry(0, "test", 206);
             statsBeat.countRetry(0, "test", 206);
             statsBeat.countThrottle(0, "test", 206);
-            statsBeat.countException(0, "test", "Statsbeat Exception");
+            statsBeat.countException(0, "test", { name: "Statsbeat", message: "Statsbeat Exception" });
             statsBeat.trackShortIntervalStatsbeats().then(() => {
                 assert.ok(sendStub.called, "should call _sendStatsbeats");
                 assert.equal(statsBeat["_statbeatMetrics"].length, 6);

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -450,7 +450,7 @@ describe("Library/Sender", () => {
         let config = new Config("2bb22222-bbbb-1ccc-8ddd-eeeeffff3333");
         let statsbeat = new Statsbeat(config);
         let statsbeatSender = new Sender(config, null, null, null, statsbeat);
-        let statsbeatError: string = "Statsbeat";
+        let statsbeatError: Error = {name: "Statsbeat", message: "Statsbeat error" };
 
         it("Succesful requests", (done) => {
             var statsbeatSpy = sandbox.spy(statsbeat, "countRequest");
@@ -488,7 +488,7 @@ describe("Library/Sender", () => {
             statsbeatSender.send([testEnvelope], () => {
                 assert.ok(statsbeatSpy.calledOnce);
                 assert.ok(retrySpy.calledOnce);
-                assert.equal(retrySpy.args[2], 206);
+                assert.equal(retrySpy.args[0][2], 206);
                 done();
             });
         });
@@ -501,7 +501,7 @@ describe("Library/Sender", () => {
             statsbeatSender.send([testEnvelope], () => {
                 assert.ok(statsbeatSpy.notCalled);
                 assert.ok(throttleSpy.calledOnce);
-                assert.equal(throttleSpy.args[2], 439);
+                assert.equal(throttleSpy.args[0][2], 439);
                 done();
             });
         });
@@ -590,7 +590,7 @@ describe("Library/Sender", () => {
             nockScope = interceptor.replyWithError(statsbeatError);
             statsbeatSender.send([testEnvelope], () => {
                 assert.equal(statsbeatSpy.callCount, 0);
-                assert.equal(exceptionSpy.args[2], "Statsbeat");
+                assert.equal(exceptionSpy.args[0][2], statsbeatError);
                 assert.ok(exceptionSpy.calledOnce);
                 done();
             });

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -450,6 +450,7 @@ describe("Library/Sender", () => {
         let config = new Config("2bb22222-bbbb-1ccc-8ddd-eeeeffff3333");
         let statsbeat = new Statsbeat(config);
         let statsbeatSender = new Sender(config, null, null, null, statsbeat);
+        let statsbeatError: Error = { name: "Statsbeat", message: "Statsbeat Error" };
 
         it("Succesful requests", (done) => {
             var statsbeatSpy = sandbox.spy(statsbeat, "countRequest");
@@ -583,9 +584,10 @@ describe("Library/Sender", () => {
             statsbeatSender.setDiskRetryMode(false);
             var statsbeatSpy = sandbox.spy(statsbeat, "countRequest");
             var exceptionSpy = sandbox.spy(statsbeat, "countException");
-            nockScope = interceptor.replyWithError("Test Error");
+            nockScope = interceptor.replyWithError(statsbeatError);
             statsbeatSender.send([testEnvelope], () => {
                 assert.equal(statsbeatSpy.callCount, 0);
+                assert.equal(statsbeat._exceptionType, "Statsbeat");
                 assert.ok(exceptionSpy.calledOnce);
                 done();
             });

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -101,10 +101,58 @@ describe("Library/Sender", () => {
             });
         });
 
-        it("should put telemetry in disk when retryable code is returned", (done) => {
+        it("should put telemetry in disk when retryable 408 code is returned", (done) => {
             var envelope = new Contracts.Envelope();
             envelope.name = "TestRetryable";
             nockScope = interceptor.reply(408, null);
+            var storeStub = sandbox.stub(sender, "_storeToDisk");
+            sender.send([envelope], (responseText) => {
+                assert.ok(storeStub.calledOnce);
+                assert.equal(storeStub.firstCall.args[0][0].name, "TestRetryable");
+                done();
+            });
+        });
+
+        it("should put telemetry in disk when retryable 500 code is returned", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestRetryable";
+            nockScope = interceptor.reply(500, null);
+            var storeStub = sandbox.stub(sender, "_storeToDisk");
+            sender.send([envelope], (responseText) => {
+                assert.ok(storeStub.calledOnce);
+                assert.equal(storeStub.firstCall.args[0][0].name, "TestRetryable");
+                done();
+            });
+        });
+
+        it("should put telemetry in disk when retryable 502 code is returned", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestRetryable";
+            nockScope = interceptor.reply(502, null);
+            var storeStub = sandbox.stub(sender, "_storeToDisk");
+            sender.send([envelope], (responseText) => {
+                assert.ok(storeStub.calledOnce);
+                assert.equal(storeStub.firstCall.args[0][0].name, "TestRetryable");
+                done();
+            });
+        });
+
+        it("should put telemetry in disk when retryable 503 code is returned", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestRetryable";
+            nockScope = interceptor.reply(503, null);
+            var storeStub = sandbox.stub(sender, "_storeToDisk");
+            sender.send([envelope], (responseText) => {
+                assert.ok(storeStub.calledOnce);
+                assert.equal(storeStub.firstCall.args[0][0].name, "TestRetryable");
+                done();
+            });
+        });
+
+        it("should put telemetry in disk when retryable 504 code is returned", (done) => {
+            var envelope = new Contracts.Envelope();
+            envelope.name = "TestRetryable";
+            nockScope = interceptor.reply(504, null);
             var storeStub = sandbox.stub(sender, "_storeToDisk");
             sender.send([envelope], (responseText) => {
                 assert.ok(storeStub.calledOnce);

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -450,7 +450,7 @@ describe("Library/Sender", () => {
         let config = new Config("2bb22222-bbbb-1ccc-8ddd-eeeeffff3333");
         let statsbeat = new Statsbeat(config);
         let statsbeatSender = new Sender(config, null, null, null, statsbeat);
-        let statsbeatError: Error = { name: "Statsbeat", message: "Statsbeat Error" };
+        let statsbeatError: string = "Statsbeat";
 
         it("Succesful requests", (done) => {
             var statsbeatSpy = sandbox.spy(statsbeat, "countRequest");
@@ -461,7 +461,6 @@ describe("Library/Sender", () => {
                 assert.equal(statsbeatSpy.args[0][1], "dc.services.visualstudio.com"); // Endpoint
                 assert.ok(!isNaN(statsbeatSpy.args[0][2])); // Duration
                 assert.equal(statsbeatSpy.args[0][3], true); // Success
-                assert.equal(statsbeat._statusCode, 200);
                 done();
 
             });
@@ -476,7 +475,7 @@ describe("Library/Sender", () => {
                 assert.equal(statsbeatSpy.args[0][1], "dc.services.visualstudio.com"); // Endpoint
                 assert.ok(!isNaN(statsbeatSpy.args[0][2])); // Duration
                 assert.equal(statsbeatSpy.args[0][3], false); // Failed
-                assert.equal(statsbeat._statusCode, 400);
+                assert.equal(statsbeatSpy.args[0][4], 400);
                 done();
             });
         });
@@ -489,7 +488,7 @@ describe("Library/Sender", () => {
             statsbeatSender.send([testEnvelope], () => {
                 assert.ok(statsbeatSpy.calledOnce);
                 assert.ok(retrySpy.calledOnce);
-                assert.equal(statsbeat._statusCode, 206);
+                assert.equal(retrySpy.args[2], 206);
                 done();
             });
         });
@@ -502,7 +501,7 @@ describe("Library/Sender", () => {
             statsbeatSender.send([testEnvelope], () => {
                 assert.ok(statsbeatSpy.notCalled);
                 assert.ok(throttleSpy.calledOnce);
-                assert.equal(statsbeat._statusCode, 439);
+                assert.equal(throttleSpy.args[2], 439);
                 done();
             });
         });
@@ -591,7 +590,7 @@ describe("Library/Sender", () => {
             nockScope = interceptor.replyWithError(statsbeatError);
             statsbeatSender.send([testEnvelope], () => {
                 assert.equal(statsbeatSpy.callCount, 0);
-                assert.equal(statsbeat._exceptionType, "Statsbeat");
+                assert.equal(exceptionSpy.args[2], "Statsbeat");
                 assert.ok(exceptionSpy.calledOnce);
                 done();
             });

--- a/Tests/Library/Sender.tests.ts
+++ b/Tests/Library/Sender.tests.ts
@@ -461,6 +461,7 @@ describe("Library/Sender", () => {
                 assert.equal(statsbeatSpy.args[0][1], "dc.services.visualstudio.com"); // Endpoint
                 assert.ok(!isNaN(statsbeatSpy.args[0][2])); // Duration
                 assert.equal(statsbeatSpy.args[0][3], true); // Success
+                assert.equal(statsbeat._statusCode, 200);
                 done();
 
             });
@@ -475,6 +476,7 @@ describe("Library/Sender", () => {
                 assert.equal(statsbeatSpy.args[0][1], "dc.services.visualstudio.com"); // Endpoint
                 assert.ok(!isNaN(statsbeatSpy.args[0][2])); // Duration
                 assert.equal(statsbeatSpy.args[0][3], false); // Failed
+                assert.equal(statsbeat._statusCode, 400);
                 done();
             });
         });
@@ -487,6 +489,7 @@ describe("Library/Sender", () => {
             statsbeatSender.send([testEnvelope], () => {
                 assert.ok(statsbeatSpy.calledOnce);
                 assert.ok(retrySpy.calledOnce);
+                assert.equal(statsbeat._statusCode, 206);
                 done();
             });
         });
@@ -499,6 +502,7 @@ describe("Library/Sender", () => {
             statsbeatSender.send([testEnvelope], () => {
                 assert.ok(statsbeatSpy.notCalled);
                 assert.ok(throttleSpy.calledOnce);
+                assert.equal(statsbeat._statusCode, 439);
                 done();
             });
         });


### PR DESCRIPTION
This adds the statusCode and exceptionType fields to the appropriate network StatsBeat metrics per the spec https://github.com/microsoft/Telemetry-Collection-Spec/blob/main/ApplicationInsights/statsbeat.md