### PR TITLE
Minimal fix for #1226

### DIFF
--- a/Library/JsonConfig.ts
+++ b/Library/JsonConfig.ts
@@ -6,6 +6,8 @@ import { IJsonConfig } from "../Declarations/Interfaces";
 import { DistributedTracingModes } from "../applicationinsights";
 import { IDisabledExtendedMetrics } from "../AutoCollection/NativePerformance";
 
+import defaultConfig from '../applicationinsights.json';
+
 const ENV_CONFIGURATION_FILE = "APPLICATIONINSIGHTS_CONFIGURATION_FILE";
 // Azure Connection String
 const ENV_connectionString = "APPLICATIONINSIGHTS_CONNECTION_STRING";
@@ -137,12 +139,14 @@ export class JsonConfig implements IJsonConfig {
                 else {
                     tempDir = path.join(rootPath, configFile);// Relative path to applicationinsights folder
                 }
-            }
-            try {
-                jsonString = fs.readFileSync(tempDir, "utf8");
-            }
-            catch (err) {
-                Logging.warn("Failed to read JSON config file: ", err);
+                try {
+                    jsonString = fs.readFileSync(tempDir, "utf8");
+                }
+                catch (err) {
+                    Logging.warn("Failed to read JSON config file: ", err);
+                }
+            } else {
+                jsonString = JSON.stringify(defaultConfig);
             }
         }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
         "declaration": true,
         "noImplicitAny": true,
         "outDir": "./out",
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
         "typeRoots": [
             "./node_modules/@types",
             "./types"


### PR DESCRIPTION
A minimal fix for trying to load the default configuration during runtime which only exists in the source code. That loading previously failed when the code is bundled. So now the default configuration is already loaded when bundling the code.

Fixes #1226.