### PR TITLE
Release 3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Unreleased
 
-### Bug Fixes
+### 3.15.1 (2026-06-24)
+
+#### Other Changes
+
+- Updated `@azure/monitor-opentelemetry`, `@azure/identity`, and `@opentelemetry/*` dependencies.
+- Removed the legacy `@azure/functions-old` (v3) dependency.
+- Resolve vulnerabilities in dependencies.
+
+#### Bug Fixes
 
 - `AutoCollectExceptions` no longer calls `forceFlush` per exception and now rate-limits exception telemetry to 50 records/min (emitting a single suppressed-count summary per window). `forceFlush` still runs on the terminal exit path.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applicationinsights",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applicationinsights",
-      "version": "3.15.0",
+      "version": "3.15.1",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Microsoft Application Insights Team",
   "license": "MIT",
   "bugs": "https://github.com/microsoft/ApplicationInsights-node.js/issues",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "Microsoft Application Insights module for Node.js",
   "repository": {
     "type": "git",

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import { MetricReader } from "@opentelemetry/sdk-metrics";
 import { OTLPExporterNodeConfigBase } from "@opentelemetry/otlp-exporter-base";
 
 
-export const APPLICATION_INSIGHTS_OPENTELEMETRY_VERSION = "3.15.0";
+export const APPLICATION_INSIGHTS_OPENTELEMETRY_VERSION = "3.15.1";
 export const DEFAULT_ROLE_NAME = "Web";
 export const AZURE_MONITOR_STATSBEAT_FEATURES = "AZURE_MONITOR_STATSBEAT_FEATURES";
 


### PR DESCRIPTION
Release 3.15.1.

### Changes
- Bump version 3.15.0 -> 3.15.1 in `package.json` / `package-lock.json`.
- Update `CHANGELOG.md` with the 3.15.1 entry covering changes since 3.15.0:

#### Other Changes
- Updated `@azure/monitor-opentelemetry`, `@azure/identity`, and `@opentelemetry/*` dependencies.
- Removed the legacy `@azure/functions-old` (v3) dependency.
- Resolve vulnerabilities in dependencies.

#### Bug Fixes
- `AutoCollectExceptions` no longer calls `forceFlush` per exception and now rate-limits exception telemetry to 50 records/min.