### PR TITLE
[Beta] Update Warning Tests and Add Console Logging by Default

### DIFF
--- a/src/shim/applicationinsights.ts
+++ b/src/shim/applicationinsights.ts
@@ -32,7 +32,11 @@ export let defaultClient: TelemetryClient;
  * and start the SDK.
  */
 export function setup(setupString?: string) {
-    defaultClient = new TelemetryClient(setupString);
+    if (!defaultClient) {
+        defaultClient = new TelemetryClient(setupString);
+    } else {
+        diag.warn("Setup has already been called once. To set up a new client, please use TelemetryClient instead.");
+    }
     return Configuration;
 }
 

--- a/src/shim/applicationinsights.ts
+++ b/src/shim/applicationinsights.ts
@@ -148,10 +148,10 @@ export class Configuration {
      * @param collectExtendedMetrics if true, extended metrics counters will be collected every minute and sent to Application Insights
      * @returns {Configuration} this class
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars 
     public static setAutoCollectPerformance(value: boolean, collectExtendedMetrics: any) {
         if (defaultClient) {
             defaultClient.config.enableAutoCollectPerformance = value;
-            defaultClient.config.enableAutoCollectExtendedMetrics = collectExtendedMetrics
         }
         return Configuration;
     }

--- a/src/shim/applicationinsights.ts
+++ b/src/shim/applicationinsights.ts
@@ -10,8 +10,6 @@ import { ICorrelationContext, HttpRequest, DistributedTracingModes } from "./typ
 import { TelemetryClient } from "./telemetryClient";
 import * as Contracts from "../declarations/contracts";
 import { Util } from "../shared/util";
-import { useAzureMonitor } from "@azure/monitor-opentelemetry";
-
 
 // We export these imports so that SDK users may use these classes directly.
 // They're exposed using "export import" so that types are passed along as expected
@@ -150,6 +148,7 @@ export class Configuration {
      * @param collectExtendedMetrics if true, extended metrics counters will be collected every minute and sent to Application Insights
      * @returns {Configuration} this class
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars 
     public static setAutoCollectPerformance(value: boolean, collectExtendedMetrics: any) {
         if (defaultClient) {
             defaultClient.config.enableAutoCollectPerformance = value;

--- a/src/shim/applicationinsights.ts
+++ b/src/shim/applicationinsights.ts
@@ -35,7 +35,7 @@ export function setup(setupString?: string) {
     if (!defaultClient) {
         defaultClient = new TelemetryClient(setupString);
     } else {
-        defaultClient.configWarnings.push("Setup has already been called once. To set up a new client, please use TelemetryClient instead.")
+        defaultClient.pushWarningToLog("Setup has already been called once. To set up a new client, please use TelemetryClient instead.")
     }
     return Configuration;
 }
@@ -148,10 +148,10 @@ export class Configuration {
      * @param collectExtendedMetrics if true, extended metrics counters will be collected every minute and sent to Application Insights
      * @returns {Configuration} this class
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars 
     public static setAutoCollectPerformance(value: boolean, collectExtendedMetrics: any) {
         if (defaultClient) {
             defaultClient.config.enableAutoCollectPerformance = value;
+            defaultClient.config.enableAutoCollectExtendedMetrics = collectExtendedMetrics
         }
         return Configuration;
     }

--- a/src/shim/applicationinsights.ts
+++ b/src/shim/applicationinsights.ts
@@ -3,7 +3,7 @@
 
 import * as http from "http";
 import * as azureFunctionsTypes from "@azure/functions";
-import { SpanContext, diag } from "@opentelemetry/api";
+import { DiagConsoleLogger, SpanContext, diag } from "@opentelemetry/api";
 import { Span } from "@opentelemetry/sdk-trace-base";
 import { CorrelationContextManager } from "./correlationContextManager";
 import { ICorrelationContext, HttpRequest, DistributedTracingModes } from "./types";
@@ -35,6 +35,7 @@ export function setup(setupString?: string) {
     if (!defaultClient) {
         defaultClient = new TelemetryClient(setupString);
     } else {
+        diag.setLogger(new DiagConsoleLogger());
         diag.warn("Setup has already been called once. To set up a new client, please use TelemetryClient instead.");
     }
     return Configuration;
@@ -51,6 +52,7 @@ export function start() {
         defaultClient.initialize();
         return Configuration;
     } catch (error) {
+        diag.setLogger(new DiagConsoleLogger());
         diag.warn("The default client has not been initialized. Please make sure to call setup() before start().");
     }
 }

--- a/src/shim/shim-config.ts
+++ b/src/shim/shim-config.ts
@@ -337,8 +337,8 @@ class Config implements IConfig {
         if (this.disableAppInsights) {
             diag.warn("disableAppInsights configuration no longer supported.");
         }
-        if (this.enableAutoCollectHeartbeat) {
-            diag.warn("Heartbeat metris are no longer supported.");
+        if (this.enableAutoCollectHeartbeat === true) {
+            diag.warn("Heartbeat metrics are no longer supported.");
         }
         if (this.enableAutoDependencyCorrelation === false) {
             diag.warn("Auto dependency correlation cannot be turned off anymore.");
@@ -378,6 +378,9 @@ class Config implements IConfig {
         }
         if (this.quickPulseHost) {
             diag.warn("The quickPulseHost configuration option is not suppored by the shim.");
+        }
+        if (this.correlationHeaderExcludedDomains) {
+            diag.warn("The correlationHeaderExcludedDomains configuration option is not supported by the shim.");
         }
         return options;
     }

--- a/src/shim/shim-config.ts
+++ b/src/shim/shim-config.ts
@@ -61,18 +61,20 @@ class Config implements IConfig {
     public noPatchModules: string;
     public noDiagnosticChannel: boolean;
 
+    private _configWarnings: string[];
 
     /**
    * Creates a new Config instance
    * @param setupString Connection String, instrumentationKey is no longer supported here
    */
-    constructor(setupString?: string) {
+    constructor(setupString?: string, configWarnings?: string[]){
         // Load config values from env variables and JSON if available
         this._mergeConfig();
         this.connectionString = setupString;
         this.webInstrumentationConfig = this.webInstrumentationConfig || null;
         this.ignoreLegacyHeaders = true;
         this.webInstrumentationConnectionString = this.webInstrumentationConnectionString || "";
+        this._configWarnings = configWarnings || [];
     }
 
     private _mergeConfig() {
@@ -335,52 +337,51 @@ class Config implements IConfig {
 
         // NOT SUPPORTED CONFIGURATION OPTIONS
         if (this.disableAppInsights) {
-            diag.warn("disableAppInsights configuration no longer supported.");
+            this._configWarnings.push("disableAppInsights configuration no longer supported.");
         }
         if (this.enableAutoCollectHeartbeat === true) {
-            diag.warn("Heartbeat metrics are no longer supported.");
+            this._configWarnings.push("Heartbeat metrics are no longer supported.");
         }
         if (this.enableAutoDependencyCorrelation === false) {
-            diag.warn("Auto dependency correlation cannot be turned off anymore.");
+            this._configWarnings.push("Auto dependency correlation cannot be turned off anymore.");
         }
         if (typeof (this.enableAutoCollectIncomingRequestAzureFunctions) === "boolean") {
-            diag.warn("Auto request generation in Azure Functions is no longer supported.");
+            this._configWarnings.push("Auto request generation in Azure Functions is no longer supported.");
         }
         if (this.enableUseAsyncHooks === false) {
-            diag.warn("The use of non async hooks is no longer supported.");
+            this._configWarnings.push("The use of non async hooks is no longer supported.");
         }
         if (this.distributedTracingMode === DistributedTracingModes.AI) {
-            diag.warn("AI only distributed tracing mode is no longer supported.");
+            this._configWarnings.push("AI only distributed tracing mode is no longer supported.");
         }
         if (this.enableResendInterval) {
-            diag.warn("The resendInterval configuration option is not supported by the shim.");
+            this._configWarnings.push("The resendInterval configuration option is not supported by the shim.");
         }
         if (this.enableMaxBytesOnDisk) {
-            diag.warn("The maxBytesOnDisk configuration option is not supported by the shim.");
+            this._configWarnings.push("The maxBytesOnDisk configuration option is not supported by the shim.");
         }
         if (this.ignoreLegacyHeaders === false) {
-            diag.warn("LegacyHeaders are not supported by the shim.");
+            this._configWarnings.push("LegacyHeaders are not supported by the shim.");
         }
-
         if (this.maxBatchSize) {
-            diag.warn("The maxBatchSize configuration option is not supported by the shim.");
+            this._configWarnings.push("The maxBatchSize configuration option is not supported by the shim.");
         }
         if (this.enableLoggerErrorToTrace) {
-            diag.warn("The enableLoggerErrorToTrace configuration option is not supported by the shim.");
+            this._configWarnings.push("The enableLoggerErrorToTrace configuration option is not supported by the shim.");
         }
         if (this.httpAgent || this.httpsAgent) {
-            diag.warn("The httpAgent and httpsAgent configuration options are not supported by the shim.");
+            this._configWarnings.push("The httpAgent and httpsAgent configuration options are not supported by the shim.");
         }
         if (
             this.webInstrumentationConfig || this.webInstrumentationSrc
         ) {
-            diag.warn("The webInstrumentation config and src options are not supported by the shim.");
+            this._configWarnings.push("The webInstrumentation config and src options are not supported by the shim.");
         }
         if (this.quickPulseHost) {
-            diag.warn("The quickPulseHost configuration option is not suppored by the shim.");
+            this._configWarnings.push("The quickPulseHost configuration option is not supported by the shim.");
         }
         if (this.correlationHeaderExcludedDomains) {
-            diag.warn("The correlationHeaderExcludedDomains configuration option is not supported by the shim.");
+            this._configWarnings.push("The correlationHeaderExcludedDomains configuration option is not supported by the shim.");
         }
         return options;
     }

--- a/src/shim/telemetryClient.ts
+++ b/src/shim/telemetryClient.ts
@@ -30,14 +30,14 @@ export class TelemetryClient {
     public commonProperties: { [key: string]: string };
     public config: Config;
     private _options: AzureMonitorOpenTelemetryOptions;
-    private _configWarnings: string[] = [];
+    public configWarnings: string[] = [];
 
     /**
      * Constructs a new instance of TelemetryClient
      * @param setupString the Connection String or Instrumentation Key to use (read from environment variable if not specified)
      */
     constructor(input?: string) {
-        const config = new Config(input, this._configWarnings);
+        const config = new Config(input, this.configWarnings);
         this.config = config;
         this.commonProperties = {};
         this.context = new Context();
@@ -60,8 +60,8 @@ export class TelemetryClient {
             (logs.getLoggerProvider() as LoggerProvider).addLogRecordProcessor(this._attributeLogProcessor);
 
             // Warn if any config warnings were generated during parsing
-            for (let i = 0; i < this._configWarnings.length; i++) {
-                diag.warn(this._configWarnings[i]);
+            for (let i = 0; i < this.configWarnings.length; i++) {
+                diag.warn(this.configWarnings[i]);
                 this._attributeLogProcessor = new AttributeLogProcessor({ ...this.context.tags, ...this.commonProperties });
                 (logs.getLoggerProvider() as LoggerProvider).addLogRecordProcessor(this._attributeLogProcessor);
             }

--- a/src/shim/telemetryClient.ts
+++ b/src/shim/telemetryClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Attributes, context, metrics, ProxyTracerProvider, SpanKind, SpanOptions, SpanStatusCode, diag, trace } from "@opentelemetry/api";
+import { Attributes, context, metrics, ProxyTracerProvider, SpanKind, SpanOptions, SpanStatusCode, diag, trace, DiagConsoleLogger } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
 import { LoggerProvider } from "@opentelemetry/sdk-logs";
 import { SemanticAttributes } from "@opentelemetry/semantic-conventions";

--- a/src/shim/telemetryClient.ts
+++ b/src/shim/telemetryClient.ts
@@ -30,14 +30,14 @@ export class TelemetryClient {
     public commonProperties: { [key: string]: string };
     public config: Config;
     private _options: AzureMonitorOpenTelemetryOptions;
+    private _configWarnings: string[] = [];
 
     /**
      * Constructs a new instance of TelemetryClient
      * @param setupString the Connection String or Instrumentation Key to use (read from environment variable if not specified)
      */
     constructor(input?: string) {
-        diag.setLogger(new DiagConsoleLogger());
-        const config = new Config(input);
+        const config = new Config(input, this._configWarnings);
         this.config = config;
         this.commonProperties = {};
         this.context = new Context();
@@ -57,6 +57,11 @@ export class TelemetryClient {
 
         this._attributeLogProcessor = new AttributeLogProcessor({ ...this.context.tags, ...this.commonProperties });
         (logs.getLoggerProvider() as LoggerProvider).addLogRecordProcessor(this._attributeLogProcessor);
+
+        // Warn if any config warnings were generated during parsing
+        for (let i = 0; i < this._configWarnings.length; i++) {
+            diag.warn(this._configWarnings[i]);
+        }
     }
 
     /**

--- a/src/shim/telemetryClient.ts
+++ b/src/shim/telemetryClient.ts
@@ -36,6 +36,7 @@ export class TelemetryClient {
      * @param setupString the Connection String or Instrumentation Key to use (read from environment variable if not specified)
      */
     constructor(input?: string) {
+        diag.setLogger(new DiagConsoleLogger());
         const config = new Config(input);
         this.config = config;
         this.commonProperties = {};

--- a/test/unitTests/shim/applicationInsights.tests.ts
+++ b/test/unitTests/shim/applicationInsights.tests.ts
@@ -23,7 +23,7 @@ describe("ApplicationInsights", () => {
     describe("#setup()", () => {
         it("should not warn if setup is called once", (done) => {
             appInsights.setup(connString);
-            const warnings = appInsights.defaultClient.configWarnings;
+            const warnings = appInsights.defaultClient["_configWarnings"];
             assert.ok(!checkWarnings("Setup has already been called once", warnings), "setup warning was incorrectly raised");
             done();
         });
@@ -63,7 +63,7 @@ describe("ApplicationInsights", () => {
 
         it("should not warn if start is called after setup", () => {
             appInsights.setup(connString).start();
-            const warnings = appInsights.defaultClient.configWarnings;
+            const warnings = appInsights.defaultClient["_configWarnings"];
             assert.ok(!checkWarnings("Start cannot be called before setup. Please call setup() first.", warnings), "warning was thrown when start was called correctly");
         });
     });
@@ -104,7 +104,7 @@ describe("ApplicationInsights", () => {
         describe("#Configuration", () => {
             it("should throw warning if attempting to set AI distributed tracing mode to AI", () => {
                 appInsights.setup(connString);
-                const warnings = appInsights.defaultClient.configWarnings;
+                const warnings = appInsights.defaultClient["_configWarnings"];
                 appInsights.Configuration.setDistributedTracingMode(appInsights.DistributedTracingModes.AI);
                 appInsights.start();
                 assert.ok(checkWarnings("AI only distributed tracing mode is no longer supported.", warnings), "warning was not raised");
@@ -112,7 +112,7 @@ describe("ApplicationInsights", () => {
 
             it("should warn if attempting to set auto collection of heartbeat", () => {
                 appInsights.setup(connString);
-                const warnings = appInsights.defaultClient.configWarnings;
+                const warnings = appInsights.defaultClient["_configWarnings"];
                 appInsights.Configuration.setAutoCollectHeartbeat(true);
                 appInsights.start();
                 assert.ok(checkWarnings("Heartbeat metrics are no longer supported.", warnings), "warning was not raised");
@@ -120,7 +120,7 @@ describe("ApplicationInsights", () => {
 
             it("should warn if attempting to set maxBytesOnDisk", () => {
                 appInsights.setup(connString);
-                const warnings = appInsights.defaultClient.configWarnings;
+                const warnings = appInsights.defaultClient["_configWarnings"];
                 appInsights.Configuration.setUseDiskRetryCaching(true, 1000, 10);
                 appInsights.start();
                 assert.ok(checkWarnings("The maxBytesOnDisk configuration option is not supported by the shim.", warnings), "warning was not raised");
@@ -135,7 +135,7 @@ describe("ApplicationInsights", () => {
 
             it("should warn if attempting to auto collect incoming azure functions requests", () => {
                 appInsights.setup(connString);
-                const warnings = appInsights.defaultClient.configWarnings;
+                const warnings = appInsights.defaultClient["_configWarnings"];
                 appInsights.Configuration.setAutoCollectIncomingRequestAzureFunctions(true);
                 appInsights.start();
                 assert.ok(checkWarnings("Auto request generation in Azure Functions is no longer supported.", warnings), "warning was not raised");

--- a/test/unitTests/shim/applicationInsights.tests.ts
+++ b/test/unitTests/shim/applicationInsights.tests.ts
@@ -23,7 +23,7 @@ describe("ApplicationInsights", () => {
     describe("#setup()", () => {
         it("should not warn if setup is called once", (done) => {
             appInsights.setup(connString);
-            const warnings = appInsights.defaultClient["_configWarnings"];
+            const warnings = appInsights.defaultClient.configWarnings;
             assert.ok(!checkWarnings("Setup has already been called once", warnings), "setup warning was incorrectly raised");
             done();
         });
@@ -54,7 +54,7 @@ describe("ApplicationInsights", () => {
             const warnStub = sandbox.stub(diag, "warn");
             appInsights.start();
             warnStub.args.forEach((arg) => {
-                if (arg.includes("The default client has not been initialized. Please make sure to call setup() before start().")) {
+                if (arg.includes("Start cannot be called before setup. Please call setup() first.")) {
                     assert.ok(true, "setup warning was not raised");
                 }
             });
@@ -63,8 +63,8 @@ describe("ApplicationInsights", () => {
 
         it("should not warn if start is called after setup", () => {
             appInsights.setup(connString).start();
-            const warnings = appInsights.defaultClient["_configWarnings"];
-            assert.ok(!checkWarnings("The default client has not been initialized. Please make sure to call setup() before start().", warnings), "warning was thrown when start was called correctly");
+            const warnings = appInsights.defaultClient.configWarnings;
+            assert.ok(!checkWarnings("Start cannot be called before setup. Please call setup() first.", warnings), "warning was thrown when start was called correctly");
         });
     });
 
@@ -104,7 +104,7 @@ describe("ApplicationInsights", () => {
         describe("#Configuration", () => {
             it("should throw warning if attempting to set AI distributed tracing mode to AI", () => {
                 appInsights.setup(connString);
-                const warnings = appInsights.defaultClient["_configWarnings"];
+                const warnings = appInsights.defaultClient.configWarnings;
                 appInsights.Configuration.setDistributedTracingMode(appInsights.DistributedTracingModes.AI);
                 appInsights.start();
                 assert.ok(checkWarnings("AI only distributed tracing mode is no longer supported.", warnings), "warning was not raised");
@@ -112,7 +112,7 @@ describe("ApplicationInsights", () => {
 
             it("should warn if attempting to set auto collection of heartbeat", () => {
                 appInsights.setup(connString);
-                const warnings = appInsights.defaultClient["_configWarnings"];
+                const warnings = appInsights.defaultClient.configWarnings;
                 appInsights.Configuration.setAutoCollectHeartbeat(true);
                 appInsights.start();
                 assert.ok(checkWarnings("Heartbeat metrics are no longer supported.", warnings), "warning was not raised");
@@ -120,7 +120,7 @@ describe("ApplicationInsights", () => {
 
             it("should warn if attempting to set maxBytesOnDisk", () => {
                 appInsights.setup(connString);
-                const warnings = appInsights.defaultClient["_configWarnings"];
+                const warnings = appInsights.defaultClient.configWarnings;
                 appInsights.Configuration.setUseDiskRetryCaching(true, 1000, 10);
                 appInsights.start();
                 assert.ok(checkWarnings("The maxBytesOnDisk configuration option is not supported by the shim.", warnings), "warning was not raised");
@@ -135,7 +135,7 @@ describe("ApplicationInsights", () => {
 
             it("should warn if attempting to auto collect incoming azure functions requests", () => {
                 appInsights.setup(connString);
-                const warnings = appInsights.defaultClient["_configWarnings"];
+                const warnings = appInsights.defaultClient.configWarnings;
                 appInsights.Configuration.setAutoCollectIncomingRequestAzureFunctions(true);
                 appInsights.start();
                 assert.ok(checkWarnings("Auto request generation in Azure Functions is no longer supported.", warnings), "warning was not raised");

--- a/test/unitTests/shim/applicationInsights.tests.ts
+++ b/test/unitTests/shim/applicationInsights.tests.ts
@@ -22,25 +22,25 @@ describe("ApplicationInsights", () => {
 
     describe("#setup()", () => {
         it("should not warn if setup is called once", (done) => {
-            const warnStub = sandbox.stub(diag, "warn");
             appInsights.setup(connString);
-            for (let i = 0; i < warnStub.args.length; i++) {
-                if (warnStub.args[i].includes("Setup has already been called once")) {
-                    assert.ok(false, `setup warning was incorrectly raised: ${warnStub.args[i]}`);
-                }
-            }
+            const warnings = appInsights.defaultClient["_configWarnings"];
+            assert.ok(!checkWarnings("Setup has already been called once", warnings), "setup warning was incorrectly raised");
             done();
         });
         it("should warn if setup is called twice", (done) => {
             const warnStub = sandbox.stub(diag, "warn");
             appInsights.setup(connString);
             appInsights.setup(connString);
-            assert.ok(checkWarnings("Setup has already been called once", warnStub), "multiple setup warning not raised");
+            warnStub.args.forEach((arg) => {
+                if (arg.includes("Setup has already been called once")) {
+                    assert.ok(true, "setup warning was not raised");
+                }
+            });
             done();
         });
         it("should not overwrite default client if called more than once", (done) => {
             appInsights.setup(connString);
-            var client = appInsights.defaultClient;
+            const client = appInsights.defaultClient;
             appInsights.setup(connString);
             appInsights.setup(connString);
             appInsights.setup(connString);
@@ -53,14 +53,18 @@ describe("ApplicationInsights", () => {
         it("should warn if start is called before setup", (done) => {
             const warnStub = sandbox.stub(diag, "warn");
             appInsights.start();
-            assert.ok(checkWarnings("The default client has not been initialized. Please make sure to call setup() before start().", warnStub), "start before setup warning not called");
+            warnStub.args.forEach((arg) => {
+                if (arg.includes("The default client has not been initialized. Please make sure to call setup() before start().")) {
+                    assert.ok(true, "setup warning was not raised");
+                }
+            });
             done();
         });
 
         it("should not warn if start is called after setup", () => {
-            var warnStub = sandbox.stub(diag, "warn");
             appInsights.setup(connString).start();
-            assert.ok(!checkWarnings("The default client has not been initialized. Please make sure to call setup() before start().", warnStub), "warning was thrown when start was called correctly");
+            const warnings = appInsights.defaultClient["_configWarnings"];
+            assert.ok(!checkWarnings("The default client has not been initialized. Please make sure to call setup() before start().", warnings), "warning was thrown when start was called correctly");
         });
     });
 
@@ -99,27 +103,27 @@ describe("ApplicationInsights", () => {
 
         describe("#Configuration", () => {
             it("should throw warning if attempting to set AI distributed tracing mode to AI", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 appInsights.setup(connString);
+                const warnings = appInsights.defaultClient["_configWarnings"];
                 appInsights.Configuration.setDistributedTracingMode(appInsights.DistributedTracingModes.AI);
                 appInsights.start();
-                assert.ok(checkWarnings("AI only distributed tracing mode is no longer supported.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("AI only distributed tracing mode is no longer supported.", warnings), "warning was not raised");
             });
 
             it("should warn if attempting to set auto collection of heartbeat", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 appInsights.setup(connString);
+                const warnings = appInsights.defaultClient["_configWarnings"];
                 appInsights.Configuration.setAutoCollectHeartbeat(true);
                 appInsights.start();
-                assert.ok(checkWarnings("Heartbeat metrics are no longer supported.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("Heartbeat metrics are no longer supported.", warnings), "warning was not raised");
             });
 
             it("should warn if attempting to set maxBytesOnDisk", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 appInsights.setup(connString);
+                const warnings = appInsights.defaultClient["_configWarnings"];
                 appInsights.Configuration.setUseDiskRetryCaching(true, 1000, 10);
                 appInsights.start();
-                assert.ok(checkWarnings("The maxBytesOnDisk configuration option is not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The maxBytesOnDisk configuration option is not supported by the shim.", warnings), "warning was not raised");
             });
 
             it("should set internal loggers", () => {
@@ -130,11 +134,11 @@ describe("ApplicationInsights", () => {
             });
 
             it("should warn if attempting to auto collect incoming azure functions requests", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 appInsights.setup(connString);
+                const warnings = appInsights.defaultClient["_configWarnings"];
                 appInsights.Configuration.setAutoCollectIncomingRequestAzureFunctions(true);
                 appInsights.start();
-                assert.ok(checkWarnings("Auto request generation in Azure Functions is no longer supported.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("Auto request generation in Azure Functions is no longer supported.", warnings), "warning was not raised");
             });
         });
     });

--- a/test/unitTests/shim/config.tests.ts
+++ b/test/unitTests/shim/config.tests.ts
@@ -9,6 +9,8 @@ import { TelemetryClient } from "../../../src/shim/telemetryClient";
 import http = require("http");
 import https = require("https");
 import { DistributedTracingModes } from '../../../applicationinsights';
+import { checkWarnings } from './testUtils';
+import { diag } from '@opentelemetry/api';
 
 
 class TestTokenCredential implements azureCoreAuth.TokenCredential {
@@ -224,127 +226,117 @@ describe("shim/configuration/config", () => {
 
         describe("#Shim unsupported messages", () => {
             it("should warn if disableAppInsights is set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.disableAppInsights = true;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("disableAppInsights configuration no longer supported.", warnStub), "warning was not raised");
             });
 
             it("should warn if collect heartbeat is set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.enableAutoCollectHeartbeat = true;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("Heartbeat metrics are no longer supported.", warnStub), "warning was not raised");
             });
 
             it("should warn if auto dependency correlation is set to false", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.enableAutoDependencyCorrelation = false;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("Auto dependency correlation cannot be turned off anymore.", warnStub), "warning was not raised");
             });
 
             it("should warn if auto request generation is azure functions is set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.enableAutoCollectIncomingRequestAzureFunctions = true;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
-            });
-
-            it("should warn if live metrics is set", () => {
-                const warnStub = sandbox.stub(console, "warn");
-                const config = new Config(connectionString);
-                config.enableSendLiveMetrics = true;
-                config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("Auto request generation in Azure Functions is no longer supported.", warnStub), "warning was not raised");
             });
 
             it("should warn if using async hooks is set to false", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.enableUseAsyncHooks = false;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("The use of non async hooks is no longer supported.", warnStub), "warning was not raised");
             });
 
             it("should warn if distributed tracing mode is set to AI", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.distributedTracingMode = DistributedTracingModes.AI;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("AI only distributed tracing mode is no longer supported.", warnStub), "warning was not raised");
             });
 
             it("should warn if resend interval is set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.enableResendInterval = 1;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("The resendInterval configuration option is not supported by the shim.", warnStub), "warning was not raised");
             });
 
             it("should warn if max bytes on disk is set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.enableMaxBytesOnDisk = 1;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("The maxBytesOnDisk configuration option is not supported by the shim.", warnStub), "warning was not raised");
             });
 
             it("should warn if ignore legacy headers is false", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.ignoreLegacyHeaders = false;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("LegacyHeaders are not supported by the shim.", warnStub), "warning was not raised");
             });
 
             it("should warn if max batch size is set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.maxBatchSize = 1;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("The maxBatchSize configuration option is not supported by the shim.", warnStub), "warning was not raised");
             });
 
             it("should warn if logger errors are set to traces", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.enableLoggerErrorToTrace = true;
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("The enableLoggerErrorToTrace configuration option is not supported by the shim.", warnStub), "warning was not raised");
             });
 
             it("should warn if httpAgent or httpsAgent are set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.httpAgent = new http.Agent();
                 config.httpsAgent = new https.Agent();
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("The httpAgent and httpsAgent configuration options are not supported by the shim.", warnStub), "warning was not raised");
             });
 
             it("should warn if web instrumentations are set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
-                config.enableWebInstrumentation = true;
                 config.webInstrumentationConfig = [{name: "test", value: true}];
                 config.webInstrumentationSrc = "test";
-                config.webInstrumentationConnectionString = "test";
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("The webInstrumentation config and src options are not supported by the shim.", warnStub), "warning was not raised");
             });
 
             it("should warn if correlationHeaderExcludedDomains is set", () => {
-                const warnStub = sandbox.stub(console, "warn");
+                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
                 config.correlationHeaderExcludedDomains = ["test.com"];
                 config.parseConfig();
-                assert.ok(warnStub.calledOn, "warning was not raised");
+                assert.ok(checkWarnings("The correlationHeaderExcludedDomains configuration option is not supported by the shim.", warnStub), "warning was not raised");
             });
         });
     });

--- a/test/unitTests/shim/config.tests.ts
+++ b/test/unitTests/shim/config.tests.ts
@@ -10,8 +10,6 @@ import http = require("http");
 import https = require("https");
 import { DistributedTracingModes } from '../../../applicationinsights';
 import { checkWarnings } from './testUtils';
-import { diag } from '@opentelemetry/api';
-
 
 class TestTokenCredential implements azureCoreAuth.TokenCredential {
     private _expiresOn: Date;
@@ -226,117 +224,117 @@ describe("shim/configuration/config", () => {
 
         describe("#Shim unsupported messages", () => {
             it("should warn if disableAppInsights is set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.disableAppInsights = true;
                 config.parseConfig();
-                assert.ok(checkWarnings("disableAppInsights configuration no longer supported.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("disableAppInsights configuration no longer supported.", warnings), "warning was not raised");
             });
 
             it("should warn if collect heartbeat is set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.enableAutoCollectHeartbeat = true;
                 config.parseConfig();
-                assert.ok(checkWarnings("Heartbeat metrics are no longer supported.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("Heartbeat metrics are no longer supported.", warnings), "warning was not raised");
             });
 
             it("should warn if auto dependency correlation is set to false", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.enableAutoDependencyCorrelation = false;
                 config.parseConfig();
-                assert.ok(checkWarnings("Auto dependency correlation cannot be turned off anymore.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("Auto dependency correlation cannot be turned off anymore.", warnings), "warning was not raised");
             });
 
             it("should warn if auto request generation is azure functions is set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.enableAutoCollectIncomingRequestAzureFunctions = true;
                 config.parseConfig();
-                assert.ok(checkWarnings("Auto request generation in Azure Functions is no longer supported.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("Auto request generation in Azure Functions is no longer supported.", warnings), "warning was not raised");
             });
 
             it("should warn if using async hooks is set to false", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.enableUseAsyncHooks = false;
                 config.parseConfig();
-                assert.ok(checkWarnings("The use of non async hooks is no longer supported.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The use of non async hooks is no longer supported.", warnings), "warning was not raised");
             });
 
             it("should warn if distributed tracing mode is set to AI", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.distributedTracingMode = DistributedTracingModes.AI;
                 config.parseConfig();
-                assert.ok(checkWarnings("AI only distributed tracing mode is no longer supported.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("AI only distributed tracing mode is no longer supported.", warnings), "warning was not raised");
             });
 
             it("should warn if resend interval is set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.enableResendInterval = 1;
                 config.parseConfig();
-                assert.ok(checkWarnings("The resendInterval configuration option is not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The resendInterval configuration option is not supported by the shim.", warnings), "warning was not raised");
             });
 
             it("should warn if max bytes on disk is set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.enableMaxBytesOnDisk = 1;
                 config.parseConfig();
-                assert.ok(checkWarnings("The maxBytesOnDisk configuration option is not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The maxBytesOnDisk configuration option is not supported by the shim.", warnings), "warning was not raised");
             });
 
             it("should warn if ignore legacy headers is false", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.ignoreLegacyHeaders = false;
                 config.parseConfig();
-                assert.ok(checkWarnings("LegacyHeaders are not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("LegacyHeaders are not supported by the shim.", warnings), "warning was not raised");
             });
 
             it("should warn if max batch size is set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.maxBatchSize = 1;
                 config.parseConfig();
-                assert.ok(checkWarnings("The maxBatchSize configuration option is not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The maxBatchSize configuration option is not supported by the shim.", warnings), "warning was not raised");
             });
 
             it("should warn if logger errors are set to traces", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.enableLoggerErrorToTrace = true;
                 config.parseConfig();
-                assert.ok(checkWarnings("The enableLoggerErrorToTrace configuration option is not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The enableLoggerErrorToTrace configuration option is not supported by the shim.", warnings), "warning was not raised");
             });
 
             it("should warn if httpAgent or httpsAgent are set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.httpAgent = new http.Agent();
                 config.httpsAgent = new https.Agent();
                 config.parseConfig();
-                assert.ok(checkWarnings("The httpAgent and httpsAgent configuration options are not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The httpAgent and httpsAgent configuration options are not supported by the shim.", warnings), "warning was not raised");
             });
 
             it("should warn if web instrumentations are set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.webInstrumentationConfig = [{name: "test", value: true}];
                 config.webInstrumentationSrc = "test";
                 config.parseConfig();
-                assert.ok(checkWarnings("The webInstrumentation config and src options are not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The webInstrumentation config and src options are not supported by the shim.", warnings), "warning was not raised");
             });
 
             it("should warn if correlationHeaderExcludedDomains is set", () => {
-                const warnStub = sandbox.stub(diag, "warn");
                 const config = new Config(connectionString);
+                const warnings = config["_configWarnings"];
                 config.correlationHeaderExcludedDomains = ["test.com"];
                 config.parseConfig();
-                assert.ok(checkWarnings("The correlationHeaderExcludedDomains configuration option is not supported by the shim.", warnStub), "warning was not raised");
+                assert.ok(checkWarnings("The correlationHeaderExcludedDomains configuration option is not supported by the shim.", warnings), "warning was not raised");
             });
         });
     });

--- a/test/unitTests/shim/testUtils.ts
+++ b/test/unitTests/shim/testUtils.ts
@@ -1,8 +1,8 @@
-export function checkWarnings(warning: string, warnStub: sinon.SinonStub) {
+export function checkWarnings(warning: string, warnings: string[]) {
     let expectedWarning: any;
-    for (let i = 0; i < warnStub.args.length; i++) {
-        if (warnStub.args[i].toString().includes(warning)) {
-            expectedWarning = warnStub.args[i];
+    for (let i = 0; i < warnings.length; i++) {
+        if (warnings[i].toString().includes(warning)) {
+            expectedWarning = warnings[i];
         }
     }
     return expectedWarning;

--- a/test/unitTests/shim/testUtils.ts
+++ b/test/unitTests/shim/testUtils.ts
@@ -1,0 +1,9 @@
+export function checkWarnings(warning: string, warnStub: sinon.SinonStub) {
+    let expectedWarning: any;
+    for (let i = 0; i < warnStub.args.length; i++) {
+        if (warnStub.args[i].toString().includes(warning)) {
+            expectedWarning = warnStub.args[i];
+        }
+    }
+    return expectedWarning;
+}


### PR DESCRIPTION
* Fixes our console warning tests to be updated using the `diag` logger from OTel.
* Automatically sets the default logger in the shim to the console.