### PR TITLE
Update OTLP Metric Exporter Creation

### DIFF
--- a/src/agent/aksLoader.ts
+++ b/src/agent/aksLoader.ts
@@ -58,9 +58,7 @@ export class AKSLoader extends AgentLoader {
             // Create metricReaders array and add OTLP reader if environment variables request it
             try {
                 const metricReaders: MetricReader[] = [];
-                
-                // Check if OTEL_METRICS_EXPORTER contains "otlp" as a separate value (not as part of another word)
-                const metricsExporter = process.env.OTEL_METRICS_EXPORTER || '';
+                const metricsExporter = (process.env.OTEL_METRICS_EXPORTER || '').toLowerCase();
                 const exportersList = metricsExporter.split(',').map(exp => exp.trim());
                 const hasOtlpExporter = exportersList.includes('otlp');
                 

--- a/test/unitTests/agent/aksLoader.tests.ts
+++ b/test/unitTests/agent/aksLoader.tests.ts
@@ -329,4 +329,52 @@ describe("agent/AKSLoader", () => {
         const options = (agent as any)._options;
         assert.ok(!options.metricReaders || options.metricReaders.length === 0, "Should not have any metric readers when otlp is not included in the list");
     });
+
+    it("constructor creates OTLP metric reader when OTEL_METRICS_EXPORTER contains uppercase OTLP", () => {
+        const env = {
+            ["APPLICATIONINSIGHTS_CONNECTION_STRING"]: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333",
+            ["OTEL_METRICS_EXPORTER"]: "OTLP",
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"]: "http://localhost:4317"
+        };
+        process.env = env;
+        
+        const agent = new AKSLoader();
+        
+        // Verify that metricReaders were added to the options
+        const options = (agent as any)._options;
+        assert.ok(options.metricReaders, "metricReaders should be present in options when OTLP is uppercase");
+        assert.equal(options.metricReaders.length, 1, "Should have exactly one metric reader");
+        
+        // Verify the metric reader is a PeriodicExportingMetricReader
+        const metricReader = options.metricReaders[0];
+        assert.equal(metricReader.constructor.name, "PeriodicExportingMetricReader", "Should be a PeriodicExportingMetricReader");
+        
+        // Verify the exporter is an OTLP exporter
+        const exporter = (metricReader as any)._exporter;
+        assert.equal(exporter.constructor.name, "OTLPMetricExporter", "Should be an OTLPMetricExporter");
+    });
+
+    it("constructor creates OTLP metric reader when OTEL_METRICS_EXPORTER contains mixed case otlp with other exporters", () => {
+        const env = {
+            ["APPLICATIONINSIGHTS_CONNECTION_STRING"]: "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333",
+            ["OTEL_METRICS_EXPORTER"]: "CONSOLE,OtLp,PROMETHEUS",
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"]: "http://localhost:4317"
+        };
+        process.env = env;
+        
+        const agent = new AKSLoader();
+        
+        // Verify that metricReaders were added to the options
+        const options = (agent as any)._options;
+        assert.ok(options.metricReaders, "metricReaders should be present in options when OtLp is mixed case with other exporters");
+        assert.equal(options.metricReaders.length, 1, "Should have exactly one metric reader");
+        
+        // Verify the metric reader is a PeriodicExportingMetricReader
+        const metricReader = options.metricReaders[0];
+        assert.equal(metricReader.constructor.name, "PeriodicExportingMetricReader", "Should be a PeriodicExportingMetricReader");
+        
+        // Verify the exporter is an OTLP exporter
+        const exporter = (metricReader as any)._exporter;
+        assert.equal(exporter.constructor.name, "OTLPMetricExporter", "Should be an OTLPMetricExporter");
+    });
 });


### PR DESCRIPTION
This pull request improves how the `AKSLoader` class detects and configures the OTLP metric exporter based on the `OTEL_METRICS_EXPORTER` environment variable. The main change is to ensure that "otlp" is recognized correctly when specified as a comma-separated value among other exporters, and not as part of another word. Several new unit tests were added to verify this behavior for different scenarios.

**Logic improvements to OTLP exporter detection:**

* Updated `AKSLoader` to check for "otlp" as a distinct value in the `OTEL_METRICS_EXPORTER` environment variable, supporting comma-separated lists and ignoring partial matches (e.g., "otlp-custom" does not trigger the exporter). (`src/agent/aksLoader.ts`)

**Expanded test coverage for exporter detection:**

* Added unit tests to verify that the OTLP metric reader is created when "otlp" appears in various positions (beginning, middle, end) and with spaces in the `OTEL_METRICS_EXPORTER` value. (`test/unitTests/agent/aksLoader.tests.ts`)
* Added tests to confirm that the OTLP metric reader is not created when "otlp" is absent or only present as part of another word (e.g., "otlp-custom"). (`test/unitTests/agent/aksLoader.tests.ts`)