### PR TITLE
Fix CodeQL Warning in Functional Tests

### DIFF
--- a/test/functionalTests/runFunctionalTests.js
+++ b/test/functionalTests/runFunctionalTests.js
@@ -22,7 +22,7 @@ function findDefaultPath() {
         const stat = fs.lstatSync(file);
         if (!stat.isDirectory()) {
             if (file.indexOf("applicationinsights") === rootDir.length + 1 &&
-                file.indexOf(".tgz") === file.length - 4) {
+                file.length >= 4 && file.indexOf(".tgz") === file.length - 4) {
                 return path.resolve(file);
             }
         }


### PR DESCRIPTION
This pull request includes a minor update to the logic for finding the default path in the `findDefaultPath` function. The change adds a safeguard to ensure that the file length is at least 4 before checking for the `.tgz` file extension, which helps prevent potential errors with short file names.

* Improved file extension check in `findDefaultPath` to ensure the file name is long enough before checking for `.tgz`, reducing the risk of runtime errors. (`test/functionalTests/runFunctionalTests.js`)