### PR TITLE
Avoid request to be blocked once the "dispose" method has been called

### DIFF
--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -122,9 +122,7 @@ class AutoCollectHttpRequests {
                 if (request && shouldCollect && AutoCollectHttpRequests.INSTANCE) {
                     AutoCollectHttpRequests.INSTANCE._registerRequest(request, response, onRequest)
                 } else {
-                    if (typeof onRequest === "function") {
-                        onRequest(request, response);
-                    }
+                    onRequest(request, response);
                 }
             }
         };

--- a/AutoCollection/HttpRequests.ts
+++ b/AutoCollection/HttpRequests.ts
@@ -119,8 +119,8 @@ class AutoCollectHttpRequests {
                 CorrelationContextManager.wrapEmitter(response);
                 const shouldCollect: boolean = request && !(<any>request)[AutoCollectHttpRequests.alreadyAutoCollectedFlag];
 
-                if (request && shouldCollect) {
-                    AutoCollectHttpRequests.INSTANCE?._registerRequest(request, response, onRequest)
+                if (request && shouldCollect && AutoCollectHttpRequests.INSTANCE) {
+                    AutoCollectHttpRequests.INSTANCE._registerRequest(request, response, onRequest)
                 } else {
                     if (typeof onRequest === "function") {
                         onRequest(request, response);


### PR DESCRIPTION
When the dispose method is called, the static INSTANCE property is set to null, which means there is no query handler (neither the original nor the custom handler).
So I've added a control to call the default handler if the INSTANCE property is set to null

Fix #1195 