### PR TITLE
Add support for Functions programming model v4

### DIFF
--- a/AutoCollection/AzureFunctionsHook.ts
+++ b/AutoCollection/AzureFunctionsHook.ts
@@ -1,8 +1,9 @@
 import { Disposable, PostInvocationContext, PreInvocationContext } from "@azure/functions-core";
-import { Context, HttpRequest, HttpResponse } from "@azure/functions";
 import Logging = require("../Library/Logging");
 import TelemetryClient = require("../Library/TelemetryClient");
 import { CorrelationContext, CorrelationContextManager } from "./CorrelationContextManager";
+import * as sharedFuncTypes from "../Library/Functions";
+import * as v3 from "@azure/functions";
 
 /** Node.js Azure Functions handle incoming HTTP requests before Application Insights SDK is available,
  * this code generate incoming request telemetry and generate correlation context to be used
@@ -14,25 +15,43 @@ export class AzureFunctionsHook {
     private _autoGenerateIncomingRequests: boolean;
     private _preInvocationHook: Disposable;
     private _postInvocationHook: Disposable;
+    private _cachedModelHelper: FuncModelV3Helper | FuncModelV4Helper | null | undefined;
 
     constructor(client: TelemetryClient) {
         this._client = client;
         this._autoGenerateIncomingRequests = false;
         try {
             this._functionsCoreModule = require("@azure/functions-core");
-            // Only v3 of Azure Functions library is supported right now. See matrix of versions here:
-            // https://github.com/Azure/azure-functions-nodejs-library
-            const funcProgModel = this._functionsCoreModule.getProgrammingModel();
-            if (funcProgModel.name === "@azure/functions" && funcProgModel.version.startsWith("3.")) {
-                this._addPreInvocationHook();
-                this._addPostInvocationHook();
-            } else {
-                Logging.warn(`AzureFunctionsHook does not support model "${funcProgModel.name}" version "${funcProgModel.version}"`);
-            }
+            this._addPreInvocationHook();
+            this._addPostInvocationHook();
         }
         catch (error) {
             Logging.info("AzureFunctionsHook failed to load, not running in Azure Functions");
         }
+    }
+
+    /**
+     * NOTE: The programming model can be changed any time until the first invocation
+     * For that reason, we delay setting the model helper until the first hook is called, but we can cache it after that
+     */
+    private _getFuncModelHelper(): FuncModelV3Helper | FuncModelV4Helper | null {
+        if (this._cachedModelHelper === undefined) {
+            const funcProgModel = this._functionsCoreModule.getProgrammingModel();
+            if (funcProgModel.name === "@azure/functions") {
+                if (funcProgModel.version.startsWith("3.")) {
+                    this._cachedModelHelper = new FuncModelV3Helper();
+                } else if (funcProgModel.version.startsWith("4.")) {
+                    this._cachedModelHelper = new FuncModelV4Helper();
+                }
+            }
+
+            if (!this._cachedModelHelper) {
+                this._cachedModelHelper = null;
+                Logging.warn(`AzureFunctionsHook does not support model "${funcProgModel.name}" version "${funcProgModel.version}"`);
+            }
+        }
+
+        return this._cachedModelHelper;
     }
 
     public enable(isEnabled: boolean) {
@@ -48,23 +67,28 @@ export class AzureFunctionsHook {
     private _addPreInvocationHook() {
         if (!this._preInvocationHook) {
             this._preInvocationHook = this._functionsCoreModule.registerHook("preInvocation", async (preInvocationContext: PreInvocationContext) => {
-                const ctx: Context = <Context>preInvocationContext.invocationContext;
                 try {
-                    // Start an AI Correlation Context using the provided Function context
-                    let extractedContext = CorrelationContextManager.startOperation(ctx);
-                    if (extractedContext) { // Will be null if CorrelationContextManager is not enabled, we should not try to propagate context in that case
-                        extractedContext.customProperties.setProperty("InvocationId", ctx.invocationId);
-                        if (ctx.traceContext.attributes) {
-                            extractedContext.customProperties.setProperty("ProcessId", ctx.traceContext.attributes["ProcessId"]);
-                            extractedContext.customProperties.setProperty("LogLevel", ctx.traceContext.attributes["LogLevel"]);
-                            extractedContext.customProperties.setProperty("Category", ctx.traceContext.attributes["Category"]);
-                            extractedContext.customProperties.setProperty("HostInstanceId", ctx.traceContext.attributes["HostInstanceId"]);
-                            extractedContext.customProperties.setProperty("AzFuncLiveLogsSessionId", ctx.traceContext.attributes["#AzFuncLiveLogsSessionId"]);
-                        }
-                        preInvocationContext.functionCallback = CorrelationContextManager.wrapCallback(preInvocationContext.functionCallback, extractedContext);
-                        if (this._isHttpTrigger(ctx) && this._autoGenerateIncomingRequests) {
-                            preInvocationContext.hookData.appInsightsExtractedContext = extractedContext;
-                            preInvocationContext.hookData.appInsightsStartTime = Date.now(); // Start trackRequest timer
+                    const modelHelper = this._getFuncModelHelper();
+                    if (modelHelper) {
+                        const sharedContext = <sharedFuncTypes.Context>preInvocationContext.invocationContext;
+                        // Start an AI Correlation Context using the provided Function context
+                        let extractedContext = CorrelationContextManager.startOperation(sharedContext);
+                        if (extractedContext) { // Will be null if CorrelationContextManager is not enabled, we should not try to propagate context in that case
+                            extractedContext.customProperties.setProperty("InvocationId", sharedContext.invocationId);
+
+                            const traceContext = sharedContext.traceContext;
+                            if (traceContext.attributes) {
+                                extractedContext.customProperties.setProperty("ProcessId", traceContext.attributes["ProcessId"]);
+                                extractedContext.customProperties.setProperty("LogLevel", traceContext.attributes["LogLevel"]);
+                                extractedContext.customProperties.setProperty("Category", traceContext.attributes["Category"]);
+                                extractedContext.customProperties.setProperty("HostInstanceId", traceContext.attributes["HostInstanceId"]);
+                                extractedContext.customProperties.setProperty("AzFuncLiveLogsSessionId", traceContext.attributes["#AzFuncLiveLogsSessionId"]);
+                            }
+                            preInvocationContext.functionCallback = CorrelationContextManager.wrapCallback(preInvocationContext.functionCallback, extractedContext);
+                            if (modelHelper.isHttpTrigger(preInvocationContext) && this._autoGenerateIncomingRequests) {
+                                preInvocationContext.hookData.appInsightsExtractedContext = extractedContext;
+                                preInvocationContext.hookData.appInsightsStartTime = Date.now(); // Start trackRequest timer
+                            }
                         }
                     }
                 }
@@ -80,21 +104,22 @@ export class AzureFunctionsHook {
         if (!this._postInvocationHook) {
             this._postInvocationHook = this._functionsCoreModule.registerHook("postInvocation", async (postInvocationContext: PostInvocationContext) => {
                 try {
-                    if (this._autoGenerateIncomingRequests) {
-                        const ctx: Context = <Context>postInvocationContext.invocationContext;
-                        if (this._isHttpTrigger(ctx)) {
-                            const request: HttpRequest = postInvocationContext.inputs[0];
-                            if (request) {
-                                const startTime: number = postInvocationContext.hookData.appInsightsStartTime || Date.now();
-                                const response = this._getAzureFunctionResponse(postInvocationContext, ctx);
-                                const extractedContext: CorrelationContext | undefined = postInvocationContext.hookData.appInsightsExtractedContext;
-                                if (!extractedContext) {
-                                    this._createIncomingRequestTelemetry(request, response, startTime, null);
-                                }
-                                else {
-                                    CorrelationContextManager.runWithContext(extractedContext, () => {
-                                        this._createIncomingRequestTelemetry(request, response, startTime, extractedContext.operation.parentId);
-                                    });
+                    const modelHelper = this._getFuncModelHelper();
+                    if (modelHelper) {
+                        if (this._autoGenerateIncomingRequests) {
+                            if (modelHelper.isHttpTrigger(postInvocationContext)) {
+                                const request = <sharedFuncTypes.HttpRequest>postInvocationContext.inputs[0];
+                                if (request) {
+                                    const startTime: number = postInvocationContext.hookData.appInsightsStartTime || Date.now();
+                                    const extractedContext: CorrelationContext | undefined = postInvocationContext.hookData.appInsightsExtractedContext;
+                                    if (!extractedContext) {
+                                        this._createIncomingRequestTelemetry(request, postInvocationContext, startTime, null);
+                                    }
+                                    else {
+                                        CorrelationContextManager.runWithContext(extractedContext, () => {
+                                            this._createIncomingRequestTelemetry(request, postInvocationContext, startTime, extractedContext.operation.parentId);
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -107,10 +132,11 @@ export class AzureFunctionsHook {
         }
     }
 
-    private _createIncomingRequestTelemetry(request: HttpRequest, response: HttpResponse, startTime: number, parentId: string) {
+    private _createIncomingRequestTelemetry(request: sharedFuncTypes.HttpRequest, hookContext: PostInvocationContext, startTime: number, parentId: string) {
+        const values = this._getFuncModelHelper().getStatusCodes(hookContext);
         let statusCode: string | number = 200; //Default
-        if (response) {
-            for (const value of [response.statusCode, response.status]) {
+        if (values) {
+            for (const value of values) {
                 if (typeof value === "number" && Number.isInteger(value)) {
                     statusCode = value;
                     break;
@@ -128,28 +154,13 @@ export class AzureFunctionsHook {
         this._client.trackRequest({
             name: request.method + " " + request.url,
             resultCode: statusCode,
-            success: typeof(statusCode) === "number" ? (0 < statusCode) && (statusCode < 400) : undefined,
+            success: typeof (statusCode) === "number" ? (0 < statusCode) && (statusCode < 400) : undefined,
             url: request.url,
             time: new Date(startTime),
             duration: Date.now() - startTime,
             id: parentId
         });
         this._client.flush();
-    }
-
-    private _getAzureFunctionResponse(postInvocationContext: PostInvocationContext, ctx: Context): HttpResponse {
-        const httpOutputBinding = ctx.bindingDefinitions.find(b => b.direction === "out" && b.type.toLowerCase() === "http");
-        if (httpOutputBinding?.name === "$return") {
-            return postInvocationContext.result;
-        } else if (httpOutputBinding && ctx.bindings && ctx.bindings[httpOutputBinding.name] !== undefined) {
-            return ctx.bindings[httpOutputBinding.name];
-        } else {
-            return ctx.res;
-        }
-    }
-
-    private _isHttpTrigger(ctx: Context) {
-        return ctx.bindingDefinitions.find(b => b.type?.toLowerCase() === "httptrigger");
     }
 
     private _removeInvocationHooks() {
@@ -161,5 +172,52 @@ export class AzureFunctionsHook {
             this._postInvocationHook.dispose();
             this._postInvocationHook = undefined;
         }
+    }
+}
+
+class FuncModelV3Helper {
+    private _getInvocationContext(hookContext: PreInvocationContext | PostInvocationContext): v3.Context {
+        return <v3.Context>hookContext.invocationContext;
+    }
+
+    public getStatusCodes(hookContext: PostInvocationContext): unknown[] | undefined {
+        const ctx = this._getInvocationContext(hookContext);
+
+        let response: v3.HttpResponse | undefined;
+        const httpOutputBinding = ctx.bindingDefinitions.find(b => b.direction === "out" && b.type.toLowerCase() === "http");
+        if (httpOutputBinding?.name === "$return") {
+            response = hookContext.result;
+        } else if (httpOutputBinding && ctx.bindings && ctx.bindings[httpOutputBinding.name] !== undefined) {
+            response = ctx.bindings[httpOutputBinding.name];
+        } else {
+            response = ctx.res;
+        }
+
+        return response ? [response.statusCode, response.status] : undefined;
+    }
+
+    public isHttpTrigger(hookContext: PreInvocationContext | PostInvocationContext): boolean {
+        const ctx = this._getInvocationContext(hookContext);
+        return !!ctx.bindingDefinitions.find(b => b.type?.toLowerCase() === "httptrigger");
+    }
+}
+
+/**
+ * V4 is only supported on Node.js v18+
+ * Unfortunately that means we can't use the "@azure/functions" types for v4 or we break the build on Node <v18
+ */
+class FuncModelV4Helper {
+    private _getInvocationContext(hookContext: PreInvocationContext | PostInvocationContext): any {
+        return hookContext.invocationContext;
+    }
+
+    public getStatusCodes(hookContext: PostInvocationContext): unknown[] | undefined {
+        let response = hookContext.result;
+        return response ? [response.status] : undefined;
+    }
+
+    public isHttpTrigger(hookContext: PreInvocationContext | PostInvocationContext) {
+        const ctx = this._getInvocationContext(hookContext);
+        return ctx.options.trigger.type.toLowerCase() === "httptrigger";
     }
 }

--- a/Library/Functions.ts
+++ b/Library/Functions.ts
@@ -1,3 +1,7 @@
+// NOTE: These types are the only parts of "@azure/functions" referenced/exported from the "applicationinsights" package
+// This is done so that the "applicationinsights" package does not need a direct dependency on "@azure/functions"
+// These types should be compatible with both functions model v3 and model v4
+
 /**
  * The context object can be used for writing logs, reading data from bindings, setting outputs and using
  * the context.done callback when your exported function is synchronous. A context object is passed
@@ -12,16 +16,6 @@ export interface Context {
     * TraceContext information to enable distributed tracing scenarios.
     */
     traceContext: TraceContext;
-    /**
-     * HTTP request object. Provided to your function when using HTTP Bindings.
-     */
-    req?: HttpRequest;
-    /**
-     * HTTP response object. Provided to your function when using HTTP Bindings.
-     */
-    res?: {
-        [key: string]: any;
-    };
 }
 
 /**
@@ -30,21 +24,35 @@ export interface Context {
 export interface HttpRequest {
     method: string | null;
     url: string;
-    headers: {
-        [key: string]: string;
-    };
+    headers: { [key: string]: string; };
+}
+
+export type TraceContext = V3TraceContext & V4TraceContext;
+
+/**
+ * TraceContext information to enable distributed tracing scenarios.
+ */
+export interface V3TraceContext {
+    /** Describes the position of the incoming request in its trace graph in a portable, fixed-length format. */
+    traceparent?: string | null;
+    /** Extends traceparent with vendor-specific data. */
+    tracestate?: string | null;
+    /** Holds additional properties being sent as part of request telemetry. */
+    attributes?: {
+        [k: string]: string;
+    } | null;
 }
 
 /**
  * TraceContext information to enable distributed tracing scenarios.
  */
-export interface TraceContext {
+export interface V4TraceContext {
     /** Describes the position of the incoming request in its trace graph in a portable, fixed-length format. */
-    traceparent: string | null | undefined;
+    traceParent?: string | null;
     /** Extends traceparent with vendor-specific data. */
-    tracestate: string | null | undefined;
+    traceState?: string | null;
     /** Holds additional properties being sent as part of request telemetry. */
-    attributes: {
+    attributes?: {
         [k: string]: string;
-    } | null | undefined;
+    } | null;
 }

--- a/Tests/AutoCollection/AzureFunctionsHook.tests.ts
+++ b/Tests/AutoCollection/AzureFunctionsHook.tests.ts
@@ -43,45 +43,78 @@ describe("AutoCollection/AzureFunctionsHook", () => {
     describe("AutoCollection/AzureFunctionsHook load mock Azure Functions Core", () => {
         let originalRequire: any;
         let azureFnContext: Context;
-        let preInvokationCallback: PreInvocationCallback;
+        let modelVersion: string;
+        let preInvocationCallback: PreInvocationCallback;
         let postInvokationCallback: PostInvocationCallback;
+
+        const attributes = {
+            "OperationName": "testOperationName",
+            "ProcessId": "testProcessId",
+            "LogLevel": "testLogLevel",
+            "Category": "testCategory",
+            "HostInstanceId": "testHostInstanceId",
+            "#AzFuncLiveLogsSessionId": "testAzFuncLiveLogsSessionId",
+        };
+        const v3Context: Context = {
+            invocationId: "testinvocationId",
+            traceContext: {
+                traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                tracestate: "",
+                attributes
+            },
+            res: {
+                "status": 400,
+            },
+            executionContext: null,
+            bindingData: null,
+            bindings: null,
+            bindingDefinitions: [{
+                name: null,
+                type: "httptrigger",
+                direction: null
+            }],
+            log: null,
+            done: null
+        };
+        const v4Context: any = {
+            invocationId: "testinvocationId",
+            functionName: "httpTrigger1",
+            traceContext: {
+                traceParent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                traceState: "",
+                attributes
+            },
+            options: {
+                trigger: {
+                    authLevel: "anonymous",
+                    methods: [
+                        "GET",
+                        "POST"
+                    ],
+                    type: "httpTrigger",
+                    name: "httpTrigger1",
+                    direction: "in"
+                },
+                return: {
+                    type: "http",
+                    name: "$return",
+                    direction: "out"
+                },
+                extraInputs: [],
+                extraOutputs: []
+            }
+        };
 
         before(() => {
             var Module = require('module');
             originalRequire = Module.prototype.require;
-            azureFnContext = {
-                invocationId: "testinvocationId",
-                traceContext: {
-                    traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
-                    tracestate: "",
-                    attributes: {
-                        "OperationName": "testOperationName",
-                        "ProcessId": "testProcessId",
-                        "LogLevel": "testLogLevel",
-                        "Category": "testCategory",
-                        "HostInstanceId": "testHostInstanceId",
-                        "#AzFuncLiveLogsSessionId": "testAzFuncLiveLogsSessionId",
-                    }
-                },
-                res: {
-                    "status": 400,
-                },
-                executionContext: null,
-                bindingData: null,
-                bindings: null,
-                bindingDefinitions: [{
-                    name: null,
-                    type: "httptrigger",
-                    direction: null
-                }],
-                log: null,
-                done: null
-            };
         });
 
         beforeEach(() => {
-            preInvokationCallback = null;
+            preInvocationCallback = null;
             postInvokationCallback = null;
+            azureFnContext = v3Context;
+            modelVersion = '3.x';
 
             // Patch require to mock functions core
             var Module = require('module');
@@ -90,7 +123,7 @@ describe("AutoCollection/AzureFunctionsHook", () => {
                     return {
                         registerHook(name: string, callback: PreInvocationCallback | PostInvocationCallback) {
                             if (name === "preInvocation") {
-                                preInvokationCallback = (callback as PreInvocationCallback);
+                                preInvocationCallback = (callback as PreInvocationCallback);
                             }
                             else if (name === "postInvocation") {
                                 postInvokationCallback = (callback as PostInvocationCallback);
@@ -99,7 +132,7 @@ describe("AutoCollection/AzureFunctionsHook", () => {
                         getProgrammingModel() {
                             return {
                                 name: "@azure/functions",
-                                version: "3.x"
+                                version: modelVersion
                             };
                         }
                     };
@@ -113,114 +146,124 @@ describe("AutoCollection/AzureFunctionsHook", () => {
             Module.prototype.require = originalRequire;
         });
 
-        it("Hook not added if using not supported programming model", () => {
-            var Module = require('module');
-            var preInvocationCalled = false;
-            var postInvocationCalled = false;
-            Module.prototype.require = function () {
-                if (arguments[0] === "@azure/functions-core") {
-                    return {
-                        registerHook(name: string, callback: PreInvocationCallback | PostInvocationCallback) {
-                            if (name === "preInvocation") {
-                                preInvocationCalled = true;
-                            }
-                            else if (name === "postInvocation") {
-                                postInvocationCalled = true;
-                            }
-                        },
-                        getProgrammingModel() {
-                            return {
-                                name: "@azure/functions",
-                                version: "2.x"
-                            };
-                        }
-                    };
-                }
-                return originalRequire.apply(this, arguments);
-            };
+        it("Hook does nothing if using unsupported programming model", async () => {
+            let spies = [
+                sandbox.spy(CorrelationContextManager, "wrapCallback"),
+                sandbox.spy(CorrelationContextManager, "startOperation"),
+                sandbox.spy(CorrelationContextManager, "runWithContext")
+            ];
+
             let azureFnHook = new AzureFunctionsHook(client);
             assert.ok(azureFnHook, "azureFnHook");
-            assert.ok(!preInvocationCalled, "preInvocationCalled");
-            assert.ok(!postInvocationCalled, "postInvocationCalled");
-        });
-
-        it("Pre Invokation Hook added if running in Azure Functions and context is propagated", () => {
-            let azureFnHook = new AzureFunctionsHook(client);
-            assert.ok(azureFnHook, "azureFnHook");
-            assert.ok(preInvokationCallback, "preInvocationCalled");
-            // Azure Functions should call preinvocation callback
-            let preInvocationContext: PreInvocationContext = {
-                inputs: [],
-                functionCallback: (unknown: any, inputs: unknown[]) => {
-                    let currentContext = CorrelationContextManager.getCurrentContext();
-                    // Context should be propagated here
-                    assert.equal(currentContext.operation.id, "0af7651916cd43dd8448eb211c80319c");
-                    assert.equal(currentContext.operation.name, "testOperationName");
-                    assert.equal(currentContext.operation.parentId, "|0af7651916cd43dd8448eb211c80319c.b7ad6b7169203331.");
-                    assert.equal(currentContext.customProperties.getProperty("InvocationId"), "testinvocationId");
-                    assert.equal(currentContext.customProperties.getProperty("ProcessId"), "testProcessId");
-                    assert.equal(currentContext.customProperties.getProperty("LogLevel"), "testLogLevel");
-                    assert.equal(currentContext.customProperties.getProperty("Category"), "testCategory");
-                    assert.equal(currentContext.customProperties.getProperty("HostInstanceId"), "testHostInstanceId");
-                    assert.equal(currentContext.customProperties.getProperty("AzFuncLiveLogsSessionId"), "testAzFuncLiveLogsSessionId");
-                },
-                hookData: {},
-                appHookData: {},
-                invocationContext: context
-            };
-            preInvokationCallback(preInvocationContext);
-        });
-
-        it("Post invocation Hook added, context is propagated and incoming request is generated if turned on", () => {
-            let azureFnHook = new AzureFunctionsHook(client);
             azureFnHook.enable(true);
-            assert.ok(azureFnHook, "azureFnHook");
-            assert.ok(preInvokationCallback, "preInvocationCalled");
+            assert.ok(preInvocationCallback, "preInvocationCalled");
             assert.ok(postInvokationCallback, "postInvocationCalled");
 
+            modelVersion = '2.x';
+
             let preInvocationContext: PreInvocationContext = {
-                inputs: [],
-                functionCallback: (unknown: any, inputs: unknown[]) => { },
+                inputs: [{ method: "HEAD", url: "test.com", headers: {}, }],
+                functionCallback: () => { },
                 hookData: {},
                 appHookData: {},
                 invocationContext: azureFnContext
             };
-            // Azure Functions should call preinvocation callback
-            preInvokationCallback(preInvocationContext);
-            assert.ok(preInvocationContext.hookData.appInsightsStartTime, "appInsightsStartTime");
-            assert.ok(preInvocationContext.hookData.appInsightsExtractedContext);
+            await preInvocationCallback(preInvocationContext);
 
-            let trackRequestSpy = sandbox.stub(client, "trackRequest");
-            // Azure Functions should call postInvokation callback
-            let request: HttpRequest = {
-                method: "HEAD",
-                url: "test.com",
-                headers: { "": "" },
-                query: null,
-                params: null,
-                user: null,
-                get: null,
-                parseFormBody: null
-            };
-            let postInvocationContext: PostInvocationContext = {
-                inputs: [
-                    request
-                ],
+            await postInvokationCallback({
+                ...preInvocationContext,
                 result: null,
                 error: null,
-                hookData: preInvocationContext.hookData,
-                appHookData: {},
-                invocationContext: azureFnContext
-            };
-            postInvokationCallback(postInvocationContext);
-            assert.ok(trackRequestSpy.called);
-            let incomingRequest = trackRequestSpy.args[0][0];
-            assert.equal(incomingRequest.id, "|0af7651916cd43dd8448eb211c80319c.b7ad6b7169203331.");
-            assert.equal(incomingRequest.name, "HEAD test.com");
-            assert.equal(incomingRequest.resultCode, 400);
-            assert.equal(incomingRequest.success, false);
-            assert.equal(incomingRequest.url, "test.com");
+            });
+
+            assert.deepEqual(preInvocationContext.hookData, {});
+            for (const spy of spies) {
+                assert.equal(spy.called, false, "CorrelationContextManager method called");
+            }
         });
+
+        for (const [testModelVersion, testInvocationContext] of [['3.x', v3Context], ['4.x', v4Context]]) {
+            it(`[${testModelVersion}] Pre Invokation Hook added if running in Azure Functions and context is propagated`, async () => {
+                modelVersion = testModelVersion;
+                let azureFnHook = new AzureFunctionsHook(client);
+                assert.ok(azureFnHook, "azureFnHook");
+                assert.ok(preInvocationCallback, "preInvocationCalled");
+                // Azure Functions should call preinvocation callback
+                let preInvocationContext: PreInvocationContext = {
+                    inputs: [],
+                    functionCallback: (unknown: any, inputs: unknown[]) => {
+                        let currentContext = CorrelationContextManager.getCurrentContext();
+                        // Context should be propagated here
+                        assert.equal(currentContext.operation.id, "0af7651916cd43dd8448eb211c80319c");
+                        assert.equal(currentContext.operation.name, "testOperationName");
+                        assert.equal(currentContext.operation.parentId, "|0af7651916cd43dd8448eb211c80319c.b7ad6b7169203331.");
+                        assert.equal(currentContext.customProperties.getProperty("InvocationId"), "testinvocationId");
+                        assert.equal(currentContext.customProperties.getProperty("ProcessId"), "testProcessId");
+                        assert.equal(currentContext.customProperties.getProperty("LogLevel"), "testLogLevel");
+                        assert.equal(currentContext.customProperties.getProperty("Category"), "testCategory");
+                        assert.equal(currentContext.customProperties.getProperty("HostInstanceId"), "testHostInstanceId");
+                        assert.equal(currentContext.customProperties.getProperty("AzFuncLiveLogsSessionId"), "testAzFuncLiveLogsSessionId");
+                    },
+                    hookData: {},
+                    appHookData: {},
+                    invocationContext: testInvocationContext
+                };
+                await preInvocationCallback(preInvocationContext);
+                preInvocationContext.functionCallback(testInvocationContext);
+            });
+
+            it(`[${testModelVersion}] Post invocation Hook added, context is propagated and incoming request is generated if turned on`, () => {
+                modelVersion = testModelVersion;
+                let azureFnHook = new AzureFunctionsHook(client);
+                azureFnHook.enable(true);
+                assert.ok(azureFnHook, "azureFnHook");
+                assert.ok(preInvocationCallback, "preInvocationCalled");
+                assert.ok(postInvokationCallback, "postInvocationCalled");
+
+                let preInvocationContext: PreInvocationContext = {
+                    inputs: [],
+                    functionCallback: (unknown: any, inputs: unknown[]) => { },
+                    hookData: {},
+                    appHookData: {},
+                    invocationContext: testInvocationContext
+                };
+                // Azure Functions should call preinvocation callback
+                preInvocationCallback(preInvocationContext);
+                assert.ok(preInvocationContext.hookData.appInsightsStartTime, "appInsightsStartTime");
+                assert.ok(preInvocationContext.hookData.appInsightsExtractedContext);
+
+                let trackRequestSpy = sandbox.stub(client, "trackRequest");
+                // Azure Functions should call postInvokation callback
+                let request: HttpRequest = {
+                    method: "HEAD",
+                    url: "test.com",
+                    headers: { "": "" },
+                    query: null,
+                    params: null,
+                    user: null,
+                    get: null,
+                    parseFormBody: null
+                };
+                let postInvocationContext: PostInvocationContext = {
+                    inputs: [
+                        request
+                    ],
+                    result: { status: 400 },
+                    error: null,
+                    hookData: preInvocationContext.hookData,
+                    appHookData: {},
+                    invocationContext: testInvocationContext
+                };
+                postInvokationCallback(postInvocationContext);
+                assert.ok(trackRequestSpy.called);
+                let incomingRequest = trackRequestSpy.args[0][0];
+                assert.equal(incomingRequest.id, "|0af7651916cd43dd8448eb211c80319c.b7ad6b7169203331.");
+                assert.equal(incomingRequest.name, "HEAD test.com");
+                assert.equal(incomingRequest.resultCode, 400);
+                assert.equal(incomingRequest.success, false);
+                assert.equal(incomingRequest.url, "test.com");
+            });
+        }
 
         it("Function code not affected by hook", async () => {
             let correlationContextSpy = sandbox.spy(CorrelationContextManager, "wrapCallback");
@@ -242,7 +285,7 @@ describe("AutoCollection/AzureFunctionsHook", () => {
                 appHookData: {},
                 invocationContext: azureFnContext
             };
-            await preInvokationCallback(preInvocationContext);
+            await preInvocationCallback(preInvocationContext);
             assert.ok(correlationContextSpy.called);
             await functionCode();
             assert.equal(someNumber, 5);


### PR DESCRIPTION
Here's a blog post about the v4 model, if you want more info: https://techcommunity.microsoft.com/t5/apps-on-azure-blog/azure-functions-version-4-of-the-node-js-programming-model-is-in/ba-p/3773541

It's currently in preview, but we plan to GA pretty soon. The v4 model cleaned up some of the invocation context and request objects, which is the pretty much the only reason the applicationinsights package has to do anything.

Fixes https://github.com/Azure/azure-functions-nodejs-library/issues/110

### My testing

I have a v4 http trigger making this get request inside the function:
```js
await axios.get('https://functionscdn.azureedge.net/public/cli-feed-v4.json');
```

And it's showing up under the overarching http trigger request in app insights, so I think that means it's working.
<img width="787" alt="Screenshot 2023-08-10 at 5 37 39 PM" src="https://github.com/microsoft/ApplicationInsights-node.js/assets/11282622/11b1bc87-2dd9-42c3-9099-9a09e47ce06e">

