### PR TITLE
Remove preinvocation hook in Azure Functions

### DIFF
--- a/AutoCollection/AzureFunctionsHook.ts
+++ b/AutoCollection/AzureFunctionsHook.ts
@@ -17,14 +17,15 @@ export class AzureFunctionsHook {
     constructor(client: TelemetryClient) {
         this._client = client;
         this._autoGenerateIncomingRequests = false;
-        try {
-            this._functionsCoreModule = require("@azure/functions-core");
-        }
-        catch (error) {
-            Logging.info("AzureFunctionsHook failed to load, not running in Azure Functions");
-            return;
-        }
-        this._addPreInvocationHook();
+        // TODO: Enable when all Azure Functions scenarios are covered
+        // try {
+        //     this._functionsCoreModule = require("@azure/functions-core");
+        // }
+        // catch (error) {
+        //     Logging.info("AzureFunctionsHook failed to load, not running in Azure Functions");
+        //     return;
+        // }
+        // this._addPreInvocationHook();
     }
 
     public enable(isEnabled: boolean) {

--- a/Tests/AutoCollection/AzureFunctionsHook.tests.ts
+++ b/Tests/AutoCollection/AzureFunctionsHook.tests.ts
@@ -32,13 +32,13 @@ describe("AutoCollection/AzureFunctionsHook", () => {
     });
 
 
-    it("Hook not added if not running in Azure Functions", () => {
-        const spy = sandbox.spy(Logging, "info");
-        let hook = new AzureFunctionsHook(client);
-        assert.equal(hook["_functionsCoreModule"], undefined);
-        assert.ok(spy.called);
-        assert.equal(spy.args[0][0], "AzureFunctionsHook failed to load, not running in Azure Functions");
-    });
+    // it("Hook not added if not running in Azure Functions", () => {
+    //     const spy = sandbox.spy(Logging, "info");
+    //     let hook = new AzureFunctionsHook(client);
+    //     assert.equal(hook["_functionsCoreModule"], undefined);
+    //     assert.ok(spy.called);
+    //     assert.equal(spy.args[0][0], "AzureFunctionsHook failed to load, not running in Azure Functions");
+    // });
 
     it("Hook added if running in Azure Functions", () => {
         let hook = new AzureFunctionsHook(client);


### PR DESCRIPTION
Fixes #1061 
Fixes #1063 
We need to investigate and test further to enable the feature back, reverting this logic to avoid future customer impact in latest version