### PR TITLE
Block preview/dev/alpha drift of @azure/monitor-opentelemetry-exporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@azure/functions": "^4.11.2",
         "@azure/identity": "^4.13.1",
         "@azure/monitor-opentelemetry": "^1.18.0",
-        "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.41",
+        "@azure/monitor-opentelemetry-exporter": ">=1.0.0-beta.41 <1.0.0-c || ^1.0.0",
         "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.7",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.217.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@azure/functions": "^4.11.2",
     "@azure/identity": "^4.13.1",
     "@azure/monitor-opentelemetry": "^1.18.0",
-    "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.41",
+    "@azure/monitor-opentelemetry-exporter": ">=1.0.0-beta.41 <1.0.0-c || ^1.0.0",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.7",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.217.0",


### PR DESCRIPTION
## Summary

The `^1.0.0-beta.41` caret range on `@azure/monitor-opentelemetry-exporter` is permissive enough under semver that `npm install` (without a lockfile) can resolve it to `@azure/monitor-opentelemetry-exporter@1.0.0-preview.6` — the prerelease identifier `preview` sorts higher than `beta` lexicographically, so `semver.maxSatisfying` picks it as the "best" match.

`1.0.0-preview.6` (published October 2020) still exists on npm and reintroduces:
- The deprecated `@azure/core-http@1.2.6` → `uuid@^8.3.0` chain (GHSA-w5hq-g745-h8pq, reported in #1501).
- The legacy `@opentelemetry/tracing@0.10.2` → `@opentelemetry/resources@0.10.2` → `gcp-metadata@3.5.0` → `json-bigint@0.3.1` chain (CVE-2020-8237, reported in #1502).

Today we are protected only because `@azure/monitor-opentelemetry@1.18.0` happens to pin the exporter to an exact version transitively, but that protection is fragile and would not hold for a lockfile-less consumer install.

## Fix

Replace the caret with an explicit two-clause range:

```diff
- "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.41",
+ "@azure/monitor-opentelemetry-exporter": ">=1.0.0-beta.41 <1.0.0-c || ^1.0.0",
```

The range:
- allows the current `1.0.0-beta.41` and all future `1.0.0-beta.*` (the `b` in `beta` is alphabetically less than `c`); and
- allows future stable `1.x.x` releases via the `|| ^1.0.0` clause; but
- rejects `1.0.0-preview.*`, `1.0.0-dev.*`, and `1.0.0-alpha.*` because their prerelease identifiers sort `>= c`.

## Behavior matrix

| Version | Matches? | Notes |
|---|---|---|
| `1.0.0-beta.41` (current) | ✅ | resolves identically to today |
| `1.0.0-beta.42`+ | ✅ | future betas |
| `1.0.0-preview.*` | ❌ | blocked (was the resolution bug) |
| `1.0.0-dev.*` | ❌ | blocked |
| `1.0.0-alpha.*` | ❌ | blocked |
| `1.0.0` stable, `1.x.x` | ✅ | via `|| ^1.0.0` |
| `2.x.x` | ❌ | matches existing `^` semantics |

Verified against the live npm registry version list with `semver.satisfies` / `semver.maxSatisfying`.

## Verification

- `package-lock.json` resolved version unchanged: `1.0.0-beta.41`.
- Runtime tree contains 0 occurrences of `json-bigint`, `gcp-metadata`, `@opentelemetry/tracing`, or `@azure/core-http`.
- `npm install` + `tsc` clean.
- `npm run test:unit`: **247 passing, 0 failing**.

Fixes #1502.
Fixes #1501.
