### PR TITLE
Rename Customer Statsbeat to Customer SDK Stats

### DIFF
--- a/src/shim/types.ts
+++ b/src/shim/types.ts
@@ -351,7 +351,7 @@ export enum StatsbeatFeature {
     DISTRO = 8,
     LIVE_METRICS = 16,
     SHIM = 32,
-    CUSTOMER_STATSBEAT = 64,
+    CUSTOMER_SDK_STATS = 64,
     MULTI_IKEY = 128,
 }
 

--- a/test/unitTests/shared/util/statsbeatFeaturesManager.tests.ts
+++ b/test/unitTests/shared/util/statsbeatFeaturesManager.tests.ts
@@ -58,15 +58,15 @@ describe("shared/util/StatsbeatFeaturesManager", () => {
             assert.ok((config.feature & StatsbeatFeature.SHIM) !== 0, "SHIM feature should remain enabled");
         });
 
-        it("should enable CUSTOMER_STATSBEAT feature using bitmap", () => {
+        it("should enable CUSTOMER_SDK_STATS feature using bitmap", () => {
             StatsbeatFeaturesManager.getInstance().initialize();
-            StatsbeatFeaturesManager.getInstance().enableFeature(StatsbeatFeature.CUSTOMER_STATSBEAT);
+            StatsbeatFeaturesManager.getInstance().enableFeature(StatsbeatFeature.CUSTOMER_SDK_STATS);
             
             const envValue = process.env["AZURE_MONITOR_STATSBEAT_FEATURES"];
             assert.ok(envValue, "environment variable should be set");
             
             const config = JSON.parse(envValue);
-            assert.ok((config.feature & StatsbeatFeature.CUSTOMER_STATSBEAT) !== 0, "CUSTOMER_STATSBEAT feature should be enabled");
+            assert.ok((config.feature & StatsbeatFeature.CUSTOMER_SDK_STATS) !== 0, "CUSTOMER_SDK_STATS feature should be enabled");
             assert.ok((config.feature & StatsbeatFeature.SHIM) !== 0, "SHIM feature should remain enabled");
         });
 


### PR DESCRIPTION
This pull request makes a terminology update to improve clarity and consistency in feature naming related to statsbeat features. The main change is the renaming of the `CUSTOMER_STATSBEAT` feature to `CUSTOMER_SDK_STATS` across both the codebase and associated tests.

Feature renaming for clarity:

* In the `StatsbeatFeature` enum in `src/shim/types.ts`, renamed `CUSTOMER_STATSBEAT` to `CUSTOMER_SDK_STATS` to better reflect its purpose.
* Updated all references in the statsbeat features manager unit tests to use the new `CUSTOMER_SDK_STATS` name, including test descriptions, feature enabling, and assertions in `test/unitTests/shared/util/statsbeatFeaturesManager.tests.ts`.