### PR TITLE
Fix SDK Version Set in the Agent

### DIFF
--- a/Bootstrap/Oryx.ts
+++ b/Bootstrap/Oryx.ts
@@ -3,9 +3,6 @@ import { StatusLogger } from "./StatusLogger";
 import { DiagnosticLogger } from "./DiagnosticLogger";
 import { NoopLogger } from "./NoopLogger";
 import appInsightsLoader = require("./Default");
-import { AttachTypePrefix } from "../Declarations/Constants";
-
-appInsightsLoader.setUsagePrefix(`al${AttachTypePrefix.INTEGRATED_AUTO}_`); // App Services Linux Auto Attach
 
 // Set Status.json logger
 appInsightsLoader.setStatusLogger(new StatusLogger(new NoopLogger()));

--- a/Library/Context.ts
+++ b/Library/Context.ts
@@ -7,6 +7,7 @@ import { APPLICATION_INSIGHTS_SDK_VERSION } from "../Declarations/Constants";
 import Logging = require("./Logging");
 import * as PrefixHelpers from "./PrefixHelper";
 import * as Constants from "../Declarations/Constants";
+import appInsights = require("../Bootstrap/Oryx");
 
 class Context {
 
@@ -67,7 +68,10 @@ class Context {
 
     private _loadInternalContext() {
         Context.sdkVersion = APPLICATION_INSIGHTS_SDK_VERSION;
-        this.tags[this.keys.internalSdkVersion] = `${PrefixHelpers.getResourceProvider()}${PrefixHelpers.getOsPrefix()}${Constants.AttachTypePrefix.MANUAL}_node:${Context.sdkVersion}`
+        // If Context is already set in the bootstrap, don't set it here
+        if (PrefixHelpers.getResourceProvider() === "u") {
+            this.tags[this.keys.internalSdkVersion] = `${PrefixHelpers.getResourceProvider()}${PrefixHelpers.getOsPrefix()}${Constants.AttachTypePrefix.MANUAL}_node:${Context.sdkVersion}`
+        }
     }
 }
 

--- a/Tests/Library/Context.tests.ts
+++ b/Tests/Library/Context.tests.ts
@@ -57,7 +57,7 @@ describe("Library/Context", () => {
             }
         });
 
-        it("should set internalSdkVersion to 'prefix_node:<version>'", () => {
+        it("should set internalSdkVersion to 'prefix_node:<version>' in manual SDK scenarios", () => {
             var context = new Context();
             const packageJsonPath = path.resolve(__dirname, "../../../", "./package.json");
             let packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));


### PR DESCRIPTION
Fixes a bug in the agent (2.10.5) where we would double-set the SDK version in Linux App Service auto-attach scenarios. This change unifies setting the agent version on envelopes in the Default Bootstrap file in auto-attach scenarios, and only sets the SDK version in the Context file if no compatible auto-attach RP environment is detected. 