### PR TITLE
Add Collection of Metrics when Measurements are passed to Events

### DIFF
--- a/src/shim/logsApi.ts
+++ b/src/shim/logsApi.ts
@@ -19,6 +19,7 @@ import {
 } from "../declarations/generated";
 import { Util } from "../shared/util";
 import { parseStack } from "../logs/exceptions";
+import { defaultClient } from "./applicationinsights";
 
 /**
  * Log manual API to generate Application Insights telemetry
@@ -104,6 +105,14 @@ export class LogApi {
         try {
             const logRecord = this._eventToLogRecord(telemetry);
             this._logger.emit(logRecord);
+            if (Object.keys(telemetry.measurements).length > 0) {
+                for (const [key, value] of Object.entries(telemetry.measurements)) {
+                    defaultClient.trackMetric({
+                        name: key,
+                        value: value,
+                    });
+                }
+            }
         } catch (err) {
             diag.error("Failed to send telemetry.", err);
         }

--- a/test/unitTests/shim/telemetryClient.tests.ts
+++ b/test/unitTests/shim/telemetryClient.tests.ts
@@ -57,10 +57,10 @@ describe("shim/TelemetryClient", () => {
     });
 
 
-    after(() => {
+    after(async () => {
         nock.cleanAll();
         nock.enableNetConnect();
-        client.shutdown();
+        await client.shutdown();
     });
 
     class TestSpanProcessor implements SpanProcessor {


### PR DESCRIPTION
* When one or more measurements are passed to manual `.trackEvent()` calls, we should collect those as individual metrics.
* Added tests to ensure that metrics are created when measurements are passed. 