### PR TITLE
Add OTel Global Detection Delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 3.13.1 ()
+
+#### Other Changes
+
+- Update OTel global detection to wait for the customer app to initialize before detection.
+
 ### 3.13.0 (2026-01-16)
 
 #### Other Changes


### PR DESCRIPTION
This pull request updates the OpenTelemetry (OTel) global detection logic in the agent loader to delay detection until after the customer application has had time to initialize. This change helps avoid premature detection and potential conflicts. The update also includes a new unit test to verify the delayed detection and adjusts the test setup to use fake timers for accurate timing simulation.

**OpenTelemetry Detection Update:**

* The agent loader now waits 1 minute (`OTEL_DETECTION_DELAY_MS`) after initialization before detecting OTel globals, allowing customer applications to initialize first. The detection timeout is unreferenced so it won't prevent process exit. (`src/agent/agentLoader.ts`) [[1]](diffhunk://#diff-3624236416117e8caf72177170accf66f14cbe6cf7e6131867e8f17861d808d2R15) [[2]](diffhunk://#diff-3624236416117e8caf72177170accf66f14cbe6cf7e6131867e8f17861d808d2L123-R129)
* The changelog has been updated to document this change. (`CHANGELOG.md`)

**Testing Improvements:**

* Unit tests for the agent loader now use fake timers to simulate the OTel detection delay, ensuring reliable and accurate testing of the new behavior. (`test/unitTests/agent/agentLoader.tests.ts`) [[1]](diffhunk://#diff-1267ea6e0917b2f18b5d32e82d9c00361321181be402d331b88e844df5d208a9R19-R23) [[2]](diffhunk://#diff-1267ea6e0917b2f18b5d32e82d9c00361321181be402d331b88e844df5d208a9R64) [[3]](diffhunk://#diff-1267ea6e0917b2f18b5d32e82d9c00361321181be402d331b88e844df5d208a9R75)
* A new test verifies that OTel detection is delayed by 1 minute and only occurs after the timeout, checking both the detection call and the appropriate log messages. (`test/unitTests/agent/agentLoader.tests.ts`)