### PR TITLE
Add Fabric Bot Issue Management

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,811 @@
+{
+    "version": "1.0",
+    "tasks": [
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "taskName": "Add needs triage label to new issues",
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "opened"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isPartOfProject",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAssignedToSomeone",
+                    "parameters": {}
+                  }
+                ]
+              }
+            ]
+          },
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "Needs: Triage :mag:"
+              }
+            }
+          ],
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ]
+        },
+        "id": "w5j6iWHr1eKJmXoCvHNNN"
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "taskName": "Replace needs author feedback label with needs attention label when the author comments on an issue",
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "created"
+                }
+              },
+              {
+                "name": "isActivitySender",
+                "parameters": {
+                  "user": {
+                    "type": "author"
+                  }
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "Needs: Author Feedback"
+                }
+              },
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "Needs: Attention :wave:"
+              }
+            },
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "Needs: Author Feedback"
+              }
+            }
+          ],
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ]
+        },
+        "id": "KkkXuD1tjzsorGLQE8kFu"
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "taskName": "Remove no recent activity label from issues",
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "closed"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "Status: No Recent Activity"
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "Status: No Recent Activity"
+              }
+            }
+          ],
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ]
+        },
+        "id": "R9tF9-8uo36K9x0jqXMT7"
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "taskName": "Remove no recent activity label when an issue is commented on",
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "Status: No Recent Activity"
+                }
+              }
+            ]
+          },
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "Status: No Recent Activity"
+              }
+            }
+          ],
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ]
+        },
+        "id": "T1_HSd--Ap2d7nsr9178q"
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "taskName": "Close stale issues",
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                1,
+                7,
+                13,
+                19
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                1,
+                7,
+                13,
+                19
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                1,
+                7,
+                13,
+                19
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                1,
+                7,
+                13,
+                19
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                1,
+                7,
+                13,
+                19
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                1,
+                7,
+                13,
+                19
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                1,
+                7,
+                13,
+                19
+              ]
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Needs: Author Feedback"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Status: No Recent Activity"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 7
+              }
+            }
+          ],
+          "actions": [
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        },
+        "id": "opn7U-Msf6apkXDIETAd_"
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "taskName": "Add no recent activity label to issues",
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                2,
+                8,
+                14,
+                20
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                2,
+                8,
+                14,
+                20
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                2,
+                8,
+                14,
+                20
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                2,
+                8,
+                14,
+                20
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                2,
+                8,
+                14,
+                20
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                2,
+                8,
+                14,
+                20
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                2,
+                8,
+                14,
+                20
+              ]
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Needs: Author Feedback"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 7
+              }
+            },
+            {
+              "name": "noLabel",
+              "parameters": {
+                "label": "Status: No Recent Activity"
+              }
+            }
+          ],
+          "actions": [
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "Status: No Recent Activity"
+              }
+            },
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**."
+              }
+            }
+          ]
+        },
+        "id": "qUvd1emC2tCDQNTBjEJhx"
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "taskName": "Close duplicate issues",
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                3,
+                9,
+                15,
+                21
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                3,
+                9,
+                15,
+                21
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                3,
+                9,
+                15,
+                21
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                3,
+                9,
+                15,
+                21
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                3,
+                9,
+                15,
+                21
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                3,
+                9,
+                15,
+                21
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                3,
+                9,
+                15,
+                21
+              ]
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "Resolution: Duplicate"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 1
+              }
+            }
+          ],
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "This issue has been marked as duplicate and has not had any activity for **1 day**. It will be closed for housekeeping purposes."
+              }
+            },
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        },
+        "id": "T__llMnXvs8Qkc-fZVeZI"
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "InPrLabel",
+        "subCapability": "InPrLabel",
+        "version": "1.0",
+        "config": {
+          "taskName": "Add 'In-PR' label on issue when an open pull request is targeting it",
+          "inPrLabelText": "Status: In PR",
+          "fixedLabelText": "Status: Fixed",
+          "fixedLabelEnabled": true
+        },
+        "id": "ze3ugXucpansV-bWS9Zd3"
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isOpen",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "created"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "Status: No Recent Activity"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "Needs: Author Feedback"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "noActivitySince",
+                    "parameters": {
+                      "days": 7
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isCloseAndComment",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "name": "isActivitySender",
+                "parameters": {
+                  "user": {
+                    "type": "author"
+                  }
+                }
+              },
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "none"
+                }
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ],
+          "taskName": "For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
+          "actions": [
+            {
+              "name": "reopenIssue",
+              "parameters": {}
+            },
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "Status: No Recent Activity"
+              }
+            },
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "Needs: Author Feedback"
+              }
+            },
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "Needs: Attention :wave:"
+              }
+            }
+          ]
+        },
+        "id": "vKqxbkzauQ-WELUP6DIBs"
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "created"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isOpen",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "none"
+                }
+              },
+              {
+                "name": "noActivitySince",
+                "parameters": {
+                  "days": 7
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isCloseAndComment",
+                    "parameters": {}
+                  }
+                ]
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ],
+          "taskName": "For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
+              }
+            }
+          ]
+        },
+        "id": "qrA0cPnVJIM_t3NQFpl3t"
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isClosed",
+              "parameters": {}
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 30
+              }
+            },
+            {
+              "name": "isUnlocked",
+              "parameters": {}
+            },
+            {
+              "name": "isIssue",
+              "parameters": {}
+            }
+          ],
+          "taskName": "Lock issues closed without activity for over 30 days",
+          "actions": [
+            {
+              "name": "lockIssue",
+              "parameters": {
+                "reason": "resolved"
+              }
+            }
+          ]
+        },
+        "id": "99fnakS8ffI6qwXYvBXPM"
+      }
+    ],
+    "userGroups": []
+}


### PR DESCRIPTION
These rules will do the following:
- Add "needs triage" label to any opened issue.
- Replace the "needs author feedback label" with "needs attention" when the author comments on an issue.
- Remove the "no recent activity" from an issue when an issue has new activity after being stagnant.
- Remove "no recent activity" label when an issue is commented on.
- If an issue is marked as "needs author feedback" and 7 days pass the issue will be marked as "no recent activity"
- If an issue is marked as "needs author feedback" and "no recent activity" after 7 days it will be closed as stale.
- Issues marked as duplicate will be closed after 1 day.
- Adds an "in-PR" label to an issue when a pull request targeting it is created.
- Re-opens an issue closed due to inactivity if the author posts a reply within 7 days.
- If an author posts a reply after the 7 days on the closed issue - automatically suggest they open a new issue.
- Lock issues closed without activity for over 30 days.