### PR TITLE
Avoid duplication of telemetry when abort event is triggered

### DIFF
--- a/Declarations/Contracts/TelemetryTypes/NodeHttpDependencyTelemetry.ts
+++ b/Declarations/Contracts/TelemetryTypes/NodeHttpDependencyTelemetry.ts
@@ -16,4 +16,10 @@ export interface NodeHttpDependencyTelemetry extends Telemetry
      * Outgoing HTTP request object
      */
     request: http.ClientRequest;
+
+    /**
+     * Flag to determine if telemetry had been processed.
+     */
+     isProcessed?: boolean;
+
 }

--- a/Declarations/Contracts/TelemetryTypes/NodeHttpRequestTelemetry.ts
+++ b/Declarations/Contracts/TelemetryTypes/NodeHttpRequestTelemetry.ts
@@ -1,11 +1,10 @@
-import { Telemetry }  from "./Telemetry";
+import { Telemetry } from "./Telemetry";
 import http = require("http");
 
 /**
  * Object encapsulating information about the incoming HTTP request
  */
-export interface NodeHttpRequestTelemetry extends Telemetry
-{
+export interface NodeHttpRequestTelemetry extends Telemetry {
     /**
      * HTTP request object
      */
@@ -15,11 +14,16 @@ export interface NodeHttpRequestTelemetry extends Telemetry
      * HTTP response object
      */
     response: http.ServerResponse;
-    
+
     /**
      * HTTP request duration. Used only for synchronous tracks.
      */
     duration?: number;
+
+    /**
+     * Flag to determine if telemetry had been processed.
+     */
+    isProcessed?: boolean;
 
     /**
      * Error that occurred while processing the request. Used only for synchronous tracks.

--- a/Library/EnvelopeFactory.ts
+++ b/Library/EnvelopeFactory.ts
@@ -130,7 +130,7 @@ class EnvelopeFactory {
         remoteDependency.success = telemetry.success;
         remoteDependency.type = telemetry.dependencyTypeName;
         remoteDependency.properties = telemetry.properties;
-        remoteDependency.resultCode = (telemetry.resultCode ? telemetry.resultCode + "" : "");
+        remoteDependency.resultCode = (telemetry.resultCode ? telemetry.resultCode.toString() : "0");
 
         if (telemetry.id) {
             remoteDependency.id = telemetry.id;
@@ -194,7 +194,7 @@ class EnvelopeFactory {
         requestData.url = telemetry.url;
         requestData.source = telemetry.source;
         requestData.duration = Util.msToTimeSpan(telemetry.duration);
-        requestData.responseCode = (telemetry.resultCode ? telemetry.resultCode + "" : "");
+        requestData.responseCode = (telemetry.resultCode ? telemetry.resultCode.toString() : "0");
         requestData.success = telemetry.success
         requestData.properties = telemetry.properties;
         requestData.measurements = telemetry.measurements;


### PR DESCRIPTION
Fixes #1023
Fixes #896 

Abort and error events are both executed in Node.js runtime > 16, this is causing duplication of telemetry when there are timeouts or canceled requests.
Added default status code 0 - Unknown instead of empty string, Breeze is currently rejecting requests with empty status code