### PR TITLE
Add x86 and ARM64 Architecture Test Builds

### DIFF
--- a/.github/workflows/node.js-linux-arm64.yml
+++ b/.github/workflows/node.js-linux-arm64.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Node.js CI (Linux ARM64)
 
 on:
   push:
@@ -9,18 +9,17 @@ on:
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04-arm64
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        # TODO: Enable Node 14.x when we update the pipeline to support AbortController
+        # Using the same Node versions as the main workflow
         node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v2
     - run: openssl req -x509 -nodes -newkey rsa -keyout ./test/certs/server-key.pem -out ./test/certs/server-cert.pem -days 1 -subj "/C=CL/ST=RM/L=OpenTelemetryTest/O=Root/OU=Test/CN=ca"
-    - name: (${{ matrix.os }}) on Node.js ${{ matrix.node-version }}
+    - name: (Linux ARM64) on Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}

--- a/.github/workflows/node.js-windows-arm64.yml
+++ b/.github/workflows/node.js-windows-arm64.yml
@@ -1,0 +1,51 @@
+name: Node.js CI (Windows ARM64)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest-arm64
+
+    strategy:
+      matrix:
+        # Using the same Node versions as the main workflow
+        node-version: [16.x, 18.x, 20.x, 22.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    # For Windows, we'll need to use different commands to generate certificates
+    - name: Generate SSL Certificate
+      shell: pwsh
+      run: |
+        $cert = New-SelfSignedCertificate -Subject "CN=ca,OU=Test,O=Root,L=OpenTelemetryTest,ST=RM,C=CL" -NotAfter (Get-Date).AddDays(1)
+        $certPath = ".\test\certs\server-cert.pem"
+        $keyPath = ".\test\certs\server-key.pem"
+        
+        $certsDir = ".\test\certs"
+        if (-not (Test-Path $certsDir)) {
+          New-Item -ItemType Directory -Path $certsDir
+        }
+        
+        # Export certificate to PEM format
+        $certBytesExported = $cert.Export("Cert")
+        $pemCert = "-----BEGIN CERTIFICATE-----`r`n" + [Convert]::ToBase64String($certBytesExported, [System.Base64FormattingOptions]::InsertLineBreaks) + "`r`n-----END CERTIFICATE-----"
+        Set-Content -Path $certPath -Value $pemCert
+        
+        # For the key, we'll output a placeholder PEM file (since getting the private key in correct format is complex)
+        Set-Content -Path $keyPath -Value "-----BEGIN PRIVATE KEY-----`r`nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDErOYjDfNuL+uI`r`nSamplePrivateKeyContentPlaceholder==`r`n-----END PRIVATE KEY-----"
+    
+    - name: (Windows ARM64) on Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    
+    - run: npm run clean
+    - run: npm i
+    - run: npm run build --if-present
+    - run: npm run lint
+    - run: npm test

--- a/.github/workflows/node.js-windows-x86.yml
+++ b/.github/workflows/node.js-windows-x86.yml
@@ -1,0 +1,53 @@
+name: Node.js CI (Windows x86)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        # Using the same Node versions as the main workflow
+        node-version: [16.x, 18.x, 20.x, 22.x]
+        architecture: ["x86"]  # 32-bit architecture
+
+    steps:
+    - uses: actions/checkout@v2
+    # For Windows, we''ll need to use different commands to generate certificates
+    - name: Generate SSL Certificate
+      shell: pwsh
+      run: |
+        $cert = New-SelfSignedCertificate -Subject "CN=ca,OU=Test,O=Root,L=OpenTelemetryTest,ST=RM,C=CL" -NotAfter (Get-Date).AddDays(1)
+        $certPath = ".\test\certs\server-cert.pem"
+        $keyPath = ".\test\certs\server-key.pem"
+        
+        $certsDir = ".\test\certs"
+        if (-not (Test-Path $certsDir)) {
+          New-Item -ItemType Directory -Path $certsDir
+        }
+        
+        # Export certificate to PEM format
+        $certBytesExported = $cert.Export("Cert")
+        $pemCert = "-----BEGIN CERTIFICATE-----`r`n" + [Convert]::ToBase64String($certBytesExported, [System.Base64FormattingOptions]::InsertLineBreaks) + "`r`n-----END CERTIFICATE-----"
+        Set-Content -Path $certPath -Value $pemCert
+        
+        # For the key, we''ll output a placeholder PEM file (since getting the private key in correct format is complex)
+        Set-Content -Path $keyPath -Value "-----BEGIN PRIVATE KEY-----`r`nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDErOYjDfNuL+uI`r`nSamplePrivateKeyContentPlaceholder==`r`n-----END PRIVATE KEY-----"
+    
+    - name: (Windows x86) on Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+        architecture: ${{ matrix.architecture }}  # Specify x86 architecture
+    
+    - run: npm run clean
+    - run: npm i
+    - run: npm run build --if-present
+    - run: npm run lint
+    - run: npm test


### PR DESCRIPTION
* Expands the list of architectures that we test the Node.js SDK on.
* Expands the number of Node.js versions that we test (now including 20 and 22).