### PR TITLE
Update the comment for the default DistributedTracingModes to be accurate

### DIFF
--- a/applicationinsights.ts
+++ b/applicationinsights.ts
@@ -23,13 +23,13 @@ export import azureFunctionsTypes = require("./Library/Functions");
 
 export enum DistributedTracingModes {
     /**
-     * (Default) Send Application Insights correlation headers
+     * Send Application Insights correlation headers
      */
 
     AI = 0,
 
     /**
-     * Send both W3C Trace Context headers and back-compatibility Application Insights headers
+     * (Default) Send both W3C Trace Context headers and back-compatibility Application Insights headers
      */
     AI_AND_W3C
 }


### PR DESCRIPTION
The readme.md file indicates DistributedTracingModes.AI_AND_W3C is the default in the 'Configuration' section. 

The default value for CorrelationIdManager.w3cEnabled = true

But the comment in applicationinsights.ts indicates DistributedTracingModes.AI is the default. It looks like this comment is not accurate, so a quick PR to fix this. 