### PR TITLE
Release 3.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@
 - Bumped `@opentelemetry/*` (0.220 / 2.9) and `@azure/monitor-opentelemetry` to resolve dependency audit alerts.
 - Replaced the `diagnostic-channel`/`diagnostic-channel-publishers` console log collection with OpenTelemetry console instrumentation provided by `@azure/monitor-opentelemetry`.
 - Deprecated `noDiagnosticChannel` and `noPatchModules` in favor of OpenTelemetry `instrumentationOptions`.
-
-#### Behavioral Changes
-
 - Console severity is now derived from the console method (`console.error` maps to Error, `console.warn` maps to Warning, and `console.log`/`console.info` map to Information).
 - An explicitly configured console `logSendingLevel` now takes precedence over `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,18 @@
 
 ## Unreleased
 
+### 3.16.0 (2026-08-12)
+
 #### Other Changes
 
-- Replaced the `diagnostic-channel`/`diagnostic-channel-publishers` console log collection with the `@opentelemetry/instrumentation-console` package.
+- Bumped `@opentelemetry/*` (0.220 / 2.9) and `@azure/monitor-opentelemetry` to resolve dependency audit alerts.
+- Replaced the `diagnostic-channel`/`diagnostic-channel-publishers` console log collection with OpenTelemetry console instrumentation provided by `@azure/monitor-opentelemetry`.
 
 ### 3.15.1 (2026-06-24)
 
 #### Other Changes
 
 - Updated `@azure/monitor-opentelemetry`, `@azure/identity`, and `@opentelemetry/*` dependencies.
-- Bumped `@opentelemetry/*` (0.220 / 2.9) and `@azure/monitor-opentelemetry` to resolve dependency audit alerts.
 - Removed the legacy `@azure/functions-old` (v3) dependency.
 - Resolve vulnerabilities in dependencies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 - Bumped `@opentelemetry/*` (0.220 / 2.9) and `@azure/monitor-opentelemetry` to resolve dependency audit alerts.
 - Replaced the `diagnostic-channel`/`diagnostic-channel-publishers` console log collection with OpenTelemetry console instrumentation provided by `@azure/monitor-opentelemetry`.
+- Deprecated `noDiagnosticChannel` and `noPatchModules` in favor of OpenTelemetry `instrumentationOptions`.
+
+#### Behavioral Changes
+
+- Console severity is now derived from the console method (`console.error` maps to Error, `console.warn` maps to Warning, and `console.log`/`console.info` map to Information).
+- An explicitly configured console `logSendingLevel` now takes precedence over `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL`.
 
 ### 3.15.1 (2026-06-24)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applicationinsights",
-  "version": "3.15.1",
+  "version": "3.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applicationinsights",
-      "version": "3.15.1",
+      "version": "3.16.0",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Microsoft Application Insights Team",
   "license": "MIT",
   "bugs": "https://github.com/microsoft/ApplicationInsights-node.js/issues",
-  "version": "3.15.1",
+  "version": "3.16.0",
   "description": "Microsoft Application Insights module for Node.js",
   "repository": {
     "type": "git",

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import { MetricReader } from "@opentelemetry/sdk-metrics";
 import { OTLPExporterNodeConfigBase } from "@opentelemetry/otlp-exporter-base";
 
 
-export const APPLICATION_INSIGHTS_OPENTELEMETRY_VERSION = "3.15.1";
+export const APPLICATION_INSIGHTS_OPENTELEMETRY_VERSION = "3.16.0";
 export const DEFAULT_ROLE_NAME = "Web";
 export const AZURE_MONITOR_STATSBEAT_FEATURES = "AZURE_MONITOR_STATSBEAT_FEATURES";
 


### PR DESCRIPTION
Release 3.16.0.

### Changes
- Bump version 3.15.1 -> 3.16.0 in `package.json` / `package-lock.json` and the SDK version constant.
- Update `CHANGELOG.md` with the 3.16.0 entry covering changes since 3.15.1:

#### Other Changes
- Updated `@azure/monitor-opentelemetry` and `@opentelemetry/*` dependencies to resolve dependency audit alerts.
- Replaced the legacy `diagnostic-channel` / `diagnostic-channel-publishers` console collection with OpenTelemetry console instrumentation provided by the Azure Monitor distro.
- Deprecated the legacy `noDiagnosticChannel` and `noPatchModules` options in favor of OpenTelemetry `instrumentationOptions`.

#### Behavioral Changes
- Console severity is now derived from the console method (`console.error` -> Error, `console.warn` -> Warning, and `console.log` / `console.info` -> Information).
- An explicitly configured console `logSendingLevel` now takes precedence over `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL`.