### PR TITLE
Revert Linux App Service SDK Already Exists Changes

### DIFF
--- a/Bootstrap/Helpers.ts
+++ b/Bootstrap/Helpers.ts
@@ -1,20 +1,13 @@
 import { DiagnosticLog, DiagnosticMessageId } from "./DataModel";
 import { DiagnosticLogger } from "./DiagnosticLogger";
-import { isWindows, isLinux } from "../Library/PrefixHelper";
 
 export function sdkAlreadyExists(_logger: DiagnosticLogger): boolean {
     try {
         // appInstance should either resolve to user SDK or crash. If it resolves to attach SDK, user probably modified their NODE_PATH
         let appInstance: string;
         try {
-            // Node 8.9+ Windows
-            if (isWindows()) {
-                appInstance = (require.resolve as any)("applicationinsights", { paths: [process.cwd()] });
-            }
-            // Node 8.9+ Linux
-            else if (isLinux()) {
-                appInstance = `${process.cwd()}${(require.resolve as any)("applicationinsights", { paths: [process.cwd()] })}`;
-            }
+            // Node 8.9+
+            appInstance = (require.resolve as any)("applicationinsights", { paths: [process.cwd()] });
         } catch (e) {
             // Node <8.9
             appInstance = require.resolve(process.cwd() + "/node_modules/applicationinsights");

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@azure/core-rest-pipeline": "1.10.1",
         "@azure/core-util": "1.2.0",
         "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
-        "@microsoft/applicationinsights-web-snippet": "^1.0.1",
+        "@microsoft/applicationinsights-web-snippet": "1.0.1",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/core": "^1.19.0",
         "@opentelemetry/sdk-trace-base": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
   },
   "dependencies": {
     "@azure/core-auth": "^1.5.0",
-    "@azure/core-util": "1.2.0",
     "@azure/core-rest-pipeline": "1.10.1",
+    "@azure/core-util": "1.2.0",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
-    "@microsoft/applicationinsights-web-snippet": "^1.0.1",
+    "@microsoft/applicationinsights-web-snippet": "1.0.1",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.19.0",
     "@opentelemetry/sdk-trace-base": "^1.19.0",


### PR DESCRIPTION
- Revert bad check for Linux App Service SDK already attached. (#1235)
- Pin version of the web-snippet-loader package.