### PR TITLE
Update Live Metrics to be on by Default

### DIFF
--- a/src/agent/agentLoader.ts
+++ b/src/agent/agentLoader.ts
@@ -47,6 +47,7 @@ export class AgentLoader {
                 enableAutoCollectExceptions: true,
                 enableAutoCollectPerformance: true,
                 samplingRatio: 1, // Sample all telemetry by default
+                enableLiveMetrics: true,
                 instrumentationOptions: {
                     azureSdk: {
                         enabled: true

--- a/src/agent/appServicesLoader.ts
+++ b/src/agent/appServicesLoader.ts
@@ -4,7 +4,10 @@
 import * as os from 'os';
 import * as path from 'path';
 import { Attributes } from '@opentelemetry/api';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+    SEMRESATTRS_SERVICE_NAME,
+    SEMRESATTRS_SERVICE_INSTANCE_ID,
+} from '@opentelemetry/semantic-conventions';
 import { Resource } from '@opentelemetry/resources';
 import { DiagnosticLogger } from './diagnostics/diagnosticLogger';
 import { FileWriter } from "./diagnostics/writers/fileWriter";
@@ -19,11 +22,11 @@ export class AppServicesLoader extends AgentLoader {
             // Azure App Services specific configuration
             const resourceAttributes: Attributes = {};
             if (process.env.WEBSITE_SITE_NAME) {
-                resourceAttributes[SemanticResourceAttributes.SERVICE_NAME] =
+                resourceAttributes[SEMRESATTRS_SERVICE_NAME] =
                     process.env.WEBSITE_SITE_NAME;
             }
             if (process.env.WEBSITE_INSTANCE_ID) {
-                resourceAttributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID] =
+                resourceAttributes[SEMRESATTRS_SERVICE_INSTANCE_ID] =
                     process.env.WEBSITE_INSTANCE_ID;
             }
             const resource = new Resource(resourceAttributes);

--- a/src/agent/azureFunctionsLoader.ts
+++ b/src/agent/azureFunctionsLoader.ts
@@ -7,7 +7,10 @@ import { DiagnosticLogger } from "./diagnostics/diagnosticLogger";
 import { StatusLogger } from "./diagnostics/statusLogger";
 import { AzureFunctionsWriter } from "./diagnostics/writers/azureFunctionsWriter";
 import { Attributes } from "@opentelemetry/api";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import {
+    SEMRESATTRS_SERVICE_NAME,
+    SEMRESATTRS_SERVICE_INSTANCE_ID,
+} from "@opentelemetry/semantic-conventions"
 
 export class AzureFunctionsLoader extends AgentLoader {
     
@@ -19,11 +22,11 @@ export class AzureFunctionsLoader extends AgentLoader {
             process.env["APPLICATION_INSIGHTS_NO_STANDARD_METRICS"] = "disable";
             const resourceAttributes: Attributes = {};
             if (process.env.WEBSITE_SITE_NAME) {
-                resourceAttributes[SemanticResourceAttributes.SERVICE_NAME] =
+                resourceAttributes[SEMRESATTRS_SERVICE_NAME] =
                     process.env.WEBSITE_SITE_NAME;
             }
             if (process.env.WEBSITE_INSTANCE_ID) {
-                resourceAttributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID] =
+                resourceAttributes[SEMRESATTRS_SERVICE_INSTANCE_ID] =
                     process.env.WEBSITE_INSTANCE_ID;
             }
             const resource = new Resource(resourceAttributes);

--- a/test/unitTests/agent/agentLoader.tests.ts
+++ b/test/unitTests/agent/agentLoader.tests.ts
@@ -18,6 +18,7 @@ describe("agent/agentLoader", () => {
         },
         enableAutoCollectExceptions: true,
         enableAutoCollectPerformance: true,
+        enableLiveMetrics: true,
         samplingRatio: 1, // Sample all telemetry by default
         instrumentationOptions: {
             azureSdk: {

--- a/test/unitTests/agent/appServicesLoader.ts
+++ b/test/unitTests/agent/appServicesLoader.ts
@@ -4,7 +4,10 @@ import * as sinon from "sinon";
 import { AppServicesLoader } from "../../../src/agent/appServicesLoader";
 import { DiagnosticLogger } from "../../../src/agent/diagnostics/diagnosticLogger";
 import { FileWriter } from "../../../src/agent/diagnostics/writers/fileWriter";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import {
+    SEMRESATTRS_SERVICE_INSTANCE_ID,
+    SEMRESATTRS_SERVICE_NAME,
+} from "@opentelemetry/semantic-conventions";
 
 describe("agent/AppServicesLoader", () => {
     let originalEnv: NodeJS.ProcessEnv;
@@ -78,11 +81,11 @@ describe("agent/AppServicesLoader", () => {
         // Agent Loader called
         assert.ok(stub.calledOnce);
         assert.equal(
-            agent["_options"].resource.attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+            agent["_options"].resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
             "testRoleInstanceId"
         );
         assert.equal(
-            agent["_options"].resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
+            agent["_options"].resource.attributes[SEMRESATTRS_SERVICE_NAME],
             "testRole"
         );
     });

--- a/test/unitTests/agent/azureFunctionsLoader.ts
+++ b/test/unitTests/agent/azureFunctionsLoader.ts
@@ -4,7 +4,10 @@ import * as sinon from "sinon";
 import { AzureFunctionsLoader } from "../../../src/agent/azureFunctionsLoader";
 import { DiagnosticLogger } from "../../../src/agent/diagnostics/diagnosticLogger";
 import { AzureFunctionsWriter } from "../../../src/agent/diagnostics/writers/azureFunctionsWriter";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { 
+    SEMRESATTRS_SERVICE_INSTANCE_ID,
+    SEMRESATTRS_SERVICE_NAME
+ } from "@opentelemetry/semantic-conventions";
 
 describe("agent/AzureFunctionsLoader", () => {
     let originalEnv: NodeJS.ProcessEnv;
@@ -68,11 +71,11 @@ describe("agent/AzureFunctionsLoader", () => {
         // Agent Loader called
         assert.ok(stub.calledOnce);
         assert.equal(
-            agent["_options"].resource.attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+            agent["_options"].resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
             "testRoleInstanceId"
         );
         assert.equal(
-            agent["_options"].resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
+            agent["_options"].resource.attributes[SEMRESATTRS_SERVICE_NAME],
             "testRole"
         );
     });

--- a/test/unitTests/metrics/performanceCounters.tests.ts
+++ b/test/unitTests/metrics/performanceCounters.tests.ts
@@ -3,11 +3,14 @@
 
 import * as assert from "assert";
 import * as sinon from "sinon";
-import { Attributes, SpanKind } from "@opentelemetry/api";
+import { SpanKind } from "@opentelemetry/api";
 import { ExportResultCode } from "@opentelemetry/core";
 import { PerformanceCounterMetrics } from "../../../src/metrics/performanceCounters";
 import { ApplicationInsightsConfig } from "../../../src/shared/configuration/config";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { 
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+ } from "@opentelemetry/semantic-conventions";
 import { Resource } from "@opentelemetry/resources";
 import { Histogram } from "@opentelemetry/sdk-metrics";
 
@@ -48,8 +51,8 @@ describe("PerformanceCounterMetricsHandler", () => {
   describe("#Metrics", () => {
     it("should observe instruments during collection", async () => {
       let resource = new Resource({});
-      resource.attributes[SemanticResourceAttributes.SERVICE_NAME] = "testcloudRoleName";
-      resource.attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID] = "testcloudRoleInstance";
+      resource.attributes[SEMRESATTRS_SERVICE_NAME] = "testcloudRoleName";
+      resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID] = "testcloudRoleInstance";
       let serverSpan: any = {
         kind: SpanKind.SERVER,
         duration: [654321],


### PR DESCRIPTION
* Updates the live metrics setting to be on by default in RP auto-attach scenarios.
* Updates imports from the sem conv package.