### PR TITLE
Fix diagnostic-channel Console Import

### DIFF
--- a/src/logs/autoCollectLogs.ts
+++ b/src/logs/autoCollectLogs.ts
@@ -10,7 +10,7 @@ export class AutoCollectLogs {
             require("./diagnostic-channel/console.sub").enable(options.console);
         } catch (error) {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
-            require("../../out/src/logs/diagnostic-channel/console.sub").enable(options.console);
+            require("../../../out/src/logs/diagnostic-channel/console.sub").enable(options.console);
         }
     }
 
@@ -20,7 +20,7 @@ export class AutoCollectLogs {
             require("./diagnostic-channel/console.sub").dispose();
         } catch (error) {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
-            require("../../out/src/logs/diagnostic-channel/console.sub").dispose();
+            require("../../../out/src/logs/diagnostic-channel/console.sub").dispose();
         }
     }
 }


### PR DESCRIPTION
This patch fixes a build-breaking issue. The current code resolves to .../out/out/..., which looks like an unintentional typo. Please review.