### PR TITLE
Ignore OTLP Export Env Var for Logs and Traces in AKS Auto-Attach Scenarios

### DIFF
--- a/src/agent/aksLoader.ts
+++ b/src/agent/aksLoader.ts
@@ -52,4 +52,27 @@ export class AKSLoader extends AgentLoader {
             );
         }
     }
+
+    public initialize() {
+        // For AKS auto attach scenario, temporarily store and remove OTEL_TRACES_EXPORTER and OTEL_LOGS_EXPORTER
+        // to ensure they don't interfere with useAzureMonitor setup
+        const originalTracesExporter = process.env.OTEL_TRACES_EXPORTER;
+        const originalLogsExporter = process.env.OTEL_LOGS_EXPORTER;
+        
+        delete process.env.OTEL_TRACES_EXPORTER;
+        delete process.env.OTEL_LOGS_EXPORTER;
+
+        try {
+            // Call parent initialize method
+            super.initialize();
+        } finally {
+            // Restore the original environment variables after useAzureMonitor is complete
+            if (originalTracesExporter !== undefined) {
+                process.env.OTEL_TRACES_EXPORTER = originalTracesExporter;
+            }
+            if (originalLogsExporter !== undefined) {
+                process.env.OTEL_LOGS_EXPORTER = originalLogsExporter;
+            }
+        }
+    }
 }

--- a/test/unitTests/agent/aksLoader.tests.ts
+++ b/test/unitTests/agent/aksLoader.tests.ts
@@ -60,4 +60,111 @@ describe("agent/AKSLoader", () => {
         let loggerProvider = logs.getLoggerProvider() as any;
         assert.equal(loggerProvider.constructor.name, "LoggerProvider");
     });
+
+    describe("OTEL environment variable handling", () => {
+        it("should remove OTEL_TRACES_EXPORTER and OTEL_LOGS_EXPORTER during initialization", () => {
+            const env = {
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"]: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333",
+                ["OTEL_TRACES_EXPORTER"]: "jaeger",
+                ["OTEL_LOGS_EXPORTER"]: "console"
+            };
+            process.env = env;
+
+            const agent = new AKSLoader();
+            
+            // Spy on the parent initialize method to check environment during call
+            let envDuringParentCall: { traces?: string; logs?: string } = {};
+            const originalInitialize = Object.getPrototypeOf(Object.getPrototypeOf(agent)).initialize;
+            const parentInitializeSpy = sandbox.stub(Object.getPrototypeOf(Object.getPrototypeOf(agent)), 'initialize').callsFake(function() {
+                envDuringParentCall.traces = process.env.OTEL_TRACES_EXPORTER;
+                envDuringParentCall.logs = process.env.OTEL_LOGS_EXPORTER;
+                return originalInitialize.call(this);
+            });
+
+            agent.initialize();
+
+            // Verify that environment variables were undefined during parent initialize call
+            assert.strictEqual(envDuringParentCall.traces, undefined, "OTEL_TRACES_EXPORTER should be undefined during parent initialize");
+            assert.strictEqual(envDuringParentCall.logs, undefined, "OTEL_LOGS_EXPORTER should be undefined during parent initialize");
+
+            // Verify parent initialize was called
+            assert.ok(parentInitializeSpy.calledOnce, "Parent initialize should be called once");
+
+            parentInitializeSpy.restore();
+        });
+
+        it("should restore OTEL_TRACES_EXPORTER and OTEL_LOGS_EXPORTER after initialization", () => {
+            const env = {
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"]: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333",
+                ["OTEL_TRACES_EXPORTER"]: "jaeger",
+                ["OTEL_LOGS_EXPORTER"]: "console"
+            };
+            process.env = env;
+
+            const agent = new AKSLoader();
+            agent.initialize();
+
+            // Verify environment variables are restored after initialization
+            assert.strictEqual(process.env.OTEL_TRACES_EXPORTER, "jaeger", "OTEL_TRACES_EXPORTER should be restored");
+            assert.strictEqual(process.env.OTEL_LOGS_EXPORTER, "console", "OTEL_LOGS_EXPORTER should be restored");
+        });
+
+        it("should handle cases where OTEL environment variables are not set", () => {
+            const env = {
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"]: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333"
+                // OTEL variables intentionally not set
+            };
+            process.env = env;
+
+            const agent = new AKSLoader();
+            agent.initialize();
+
+            // Verify that undefined variables remain undefined
+            assert.strictEqual(process.env.OTEL_TRACES_EXPORTER, undefined, "OTEL_TRACES_EXPORTER should remain undefined");
+            assert.strictEqual(process.env.OTEL_LOGS_EXPORTER, undefined, "OTEL_LOGS_EXPORTER should remain undefined");
+        });
+
+        it("should restore environment variables even if parent initialize throws", () => {
+            const env = {
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"]: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333",
+                ["OTEL_TRACES_EXPORTER"]: "jaeger",
+                ["OTEL_LOGS_EXPORTER"]: "console"
+            };
+            process.env = env;
+
+            const agent = new AKSLoader();
+            
+            // Stub parent initialize to throw an error
+            const parentInitializeStub = sandbox.stub(Object.getPrototypeOf(Object.getPrototypeOf(agent)), 'initialize').throws(new Error("Test error"));
+
+            try {
+                agent.initialize();
+                assert.fail("Expected initialize to throw an error");
+            } catch (error: any) {
+                assert.strictEqual(error.message, "Test error", "Should propagate the error from parent initialize");
+            }
+
+            // Verify environment variables are still restored despite the error
+            assert.strictEqual(process.env.OTEL_TRACES_EXPORTER, "jaeger", "OTEL_TRACES_EXPORTER should be restored even after error");
+            assert.strictEqual(process.env.OTEL_LOGS_EXPORTER, "console", "OTEL_LOGS_EXPORTER should be restored even after error");
+
+            parentInitializeStub.restore();
+        });
+
+        it("should handle partial environment variable sets correctly", () => {
+            const env = {
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"]: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333",
+                ["OTEL_TRACES_EXPORTER"]: "jaeger"
+                // OTEL_LOGS_EXPORTER intentionally not set
+            };
+            process.env = env;
+
+            const agent = new AKSLoader();
+            agent.initialize();
+
+            // Verify that only the set variable is restored
+            assert.strictEqual(process.env.OTEL_TRACES_EXPORTER, "jaeger", "OTEL_TRACES_EXPORTER should be restored");
+            assert.strictEqual(process.env.OTEL_LOGS_EXPORTER, undefined, "OTEL_LOGS_EXPORTER should remain undefined");
+        });
+    });
 });


### PR DESCRIPTION
This pull request introduces logic in the `AKSLoader` class to temporarily remove the `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` environment variables during initialization, ensuring these variables do not interfere with Azure Monitor setup. Comprehensive unit tests are added to verify correct handling and restoration of these environment variables under various scenarios, including error cases and partial variable presence.

**Environment variable management:**

* Added an `initialize` method to `AKSLoader` that temporarily removes `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` from `process.env` during initialization, and restores them afterward, to prevent interference with Azure Monitor setup.

**Testing and reliability:**

* Added a new test suite in `aksLoader.tests.ts` to verify that `AKSLoader.initialize()` correctly removes and restores the OTEL environment variables during and after initialization, including tests for cases when variables are missing, partially set, or when errors occur during parent initialization.