### PR TITLE
Add Handling for Undefined Triggered Function Response

### DIFF
--- a/AutoCollection/AzureFunctionsHook.ts
+++ b/AutoCollection/AzureFunctionsHook.ts
@@ -109,17 +109,21 @@ export class AzureFunctionsHook {
 
     private _createIncomingRequestTelemetry(request: HttpRequest, response: HttpResponse, startTime: number, parentId: string) {
         let statusCode: string | number = 200; //Default
-        for (const value of [response.statusCode, response.status]) {
-            if (typeof value === "number" && Number.isInteger(value)) {
-                statusCode = value;
-                break;
-            } else if (typeof value === "string") {
-                const parsedVal = parseInt(value);
-                if (!isNaN(parsedVal)) {
-                    statusCode = parsedVal;
+        if (response) {
+            for (const value of [response.statusCode, response.status]) {
+                if (typeof value === "number" && Number.isInteger(value)) {
+                    statusCode = value;
                     break;
+                } else if (typeof value === "string") {
+                    const parsedVal = parseInt(value);
+                    if (!isNaN(parsedVal)) {
+                        statusCode = parsedVal;
+                        break;
+                    }
                 }
             }
+        } else {
+            statusCode = 500;
         }
         this._client.trackRequest({
             name: request.method + " " + request.url,

--- a/AutoCollection/AzureFunctionsHook.ts
+++ b/AutoCollection/AzureFunctionsHook.ts
@@ -123,12 +123,12 @@ export class AzureFunctionsHook {
                 }
             }
         } else {
-            statusCode = 500;
+            statusCode = undefined;
         }
         this._client.trackRequest({
             name: request.method + " " + request.url,
             resultCode: statusCode,
-            success: (0 < statusCode) && (statusCode < 400),
+            success: typeof(statusCode) === "number" ? (0 < statusCode) && (statusCode < 400) : undefined,
             url: request.url,
             time: new Date(startTime),
             duration: Date.now() - startTime,


### PR DESCRIPTION
Fixes #1149 

Added check to ensure that if response is not defined we return a status code 500 instead of throwing a type error.