### PR TITLE
Fix error when `_shutdownStatsbeat` gets called while being undefined

### DIFF
--- a/Library/Sender.ts
+++ b/Library/Sender.ts
@@ -34,7 +34,7 @@ class Sender {
 
     private _config: Config;
     private _isStatsbeatSender: boolean;
-    private _shutdownStatsbeat: () => void;
+    private _shutdownStatsbeat?: () => void;
     private _failedToIngestCounter: number;
     private _statsbeatHasReachedIngestionAtLeastOnce: boolean;
     private _statsbeat: Statsbeat;
@@ -200,7 +200,7 @@ class Sender {
                         this._numConsecutiveFailures = 0;
                         if (responseString.includes(INVALID_IKEY) && res.statusCode === 400) {
                             Logging.warn("Instrumentation key was invalid, please check the iKey");
-                            this._shutdownStatsbeat();
+                            this._shutdownStatsbeat?.();
                         }
                         // Handling of Statsbeat instance sending data, should turn it off if is not able to reach ingestion endpoint
                         if (this._isStatsbeatSender && !this._statsbeatHasReachedIngestionAtLeastOnce) {


### PR DESCRIPTION
This PR fixes #1258 issue, a `_shutdownStatsbeat` function should not be called if it is undefined.

The constructor parameter is optional, however, the according class property is not. 
There is a nullability check in one of the methods, but not in the `res.on("end", ...` handler. This causes errors when the callback is not provided.

I've made the class property type nullable as well for convenience, but unfortunately, TS strict mode is turned off in this project. As a result, that kind of nullability issues are not caught by TS.
