### PR TITLE
[Preview] Standard Metrics Updates

### DIFF
--- a/src/autoCollection/metrics/collection/azureHttpMetricsInstrumentation.ts
+++ b/src/autoCollection/metrics/collection/azureHttpMetricsInstrumentation.ts
@@ -15,7 +15,7 @@ import { getRequestInfo } from '@opentelemetry/instrumentation-http';
 import { Histogram, MeterProvider, ValueType } from '@opentelemetry/api-metrics';
 
 import { APPLICATION_INSIGHTS_SDK_VERSION } from "../../../declarations/constants";
-import { HttpMetricsInstrumentationConfig, IHttpStandardMetric, MetricId, MetricName } from '../types';
+import { HttpMetricsInstrumentationConfig, IHttpStandardMetric, MetricName } from '../types';
 import { Logger } from '../../../library/logging';
 import { SpanKind, TracerProvider } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
@@ -79,7 +79,6 @@ export class AzureHttpMetricsInstrumentation extends InstrumentationBase<Http> {
         success = (0 < statusCode) && (statusCode < 500);
       }
       if (metric.spanKind == SpanKind.SERVER) {
-        metric.attributes["_MS.MetricId"] = MetricId.REQUESTS_DURATION;
         this._httpServerDurationHistogram.record(durationMs, metric.attributes);
         this.intervalRequestExecutionTime += durationMs;
         if (!success) {
@@ -88,7 +87,6 @@ export class AzureHttpMetricsInstrumentation extends InstrumentationBase<Http> {
         this.totalRequestCount++;
       }
       else {
-        metric.attributes["_MS.MetricId"] = MetricId.DEPENDENCIES_DURATION;
         this._httpClientDurationHistogram.record(durationMs, metric.attributes);
         this.intervalDependencyExecutionTime += durationMs;
         if (!success) {

--- a/src/autoCollection/metrics/handlers/liveMetricsHandler.ts
+++ b/src/autoCollection/metrics/handlers/liveMetricsHandler.ts
@@ -61,7 +61,6 @@ export class LiveMetricsHandler {
 
     public start() {
         this._processMetrics.enable(true);
-        this._exceptionMetrics.enable(true);
         this._requestMetrics.enable(true);
         this._dependencyMetrics.enable(true);
     }
@@ -147,6 +146,14 @@ export class LiveMetricsHandler {
         }));
         views.push(new View({
             instrumentName: MetricName.PROCESS_TIME,
+            aggregation: new DropAggregation(),
+        }));
+        views.push(new View({
+            instrumentName: MetricName.EXCEPTION_COUNT,
+            aggregation: new DropAggregation(),
+        }));
+        views.push(new View({
+            instrumentName: MetricName.TRACE_COUNT,
             aggregation: new DropAggregation(),
         }));
         return views;

--- a/src/autoCollection/metrics/handlers/standardMetricsHandler.ts
+++ b/src/autoCollection/metrics/handlers/standardMetricsHandler.ts
@@ -61,11 +61,11 @@ export class StandardMetricsHandler {
     private _getViews(): View[] {
         let views = [];
         views.push(new View({
-            name: StandardMetric.REQUEST_DURATION,
+            name: StandardMetric.HTTP_REQUEST_DURATION,
             instrumentName: "http.server.duration" // Metric semantic conventions not available yet
         }));
         views.push(new View({
-            name: StandardMetric.DEPENDENCY_DURATION,
+            name: StandardMetric.HTTP_DEPENDENCY_DURATION,
             instrumentName: "http.client.duration" // Metric semantic conventions not available yet
         }));
         views.push(new View({

--- a/src/autoCollection/metrics/handlers/standardMetricsHandler.ts
+++ b/src/autoCollection/metrics/handlers/standardMetricsHandler.ts
@@ -1,6 +1,6 @@
 import { AzureExporterConfig, AzureMonitorMetricExporter } from "@azure/monitor-opentelemetry-exporter";
 import { Meter } from "@opentelemetry/api-metrics";
-import { MeterProvider, MeterProviderOptions, PeriodicExportingMetricReader, PeriodicExportingMetricReaderOptions, View } from "@opentelemetry/sdk-metrics";
+import { DropAggregation, MeterProvider, MeterProviderOptions, PeriodicExportingMetricReader, PeriodicExportingMetricReaderOptions, View } from "@opentelemetry/sdk-metrics";
 import { Config } from "../../../library";
 import { ResourceManager } from "../../../library/handlers";
 import { ExceptionMetrics } from "../collection/exceptionMetrics";
@@ -42,11 +42,6 @@ export class StandardMetricsHandler {
         this._traceMetrics = new TraceMetrics(this._meter);
     }
 
-    public start() {
-        this._exceptionMetrics.enable(true);
-        this._traceMetrics.enable(true);
-    }
-
     public shutdown() {
         this._meterProvider.shutdown();
     }
@@ -66,22 +61,29 @@ export class StandardMetricsHandler {
     private _getViews(): View[] {
         let views = [];
         views.push(new View({
-            name: StandardMetric.REQUESTS,
-            instrumentName: MetricName.REQUEST_DURATION,
-            attributeKeys: []
+            name: StandardMetric.REQUEST_DURATION,
+            instrumentName: "http.server.duration" // Metric semantic conventions not available yet
         }));
         views.push(new View({
-            name: StandardMetric.DEPENDENCIES,
-            instrumentName: MetricName.DEPENDENCY_DURATION,
-            attributeKeys: []
+            name: StandardMetric.DEPENDENCY_DURATION,
+            instrumentName: "http.client.duration" // Metric semantic conventions not available yet
         }));
         views.push(new View({
-            name: StandardMetric.EXCEPTIONS,
-            instrumentName: MetricName.EXCEPTION_RATE
+            name: StandardMetric.EXCEPTION_COUNT,
+            instrumentName: MetricName.EXCEPTION_COUNT
         }));
         views.push(new View({
-            name: StandardMetric.TRACES,
-            instrumentName: MetricName.TRACE_RATE
+            name: StandardMetric.TRACE_COUNT,
+            instrumentName: MetricName.TRACE_COUNT
+        }));
+        // Ignore list
+        views.push(new View({
+            instrumentName: MetricName.EXCEPTION_RATE,
+            aggregation: new DropAggregation(),
+        }));
+        views.push(new View({
+            instrumentName: MetricName.TRACE_RATE,
+            aggregation: new DropAggregation(),
         }));
         return views;
     }

--- a/src/autoCollection/metrics/types.ts
+++ b/src/autoCollection/metrics/types.ts
@@ -61,10 +61,10 @@ export enum QuickPulseCounter {
 }
 
 export enum StandardMetric {
-  REQUEST_DURATION = "azureMonitor.standardMetric.requestDuration",
-  DEPENDENCY_DURATION = "azureMonitor.standardMetric.dependencyDuration",
-  EXCEPTION_COUNT = "azureMonitor.standardMetric.exceptionCount",
-  TRACE_COUNT = "azureMonitor.standardMetric.traceCount",
+  HTTP_REQUEST_DURATION = "azureMonitor.http.requestDuration",
+  HTTP_DEPENDENCY_DURATION = "azureMonitor.http.dependencyDuration",
+  EXCEPTION_COUNT = "azureMonitor.exceptionCount",
+  TRACE_COUNT = "azureMonitor.traceCount",
 }
 
 export enum NativeMetricsCounter {

--- a/src/autoCollection/metrics/types.ts
+++ b/src/autoCollection/metrics/types.ts
@@ -25,8 +25,10 @@ export enum MetricName {
   DEPENDENCY_DURATION = "DEPENDENCY_DURATION",
   // Exceptions
   EXCEPTION_RATE = "EXCEPTION_RATE",
+  EXCEPTION_COUNT = "EXCEPTION_COUNT",
   // Traces
   TRACE_RATE = "TRACE_RATE",
+  TRACE_COUNT = "TRACE_COUNT",
 }
 
 export enum PerformanceCounter {
@@ -59,10 +61,10 @@ export enum QuickPulseCounter {
 }
 
 export enum StandardMetric {
-  REQUESTS = "http.server.duration",
-  DEPENDENCIES = "http.client.duration",
-  EXCEPTIONS = "Exceptions",
-  TRACES = "Traces",
+  REQUEST_DURATION = "azureMonitor.standardMetric.requestDuration",
+  DEPENDENCY_DURATION = "azureMonitor.standardMetric.dependencyDuration",
+  EXCEPTION_COUNT = "azureMonitor.standardMetric.exceptionCount",
+  TRACE_COUNT = "azureMonitor.standardMetric.traceCount",
 }
 
 export enum NativeMetricsCounter {
@@ -81,16 +83,8 @@ export enum GarbageCollectionType {
   IncrementalMarking = "IncrementalMarking"
 }
 
-export enum MetricId {
-  REQUESTS_DURATION = "requests/duration",
-  DEPENDENCIES_DURATION = "dependencies/duration",
-  EXCEPTIONS_COUNT = "exceptions/count",
-  TRACES_COUNT = "traces/count",
-}
-
 export class AggregatedMetric {
   public name: string;
-  public metricType: MetricId;
   public dimensions: { [key: string]: any };
   public value: number;
   public count: number;

--- a/src/library/handlers/metricHandler.ts
+++ b/src/library/handlers/metricHandler.ts
@@ -42,7 +42,6 @@ export class MetricHandler {
     public start() {
         this._perfCounterMetricsHandler?.start();
         this._liveMetricsHandler?.start();
-        this._standardMetricsHandler?.start();
         this._heartbeatHandler?.start();
     }
 

--- a/src/library/handlers/sampler.ts
+++ b/src/library/handlers/sampler.ts
@@ -4,6 +4,8 @@ import { Link, Attributes, SpanKind, Context } from '@opentelemetry/api';
 import { Sampler, SamplingDecision, SamplingResult } from '@opentelemetry/sdk-trace-base';
 
 
+const AzureMonitorSampleRate = "_MS.sampleRate"; 
+
 export class ApplicationInsightsSampler implements Sampler {
 
     private readonly _samplingPercentage: number
@@ -31,7 +33,7 @@ export class ApplicationInsightsSampler implements Sampler {
         }
         // Add sample rate as span attribute
         attributes = attributes || {};
-        attributes["sampleRate"] = this._samplingPercentage;
+        attributes[AzureMonitorSampleRate] = this._samplingPercentage;
         return isSampledIn ? { decision: SamplingDecision.RECORD_AND_SAMPLED, attributes: attributes } : { decision: SamplingDecision.NOT_RECORD, attributes: attributes };
     }
 

--- a/src/library/handlers/traceHandler.ts
+++ b/src/library/handlers/traceHandler.ts
@@ -102,7 +102,9 @@ export class TraceHandler {
         }
         if (!this._httpInstrumentation) {
             this._httpInstrumentation = new HttpInstrumentation(this._config.instrumentations.http);
-            this._httpInstrumentation.setMeterProvider(this._metricHandler.getStandardMetricsHandler().getMeterProvider());
+            if (this._metricHandler) {
+                this._httpInstrumentation.setMeterProvider(this._metricHandler.getStandardMetricsHandler().getMeterProvider());
+            }
             this.addInstrumentation(this._httpInstrumentation);
         }
         if (!this._azureSdkInstrumentation) {

--- a/test/unitTests/autoCollection/liveMetricsHandler.tests.ts
+++ b/test/unitTests/autoCollection/liveMetricsHandler.tests.ts
@@ -27,7 +27,7 @@ describe("#LiveMetricsHandler", () => {
     });
 
     it("should create instruments", () => {
-        assert.ok(autoCollect.getExceptionMetrics()["_exceptionsGauge"], "_exceptionsGauge not available");
+        assert.ok(autoCollect.getExceptionMetrics()["_exceptionsRateGauge"], "_exceptionsRateGauge not available");
         assert.ok(autoCollect.getRequestMetrics()["_requestRateGauge"], "_requestRateGauge not available");
         assert.ok(autoCollect.getRequestMetrics()["_requestFailureRateGauge"], "_requestFailureRateGauge not available");
         assert.ok(autoCollect.getDependencyMetrics()["_dependencyRateGauge"], "_dependencyRateGauge not available");

--- a/test/unitTests/autoCollection/standardMetrics.tests.ts
+++ b/test/unitTests/autoCollection/standardMetrics.tests.ts
@@ -171,8 +171,8 @@ describe("#StandardMetricsHandler", () => {
             assert.equal(metrics[1].descriptor.name, StandardMetric.TRACE_COUNT);
             metrics = scopeMetrics[1].metrics;
             assert.strictEqual(metrics.length, 2, 'metrics count');
-            assert.equal(metrics[0].descriptor.name, StandardMetric.REQUEST_DURATION);
-            assert.equal(metrics[1].descriptor.name, StandardMetric.DEPENDENCY_DURATION);
+            assert.equal(metrics[0].descriptor.name, StandardMetric.HTTP_REQUEST_DURATION);
+            assert.equal(metrics[1].descriptor.name, StandardMetric.HTTP_DEPENDENCY_DURATION);
         });
     });
 });

--- a/test/unitTests/library/metricHandler.tests.ts
+++ b/test/unitTests/library/metricHandler.tests.ts
@@ -35,9 +35,8 @@ describe("Library/MetricHandler", () => {
             _config.enableAutoCollectPreAggregatedMetrics = true;
             let handler = new MetricHandler(_config);
             handler["_perfCounterMetricsHandler"]["_nativeMetrics"]["_metricsAvailable"] = false;
-            let stub = sinon.stub(handler["_standardMetricsHandler"], "start");
             handler.start();
-            assert.ok(stub.calledOnce, "start called");
+            assert.ok(handler.getStandardMetricsHandler());
         });
 
         it("heartbeat metrics enablement during start", () => {

--- a/test/unitTests/library/sampler.tests.ts
+++ b/test/unitTests/library/sampler.tests.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { SamplingDecision } from "@opentelemetry/api";
+import { SamplingDecision } from "@opentelemetry/sdk-trace-base";
 import { ApplicationInsightsSampler } from "../../../src/library/handlers/sampler";
 
 


### PR DESCRIPTION
Fix issue with Exceptions/Traces not exporting all dimensions, using BatchObservableResult
Fix issue with Perf Counters reporting trace/exceptions counts instead of rates
Added prefix in all Standard Metrics for easy discoverability in Azure Monitor Exporter
Azure Monitor Exporter will add extra attributes to Standard Metrics
Add sampleRate attribute in Spans for Exporter to use

