### PR TITLE
Elaborate fix for #1226

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
         "declaration": true,
         "noImplicitAny": true,
         "outDir": "./out",
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
         "typeRoots": [
             "./node_modules/@types",
             "./types"


### PR DESCRIPTION
A more elaborate fix for trying to load the default configuration during runtime which only exists in the source code. That loading previously failed when the code is bundled. So now the default configuration is already loaded when bundling the code.

This is a more elaborate fix than #1241. I would prefer this solution but I do not know which style you prefer.

Fixes #1226.