### PR TITLE
[Beta] Update Instrumentation Options Type in Docs and Export from Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install applicationinsights@beta
 
 
 ```typescript
-const { useAzureMonitor, AzureMonitorOpenTelemetryOptions } = require("applicationinsights");
+const { useAzureMonitor, AzureMonitorOpenTelemetryOptions, InstrumentationOptions } = require("applicationinsights");
 
 const config : AzureMonitorOpenTelemetryOptions = {
     azureMonitorExporterOptions: {
@@ -101,7 +101,7 @@ const config : AzureMonitorOpenTelemetryOptions = {
         console: { enabled: true},
         bunyan: { enabled: true},
         winston: { enabled: true},
-    },
+    } as InstrumentationOptions,
     resource: resource,
     extendedMetrics:{
         gc: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 export { TelemetryClient } from "./shim/telemetryClient";
-export { AzureMonitorOpenTelemetryOptions } from "./types";
+export { AzureMonitorOpenTelemetryOptions, InstrumentationOptions } from "./types";
 export { KnownSeverityLevel } from "./declarations/generated";
 export {
     AvailabilityTelemetry,


### PR DESCRIPTION
`AzureMonitorOpenTelemetryOptions` extends `DistroOptions` which contains the `InstrumentationOptions` interface, which we cannot modify. Therefore we need to cast `DistroInstrumentationOptions` passed to the shim config by the client to `InstrumentationOptions` which includes the console and winston instrumentation options.

#1269