### PR TITLE
Update How Manual Attach is Checked

### DIFF
--- a/Bootstrap/Default.ts
+++ b/Bootstrap/Default.ts
@@ -15,7 +15,6 @@ let _appInsights: typeof types | null;
 
 export const defaultConfig = new Config(); // Will read env variables, expose for Agent initialization
 let _prefix = `${PrefixHelpers.getResourceProvider()}${PrefixHelpers.getOsPrefix()}${Constants.AttachTypePrefix.INTEGRATED_AUTO}_`;
-Context.sdkPrefix = _prefix;
 let _fullSdkVersion = `${_prefix}node:${Context.sdkVersion}`;
 const _instrumentationKey = defaultConfig.instrumentationKey;
 let _logger: DiagnosticLogger = new DiagnosticLogger(console, _instrumentationKey);
@@ -112,6 +111,7 @@ export function setupAndStart(aadTokenCredential?: azureCoreAuth.TokenCredential
         }
 
         // Instrument the SDK
+        Context.sdkPrefix = _prefix;
         _appInsights.setup();
         const appInsightsSDKVersion = _appInsights.defaultClient.context.keys.internalSdkVersion;
 

--- a/Bootstrap/Default.ts
+++ b/Bootstrap/Default.ts
@@ -12,10 +12,11 @@ import Context = require("../Library/Context");
 
 // Private configuration vars
 let _appInsights: typeof types | null;
-let _prefix = `${PrefixHelpers.getResourceProvider()}${PrefixHelpers.getOsPrefix()}${Constants.AttachTypePrefix.INTEGRATED_AUTO}_`;
-let _fullSdkVersion = `${_prefix}node:${Context.sdkVersion}`;
 
 export const defaultConfig = new Config(); // Will read env variables, expose for Agent initialization
+let _prefix = `${PrefixHelpers.getResourceProvider()}${PrefixHelpers.getOsPrefix()}${Constants.AttachTypePrefix.INTEGRATED_AUTO}_`;
+Context.sdkPrefix = _prefix;
+let _fullSdkVersion = `${_prefix}node:${Context.sdkVersion}`;
 const _instrumentationKey = defaultConfig.instrumentationKey;
 let _logger: DiagnosticLogger = new DiagnosticLogger(console, _instrumentationKey);
 let _statusLogger: StatusLogger = new StatusLogger(console, _instrumentationKey);

--- a/Library/Context.ts
+++ b/Library/Context.ts
@@ -7,7 +7,6 @@ import { APPLICATION_INSIGHTS_SDK_VERSION } from "../Declarations/Constants";
 import Logging = require("./Logging");
 import * as PrefixHelpers from "./PrefixHelper";
 import * as Constants from "../Declarations/Constants";
-import appInsights = require("../Bootstrap/Oryx");
 
 class Context {
 
@@ -15,7 +14,8 @@ class Context {
     public tags: { [key: string]: string };
     public static DefaultRoleName: string = "Web";
     public static appVersion: { [path: string]: string } = {};
-    public static sdkVersion: string = null;
+    public static sdkVersion: string = APPLICATION_INSIGHTS_SDK_VERSION;
+    public static sdkPrefix: string = null;
 
     constructor(packageJsonPath?: string) {
         this.keys = new Contracts.ContextTagKeys();
@@ -67,9 +67,8 @@ class Context {
     }
 
     private _loadInternalContext() {
-        Context.sdkVersion = APPLICATION_INSIGHTS_SDK_VERSION;
         // If Context is already set in the bootstrap, don't set it here
-        if (PrefixHelpers.getResourceProvider() === "u") {
+        if (!Context.sdkPrefix) {
             this.tags[this.keys.internalSdkVersion] = `${PrefixHelpers.getResourceProvider()}${PrefixHelpers.getOsPrefix()}${Constants.AttachTypePrefix.MANUAL}_node:${Context.sdkVersion}`
         }
     }

--- a/Tests/Library/Context.tests.ts
+++ b/Tests/Library/Context.tests.ts
@@ -18,6 +18,8 @@ describe("Library/Context", () => {
             var jsonContent = JSON.stringify({ "version": "testVersion" });
             var testFilePath = path.resolve(__dirname, "testpackage.json");
             fs.writeFile(testFilePath, jsonContent, () => { });
+            // Clear the sdkPrefix in case it's been set by other tests initializing the agent.
+            Context.sdkPrefix = null;
         });
 
         after(() => {


### PR DESCRIPTION
Updated to assume manual attach only in the case that the bootstrapper has not been run instead of when the RP is unknown. This is a more correct check.

Also validated by loading the bootstrapper and ensuring integrated auto versions are reported correctly for all supported RPs.