### PR TITLE
Address Negative Average Duration

### DIFF
--- a/AutoCollection/Statsbeat.ts
+++ b/AutoCollection/Statsbeat.ts
@@ -250,10 +250,11 @@ class Statsbeat {
 
     private _trackRequestDuration(commonProperties: {}) {
         for (let i = 0; i < this._networkStatsbeatCollection.length; i++) {
-            var currentCounter = this._networkStatsbeatCollection[i];
+            let currentCounter = this._networkStatsbeatCollection[i];
             currentCounter.time = +new Date;
-            var intervalRequests = (currentCounter.totalRequestCount - currentCounter.lastRequestCount) || 0;
-            var averageRequestExecutionTime = ((currentCounter.intervalRequestExecutionTime - currentCounter.lastIntervalRequestExecutionTime) / intervalRequests) || 0;
+            let intervalRequests = (currentCounter.totalRequestCount - currentCounter.lastRequestCount) || 0;
+            let totalRequestExecutionTime = currentCounter.intervalRequestExecutionTime - currentCounter.lastIntervalRequestExecutionTime;
+            let averageRequestExecutionTime = totalRequestExecutionTime > 0 ? (totalRequestExecutionTime / intervalRequests) || 0 : 0;
             currentCounter.lastIntervalRequestExecutionTime = currentCounter.intervalRequestExecutionTime; // reset
             if (intervalRequests > 0) {
                 // Add extra properties
@@ -436,7 +437,9 @@ class Statsbeat {
             "norwaywest",
             "swedencentral",
             "switzerlandnorth",
-            "switzerlandwest"
+            "switzerlandwest",
+            "uksouth",
+            "ukwest"
         ];
         for (let i = 0; i < euEndpoints.length; i++) {
             if (currentEndpoint.indexOf(euEndpoints[i]) > -1) {

--- a/AutoCollection/Statsbeat.ts
+++ b/AutoCollection/Statsbeat.ts
@@ -284,6 +284,7 @@ class Statsbeat {
             if (res != null && res.length > 1) {
                 shortHost = res[1];
             }
+            shortHost = shortHost.replace(".in.applicationinsights.azure.com", "");
         }
         catch (error) {
             // Ignore error


### PR DESCRIPTION
This PR sets `averageRequestExecutionTime` to 0 when given a negative `totalRequestExecutionTime` assuming that in this case something is wrong with the input `executionTime`.

This PR also adds support for more EU regions as defined by: 
https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/blob/main/ApplicationInsights/statsbeat/eudb.md

And shortens the `shortHost` name to be within spec:
https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/pull/139