### PR TITLE
Remove Explicit Creation of Metric Exporter in AKS Auto-Attach Scenario

### DIFF
--- a/src/agent/aksLoader.ts
+++ b/src/agent/aksLoader.ts
@@ -14,11 +14,6 @@ export class AKSLoader extends AgentLoader {
     constructor() {
         super();
         if (this._canLoad) {
-            // AKS specific configuration
-            this._options.otlpMetricExporterConfig = {
-                // Add OTLP if env variable is present
-                enabled: process.env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] ? true : false
-            };
             (this._options.instrumentationOptions as InstrumentationOptions) = {
                 ...this._options.instrumentationOptions,
                 console: { enabled: true },

--- a/test/unitTests/agent/aksLoader.tests.ts
+++ b/test/unitTests/agent/aksLoader.tests.ts
@@ -2,7 +2,6 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { ProxyTracerProvider, metrics, trace } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
-
 import { AKSLoader } from "../../../src/agent/aksLoader";
 import { DiagnosticLogger } from "../../../src/agent/diagnostics/diagnosticLogger";
 import { FileWriter } from "../../../src/agent/diagnostics/writers/fileWriter";
@@ -61,19 +60,5 @@ describe("agent/AKSLoader", () => {
         let loggerProvider = logs.getLoggerProvider() as any;
         assert.equal(loggerProvider.constructor.name, "LoggerProvider");
         assert.equal(loggerProvider["_sharedState"]["registeredLogRecordProcessors"][1]["_exporter"].constructor.name, "AzureMonitorLogExporter");
-    });
-
-    it("should add OTLP exporter if env variable is present", () => {
-        const env = {
-            ["APPLICATIONINSIGHTS_CONNECTION_STRING"]: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333",
-            ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]: "something",
-        };
-        process.env = env;
-        const agent = new AKSLoader();
-        agent.initialize();
-        let meterProvider = metrics.getMeterProvider() as any;
-        assert.equal(meterProvider.constructor.name, "MeterProvider");
-        assert.equal(meterProvider["_sharedState"]["metricCollectors"].length, 2);
-        assert.equal(meterProvider["_sharedState"]["metricCollectors"][1]["_metricReader"]["_exporter"].constructor.name, "OTLPMetricExporter");
     });
 });


### PR DESCRIPTION
Per the spec https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/blob/main/ApplicationInsights/AKS_AutoAttach_Metrics.md#sending-otel-metrics-to-amw the OTEL_METRICS_EXPORTER env var should be populated when in AKS auto-attach scenarios. 

The OTel code that controls creation of the metric exporter in the even that this env var is populated exists here: https://github.com/open-telemetry/opentelemetry-js/blob/dac72912b3a895c91ee95cfa39a22a916411ba4c/experimental/packages/opentelemetry-sdk-node/src/sdk.ts#L115