### PR TITLE
Update Sampling Percentage to Accept 0 as Valid

### DIFF
--- a/src/shared/configuration/config.ts
+++ b/src/shared/configuration/config.ts
@@ -112,6 +112,7 @@ export class ApplicationInsightsConfig {
             if (typeof(options.samplingRatio) === "number") {
                 this.samplingRatio = options.samplingRatio;
             }
+            this.samplingRatio = options.samplingRatio !== undefined ? options.samplingRatio : this.samplingRatio;
 
             // Set console logging level from env var
             if (process.env[loggingLevel]) { 

--- a/src/shared/configuration/config.ts
+++ b/src/shared/configuration/config.ts
@@ -109,7 +109,9 @@ export class ApplicationInsightsConfig {
                 options.instrumentationOptions
             );
             this.resource = Object.assign(this.resource, options.resource);
-            this.samplingRatio = options.samplingRatio || this.samplingRatio;
+            if (typeof(options.samplingRatio) === "number") {
+                this.samplingRatio = options.samplingRatio;
+            }
 
             // Set console logging level from env var
             if (process.env[loggingLevel]) { 

--- a/src/shared/configuration/config.ts
+++ b/src/shared/configuration/config.ts
@@ -109,9 +109,6 @@ export class ApplicationInsightsConfig {
                 options.instrumentationOptions
             );
             this.resource = Object.assign(this.resource, options.resource);
-            if (typeof(options.samplingRatio) === "number") {
-                this.samplingRatio = options.samplingRatio;
-            }
             this.samplingRatio = options.samplingRatio !== undefined ? options.samplingRatio : this.samplingRatio;
 
             // Set console logging level from env var

--- a/src/shim/shim-config.ts
+++ b/src/shim/shim-config.ts
@@ -151,7 +151,7 @@ class Config implements IConfig {
             ...options.instrumentationOptions,
             console: { enabled: false },
         };
-        if (typeof(this.samplingPercentage) === "number") {
+        if (this.samplingPercentage !== undefined) {
             options.samplingRatio = this.samplingPercentage / 100;
         }
         options.instrumentationOptions = {

--- a/src/shim/shim-config.ts
+++ b/src/shim/shim-config.ts
@@ -156,7 +156,7 @@ class Config implements IConfig {
             options.samplingRatio = samplingRatio;
         } else {
             options.samplingRatio = 1;
-            this._configWarnings.push(`Sampling percentage should be between 0 and 100. Defaulting to 100.`);
+            this._configWarnings.push("Sampling percentage should be between 0 and 100. Defaulting to 100.");
         }
         options.instrumentationOptions = {
             ...options.instrumentationOptions,

--- a/src/shim/shim-config.ts
+++ b/src/shim/shim-config.ts
@@ -151,7 +151,7 @@ class Config implements IConfig {
             ...options.instrumentationOptions,
             console: { enabled: false },
         };
-        if (this.samplingPercentage) {
+        if (typeof(this.samplingPercentage) === "number") {
             options.samplingRatio = this.samplingPercentage / 100;
         }
         options.instrumentationOptions = {

--- a/src/shim/shim-config.ts
+++ b/src/shim/shim-config.ts
@@ -151,8 +151,12 @@ class Config implements IConfig {
             ...options.instrumentationOptions,
             console: { enabled: false },
         };
-        if (this.samplingPercentage !== undefined) {
-            options.samplingRatio = this.samplingPercentage / 100;
+        const samplingRatio = this.samplingPercentage / 100;
+        if (samplingRatio >= 0 && samplingRatio <= 1) {
+            options.samplingRatio = samplingRatio;
+        } else {
+            options.samplingRatio = 1;
+            this._configWarnings.push(`Sampling percentage should be between 0 and 100. Defaulting to 100.`);
         }
         options.instrumentationOptions = {
             ...options.instrumentationOptions,

--- a/test/unitTests/shim/config.tests.ts
+++ b/test/unitTests/shim/config.tests.ts
@@ -102,6 +102,15 @@ describe("shim/configuration/config", () => {
             assert.equal(options.azureMonitorExporterOptions.disableOfflineStorage, false, "wrong disableOfflineStorage");
         });
 
+        it("should initialize zero sampling percentage", () => {
+            const config = new Config(connectionString);
+            config.samplingPercentage = 0;
+
+            let options = config.parseConfig();
+
+            assert.equal(options.samplingRatio, 0, "wrong samplingRatio");
+        });
+
         it("should activate DEBUG internal logger", () => {
             const env = <{ [id: string]: string }>{};
             process.env = env;

--- a/test/unitTests/shim/config.tests.ts
+++ b/test/unitTests/shim/config.tests.ts
@@ -210,6 +210,14 @@ describe("shim/configuration/config", () => {
             assert.equal(process.env["APPLICATION_INSIGHTS_NO_STANDARD_METRICS"], "disable");
         });
 
+        it("should warn if an invalid sampling percentage is passed in", () => {
+            const config = new Config(connectionString);
+            const warnings = config["_configWarnings"];
+            config.samplingPercentage = 101;
+            config.parseConfig();
+            assert.ok(checkWarnings("Sampling percentage should be between 0 and 100. Defaulting to 100.", warnings), "warning was not raised");
+        });
+
         describe("#Shim unsupported messages", () => {
             it("should warn if disableAppInsights is set", () => {
                 const config = new Config(connectionString);


### PR DESCRIPTION
* Previously setting the sampling percentage as 0 would actually set sampling to 1 as 0 is falsy and would revert to the default value of the sampling percentage.

Resolves #1336 